### PR TITLE
Add .astro directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # build output
 dist/
 .output/
+.astro/
 
 # dependencies
 node_modules/


### PR DESCRIPTION
## Summary

Added `.astro/` to `.gitignore` to exclude Astro's build cache from version control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)