### PR TITLE
Add Open Graph social preview images

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -23,6 +23,7 @@ function rehypeRenameFootnotes() {
 
 // https://astro.build/config
 export default defineConfig({
+  site: 'https://lifebuild.me',
   integrations: [react()],
   output: 'static',
   build: {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,9 +1,20 @@
 ---
 interface Props {
   title?: string;
+  description?: string;
+  image?: string;
+  imageAlt?: string;
 }
 
-const { title = 'LifeBuild — Reclaim Your Sovereignty' } = Astro.props;
+const {
+  title = 'LifeBuild — Reclaim Your Sovereignty',
+  description = 'LifeBuild helps you design, track, and achieve the life you want to live. Take back control of your time, energy, and priorities.',
+  image = '/header-story/hero-story-1.webp',
+  imageAlt = 'A cozy desk scene with a vintage computer displaying a castle-building game',
+} = Astro.props;
+
+const canonicalURL = new URL(Astro.url.pathname, Astro.site || 'https://lifebuild.me');
+const imageURL = new URL(image, Astro.site || 'https://lifebuild.me');
 ---
 
 <!doctype html>
@@ -20,6 +31,26 @@ const { title = 'LifeBuild — Reclaim Your Sovereignty' } = Astro.props;
       rel="stylesheet"
     />
     <title>{title}</title>
+
+    <!-- Primary Meta Tags -->
+    <meta name="title" content={title} />
+    <meta name="description" content={description} />
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content={canonicalURL} />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:image" content={imageURL} />
+    <meta property="og:image:alt" content={imageAlt} />
+
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image" />
+    <meta property="twitter:url" content={canonicalURL} />
+    <meta property="twitter:title" content={title} />
+    <meta property="twitter:description" content={description} />
+    <meta property="twitter:image" content={imageURL} />
+    <meta property="twitter:image:alt" content={imageAlt} />
   </head>
   <body>
     <div class="ambient-glow glow-1"></div>

--- a/src/pages/book/[slug].astro
+++ b/src/pages/book/[slug].astro
@@ -48,7 +48,12 @@ if (chapter.status === 'published') {
 }
 ---
 
-<Layout title={`LifeBuild — ${chapter.title}`}>
+<Layout
+  title={`${chapter.title} — The Sovereignty Gap`}
+  description={chapter.teaser}
+  image="/lifebuild-book.png"
+  imageAlt="The Sovereignty Gap book cover - a leather-bound tome with golden text"
+>
   <BookHeader currentChapter={chapter} slot="nav" />
   <main class="container book-page">
     <header class="chapter-header">

--- a/src/pages/book/appendix.astro
+++ b/src/pages/book/appendix.astro
@@ -4,7 +4,12 @@ import Layout from '../../layouts/Layout.astro';
 import '../../styles/book.css';
 ---
 
-<Layout title="LifeBuild — Appendix">
+<Layout
+  title="Appendix — The Sovereignty Gap"
+  description="Supplementary materials for The Sovereignty Gap book."
+  image="/lifebuild-book.png"
+  imageAlt="The Sovereignty Gap book cover - a leather-bound tome with golden text"
+>
   <BookHeader slot="nav" />
   <main class="container book-page">
     <h1>Appendix</h1>

--- a/src/pages/book/index.astro
+++ b/src/pages/book/index.astro
@@ -10,7 +10,12 @@ const groupedChapters = groupChaptersByPart();
 const statusLabel = (status: string) => (status === 'published' ? 'Published' : 'Coming soon');
 ---
 
-<Layout title="The Sovereignty Gap">
+<Layout
+  title="The Sovereignty Gap — How We Lose Control of Our Own Lives & How to Take It Back"
+  description="A serialized guide to reclaiming sovereignty in your personal life. Learn how to take back control of your time, energy, and priorities."
+  image="/lifebuild-book.png"
+  imageAlt="The Sovereignty Gap book cover - a leather-bound tome with golden text"
+>
   <BookHeader slot="nav" showProgress={false} />
   <main class="container book-page book-landing">
     <h1>The Sovereignty Gap</h1>

--- a/src/pages/book/references.astro
+++ b/src/pages/book/references.astro
@@ -4,7 +4,12 @@ import Layout from '../../layouts/Layout.astro';
 import '../../styles/book.css';
 ---
 
-<Layout title="LifeBuild — References">
+<Layout
+  title="References — The Sovereignty Gap"
+  description="Reference materials and citations for The Sovereignty Gap book."
+  image="/lifebuild-book.png"
+  imageAlt="The Sovereignty Gap book cover - a leather-bound tome with golden text"
+>
   <BookHeader slot="nav" />
   <main class="container book-page">
     <h1>References</h1>

--- a/src/pages/socialcontract.astro
+++ b/src/pages/socialcontract.astro
@@ -4,7 +4,10 @@ import TopNav from '../components/TopNav.astro';
 import Footer from '../components/Footer.astro';
 ---
 
-<Layout title="Honest Alpha Social Contract — LifeBuild">
+<Layout
+  title="Honest Alpha Social Contract — LifeBuild"
+  description="This isn't fine print. It's a handshake. What we're asking of you and what you're getting in return as a LifeBuild alpha tester."
+>
   <TopNav slot="nav" />
   <main class="container socialcontract-page">
     <h1>The Honest Alpha Social Contract</h1>

--- a/src/pages/updates.astro
+++ b/src/pages/updates.astro
@@ -31,7 +31,10 @@ const entries = Object.entries(changelogModules)
   .sort((a, b) => new Date(b.frontmatter.date).getTime() - new Date(a.frontmatter.date).getTime());
 ---
 
-<Layout title="Updates — LifeBuild">
+<Layout
+  title="Updates — LifeBuild"
+  description="Product changelog and release notes for LifeBuild. See what's new and what's coming next."
+>
   <TopNav slot="nav" />
   <main class="container updates-page">
     <h1>Updates</h1>


### PR DESCRIPTION
## Summary
- Adds Open Graph and Twitter Card meta tags to all pages for rich social previews
- Homepage uses the warm hero-story-1.webp desk scene
- All book pages (/book, /book/[chapters], /book/appendix, /book/references) use the lifebuild-book.png cover
- Updates and social contract pages inherit the default hero image
- Configures site URL in astro.config.mjs for proper absolute image URLs

## Test plan
- [ ] Deploy preview and test with [opengraph.xyz](https://opengraph.xyz) or similar OG tester
- [ ] Verify homepage shows hero-story-1.webp image
- [ ] Verify /book shows the book cover image
- [ ] Test on Twitter/X card validator
- [ ] Test on LinkedIn post inspector

🤖 Generated with [Claude Code](https://claude.com/claude-code)