### PR TITLE
Add /socialcontract page

### DIFF
--- a/src/pages/socialcontract.astro
+++ b/src/pages/socialcontract.astro
@@ -1,0 +1,62 @@
+---
+import Layout from '../layouts/Layout.astro';
+import '../styles/book.css';
+---
+
+<Layout title="Honest Alpha Social Contract — LifeBuild">
+  <main class="container book-page">
+    <h1>The Honest Alpha Social Contract</h1>
+    <p><em>This isn't fine print. It's a handshake.</em></p>
+
+    <h2>What We're Asking of You</h2>
+    <ul>
+      <li>
+        <strong>Break things.</strong> Push buttons, try weird workflows, find bugs before anyone else
+        does.
+      </li>
+      <li>
+        <strong>Report problems.</strong> When something doesn't work or feels awkward, tell us.
+      </li>
+      <li>
+        <strong>Be patient.</strong> Features will be incomplete and things will change between sessions.
+      </li>
+      <li>
+        <strong>Give honest feedback.</strong> Polite lies don't help us build something worth using.
+      </li>
+      <li>
+        <strong>Don't expect polish.</strong> You're seeing rough cuts, not the finished film.
+      </li>
+    </ul>
+
+    <h2>What You're Getting in Return</h2>
+    <ul>
+      <li>
+        <strong>Early access.</strong> You're among fewer than 20 people in the world using this. You'll
+        join the alpha-only Discord and swap LifeBuilds, strategies, and get to know the founders better.
+      </li>
+      <li>
+        <strong>Direct influence.</strong> Your feedback goes directly to the people making decisions.
+      </li>
+      <li>
+        <strong>Founder pricing for life.</strong> A permanent discount when we eventually charge.
+      </li>
+    </ul>
+
+    <h2>Duration & What Happens Next</h2>
+    <p>Alpha ends April 30, 2026.</p>
+    <ul>
+      <li>
+        <strong>Your account stays.</strong> Everything you've built carries over.
+      </li>
+      <li>
+        <strong>You automatically move to beta.</strong> No action required; beta stays free.
+      </li>
+      <li>
+        <strong>Two-month grace period.</strong> When we start charging, you get two extra months before
+        deciding.
+      </li>
+    </ul>
+
+    <p>Sign if that sounds like a plan — drop us a line if it doesn't.</p>
+  </main>
+</Layout>


### PR DESCRIPTION
## Summary
- Adds a standalone `/socialcontract` page with the Honest Alpha social contract content
- Uses the same Tufte-style book typography and layout as `/book`
- Not linked from nav or elsewhere — accessible only via direct URL

## Test plan
- [ ] Visit `/socialcontract` and verify content renders correctly
- [ ] Check responsive layout on mobile viewports
- [ ] Confirm dark mode styling works

🤖 Generated with [Claude Code](https://claude.com/claude-code)