### PR TITLE
Disable chapter 3 link on book page

### DIFF
--- a/src/data/bookChapters.ts
+++ b/src/data/bookChapters.ts
@@ -43,7 +43,7 @@ export const bookChapters: BookChapter[] = [
     slug: 'chapter-3',
     title: 'Seeing the Restoration Gap',
     part: 'The Lens',
-    status: 'published',
+    status: 'coming_soon',
     teaser:
       "A lens for understanding why you're depleted—and why a lot of \"rest\" doesn't seem to restore you. You'll learn to tell the difference between time that rebuilds your capacity and time that just feels like it should.",
   },


### PR DESCRIPTION
## Summary
- Changes chapter 3 status from `published` to `coming_soon`
- Removes the clickable link for chapter 3 on the book table of contents
- Chapter will display "Coming soon" instead of "Published"

## Test plan
- [ ] Visit /book and verify chapter 3 is no longer a clickable link
- [ ] Verify chapter 3 shows "Coming soon" status

🤖 Generated with [Claude Code](https://claude.com/claude-code)