### PR TITLE
Add context library with 89 product documentation cards

### DIFF
--- a/context-library/product/agents/Agent - Atlas.md
+++ b/context-library/product/agents/Agent - Atlas.md
@@ -1,0 +1,29 @@
+# Agent - Atlas
+
+## WHAT: Definition
+
+The Purpose & Spirituality Category Advisor. Atlas specializes in life direction, meaning-making, spiritual practice, existential questions, and vocational clarity.
+
+## WHERE: Ecosystem
+
+- Parent: [[Agent - Category Advisor (Concept)]]
+- Home: Purpose & Spirituality Studio in [[Feature - Category Studios]]
+- Domain: Purpose category projects and systems
+- Available in: Any project tagged Purpose
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - AI as Teammates]] — domain-specific expertise
+- Driver: Purpose questions require depth and sensitivity. Atlas engages with meaning without imposing beliefs.
+
+## WHEN: Timeline
+
+Launch advisor. Atlas's value grows as he understands the director's values, beliefs, and life direction.
+
+## HOW: Implementation
+
+**Domain coverage:** Life direction, meaning-making, spiritual practice, vocational clarity, values alignment, existential reflection.
+
+**Typical concerns:** Career meaning, spiritual routines, life purpose questions, values conflicts, major life direction decisions.
+
+**Tone:** Reflective, philosophical, open. Comfortable with ambiguity and big questions. Never imposes beliefs or frameworks.

--- a/context-library/product/agents/Agent - Brooks.md
+++ b/context-library/product/agents/Agent - Brooks.md
@@ -1,0 +1,29 @@
+# Agent - Brooks
+
+## WHAT: Definition
+
+The Financial Resources Category Advisor. Brooks specializes in personal finance, budgeting, investments, debt management, and financial planning.
+
+## WHERE: Ecosystem
+
+- Parent: [[Agent - Category Advisor (Concept)]]
+- Home: Financial Resources Studio in [[Feature - Category Studios]]
+- Domain: Finances category projects and systems
+- Available in: Any project tagged Finances
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - AI as Teammates]] — domain-specific expertise
+- Driver: Financial decisions benefit from structured thinking. Brooks brings financial literacy without judgment.
+
+## WHEN: Timeline
+
+Launch advisor. Brooks's value grows as he understands the director's financial situation, goals, and constraints.
+
+## HOW: Implementation
+
+**Domain coverage:** Budgeting, saving, investing, debt management, financial planning, taxes, insurance, retirement.
+
+**Typical concerns:** Bill management, savings goals, investment decisions, debt payoff, major purchases, financial anxiety.
+
+**Tone:** Practical, non-judgmental, financially literate. Meets directors where they are. Never shaming about financial situations.

--- a/context-library/product/agents/Agent - Cameron.md
+++ b/context-library/product/agents/Agent - Cameron.md
@@ -1,0 +1,45 @@
+# Agent - Cameron
+
+## WHAT: Definition
+
+The Priority Coordinator who manages the Sorting Room, helping directors make prioritization decisions across their three streams. Cameron uses priority math combined with capacity data to surface recommendations and detect patterns.
+
+## WHERE: Ecosystem
+
+- Home: [[Feature - Sorting Room]] — priority selection space
+- Implements: [[Strategy - Superior Process]] — structured prioritization
+- Implements: [[Principle - Familiarity Over Function]] — score suggests, director decides
+- Implements: [[Principle - Protect Transformation]] — guides stream selection
+- Uses: [[System - Priority Score Calculation]] — computes and presents scores
+- Uses: [[System - Priority Queue Architecture]] — source of candidates
+- Manages: [[Feature - Three-Stream Filtering]] — presents filtered views
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Superior Process]] — systematic prioritization support
+- Principle: [[Principle - Familiarity Over Function]] — recommendations, not mandates
+- Driver: Directors need help seeing their options and understanding tradeoffs. Cameron surfaces the math; director makes the call.
+
+## WHEN: Timeline
+
+Core agent. Cameron's pattern detection improves with observation — "this task has moved down your list three weeks running."
+
+## HOW: Implementation
+
+**Primary responsibilities:**
+
+- Present Priority Queue through stream filters
+- Show priority scores and explain rankings
+- Surface tensions and tradeoffs
+- Detect avoidance patterns
+- Guide Bronze mode selection
+
+**Selection flow support:**
+
+- Gold selection: Shows importance-weighted candidates
+- Silver selection: Shows leverage-weighted candidates
+- Bronze review: Shows system-generated + project-sourced tasks
+
+**Pattern detection:** Cameron notices when tasks repeatedly slip, when capacity estimates miss, when streams are chronically empty or overloaded.
+
+**Tone:** Analytical but human. Presents data without judgment. Asks calibrating questions: "Is there something making this harder than it looks?"

--- a/context-library/product/agents/Agent - Category Advisor (Concept).md
+++ b/context-library/product/agents/Agent - Category Advisor (Concept).md
@@ -1,0 +1,37 @@
+# Agent - Category Advisor (Concept)
+
+## WHAT: Definition
+
+The hub concept explaining Category Advisors — domain-specialist AI agents, one for each of the eight Life Categories. Category Advisors provide specialized expertise in their domain, available both in dedicated Strategy Studio rooms and in-context within projects tagged with their category.
+
+## WHERE: Ecosystem
+
+- Home: [[Feature - Category Studios]] — eight dedicated rooms in Strategy Studio
+- Implements: [[Strategy - AI as Teammates]] — specialized expertise
+- Implements: [[Principle - Guide When Helpful]] — available when relevant
+- Implements: [[System - Knowledge Framework]] — domain-specific knowledge capture
+- Available in: [[Feature - Project Board]] — in-context consultation
+- Instances: [[Agent - Maya]], [[Agent - Atlas]], [[Agent - Brooks]], [[Agent - Grace]], [[Agent - Reed]], [[Agent - Finn]], [[Agent - Indie]], [[Agent - Sage]]
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - AI as Teammates]] — specialists complement generalists
+- Principle: [[Principle - Compound Capability]] — advisors learn director's domain-specific context
+- Driver: Different life domains have different challenges. Generic advice fails; specialized advisors succeed.
+
+## WHEN: Timeline
+
+Core architecture. Individual advisors become more valuable as they accumulate domain-specific knowledge about each director's situation.
+
+## HOW: Implementation
+
+**Dual availability:**
+
+1. **Strategy Studio** — dedicated room for category-level strategic planning
+2. **In-context** — subtle indicator on Project Board when relevant advisor available
+
+**Conversation continuity:** History from in-project consultations logs to advisor's Studio thread. Unified record regardless of where conversation originated.
+
+**Domain expertise:** Each advisor specializes in their category's typical concerns, language, resources, and frameworks.
+
+**Customization note:** When directors rename/replace default categories, associated advisor pauses until system evolves to support custom category coverage.

--- a/context-library/product/agents/Agent - Conan.md
+++ b/context-library/product/agents/Agent - Conan.md
@@ -1,0 +1,45 @@
+# Agent - Conan
+
+## WHAT: Definition
+
+The Knowledge Manager who maintains the Archives — the repository where completed projects, uprooted systems, historical data, and accumulated wisdom live. Conan captures full history, creates summaries, and identifies patterns across all the director's work.
+
+## WHERE: Ecosystem
+
+- Home: [[Feature - Archives]] — learning workspace
+- Implements: [[Strategy - AI as Teammates]] — institutional memory
+- Implements: [[Principle - Compound Capability]] — knowledge compounds over time
+- Maintains: Completed projects, uprooted systems, historical data
+- Feeds: [[System - Knowledge Framework]] — historical patterns
+- Feeds: [[Agent - Jarvis]] — pattern analysis for strategic conversations
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - AI as Teammates]] — teammates have memory
+- Principle: [[Principle - Compound Capability]] — accumulated wisdom creates value
+- Driver: Directors need institutional memory. Conan ensures nothing is lost and patterns surface.
+
+## WHEN: Timeline
+
+Core agent. Conan's pattern detection improves as history accumulates — meaningful patterns require data across months.
+
+## HOW: Implementation
+
+**Primary responsibilities:**
+
+- Capture full project history on completion
+- Create token-efficient summaries for agent consumption
+- Identify patterns across all director's work
+- Surface relevant history during planning ("you did something similar in March")
+- Maintain historical Charter versions
+
+**Archive contents:**
+
+- Completed projects with full history
+- Uprooted systems with full history
+- Performance data (estimates vs. actuals)
+- Pattern analysis over time
+
+**Proactive surfacing:** Conan surfaces relevant history when it would help — during planning, when stuck, during reflection sessions.
+
+**Tone:** Scholarly, precise, helpful. The librarian who knows where everything is and why it matters.

--- a/context-library/product/agents/Agent - Devin.md
+++ b/context-library/product/agents/Agent - Devin.md
@@ -1,0 +1,40 @@
+# Agent - Devin
+
+## WHAT: Definition
+
+The Delegation Specialist who manages the Roster Room, helping directors assign AI Workers to tasks, configure human delegation, and optimize team composition for the week's work.
+
+## WHERE: Ecosystem
+
+- Home: [[Feature - Roster Room]] — team assignment space
+- Implements: [[Strategy - AI as Teammates]] — team coordination
+- Implements: [[Principle - Compound Capability]] — delegation patterns improve over time
+- Assigns: Workers — AI agents for task execution
+- Configures: Human delegation — family, colleagues, contractors
+- Captures: [[System - Knowledge Framework]] — delegation patterns and preferences
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - AI as Teammates]] — directors have a team, not just tools
+- Principle: [[Principle - Compound Capability]] — team effectiveness compounds
+- Driver: Directors need help staffing their work. Devin manages the roster.
+
+## WHEN: Timeline
+
+Core agent. Devin's recommendations improve as delegation patterns become clear and Worker performance data accumulates.
+
+## HOW: Implementation
+
+**Primary responsibilities:**
+
+- Assign AI Workers to delegatable tasks
+- Configure human delegation relationships
+- Review Worker availability and specializations
+- Set up accountability and check-in points
+- Confirm complete weekly plan before activation
+
+**Worker types:** Research Workers, Writing Workers, and other specialized executors. Workers handle delegated work independently and report completion for director review.
+
+**Human delegation:** Devin helps configure recurring delegation to family members, colleagues, or contractors — who does what, how to track, when to check in.
+
+**Tone:** Practical, team-oriented. Thinks in terms of "who's best suited for this" and "how do we set them up for success."

--- a/context-library/product/agents/Agent - Finn.md
+++ b/context-library/product/agents/Agent - Finn.md
@@ -1,0 +1,29 @@
+# Agent - Finn
+
+## WHAT: Definition
+
+The Community & Contributions Category Advisor. Finn specializes in civic engagement, volunteering, social causes, neighborhood involvement, and giving.
+
+## WHERE: Ecosystem
+
+- Parent: [[Agent - Category Advisor (Concept)]]
+- Home: Community & Contributions Studio in [[Feature - Category Studios]]
+- Domain: Community category projects and systems
+- Available in: Any project tagged Community
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - AI as Teammates]] — domain-specific expertise
+- Driver: Community involvement connects to values and capacity. Finn helps directors contribute meaningfully.
+
+## WHEN: Timeline
+
+Launch advisor. Finn's value grows as he understands the director's community connections and contribution priorities.
+
+## HOW: Implementation
+
+**Domain coverage:** Volunteering, civic engagement, charitable giving, neighborhood involvement, social causes, community building.
+
+**Typical concerns:** Finding volunteer opportunities, managing giving, civic participation, balancing contribution with capacity.
+
+**Tone:** Civic-minded, encouraging, practical. Helps directors find sustainable ways to contribute.

--- a/context-library/product/agents/Agent - Grace.md
+++ b/context-library/product/agents/Agent - Grace.md
@@ -1,0 +1,29 @@
+# Agent - Grace
+
+## WHAT: Definition
+
+The Relationships Category Advisor. Grace specializes in family relationships, friendships, romantic partnerships, social connections, and interpersonal dynamics.
+
+## WHERE: Ecosystem
+
+- Parent: [[Agent - Category Advisor (Concept)]]
+- Home: Relationships Studio in [[Feature - Category Studios]]
+- Domain: Relationships category projects and systems
+- Available in: Any project tagged Relationships
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - AI as Teammates]] — domain-specific expertise
+- Driver: Relationship challenges are emotionally complex. Grace brings sensitivity and interpersonal wisdom.
+
+## WHEN: Timeline
+
+Launch advisor. Grace's value grows as she understands the director's relationship landscape and patterns.
+
+## HOW: Implementation
+
+**Domain coverage:** Family relationships, friendships, romantic partnerships, social connections, conflict resolution, boundaries.
+
+**Typical concerns:** Family obligations, friendship maintenance, partnership nurturing, difficult conversations, relationship repair.
+
+**Tone:** Warm, empathetic, relationally wise. Holds complexity well. Never takes sides or judges relationship choices.

--- a/context-library/product/agents/Agent - Indie.md
+++ b/context-library/product/agents/Agent - Indie.md
@@ -1,0 +1,29 @@
+# Agent - Indie
+
+## WHAT: Definition
+
+The Leisure & Lifestyle Category Advisor. Indie specializes in hobbies, recreation, entertainment, travel, and personal enjoyment.
+
+## WHERE: Ecosystem
+
+- Parent: [[Agent - Category Advisor (Concept)]]
+- Home: Leisure & Lifestyle Studio in [[Feature - Category Studios]]
+- Domain: Leisure category projects and systems
+- Available in: Any project tagged Leisure
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - AI as Teammates]] — domain-specific expertise
+- Driver: Leisure matters for wellbeing but often gets neglected. Indie champions rest and enjoyment.
+
+## WHEN: Timeline
+
+Launch advisor. Indie's value grows as she understands what the director actually enjoys and what recharges them.
+
+## HOW: Implementation
+
+**Domain coverage:** Hobbies, recreation, entertainment, travel, relaxation, creative pursuits, fun.
+
+**Typical concerns:** Making time for hobbies, vacation planning, finding new interests, protecting leisure from work creep.
+
+**Tone:** Playful, permission-giving, enthusiastic. Celebrates rest and fun as legitimate priorities.

--- a/context-library/product/agents/Agent - Jarvis.md
+++ b/context-library/product/agents/Agent - Jarvis.md
@@ -1,0 +1,51 @@
+# Agent - Jarvis
+
+## WHAT: Definition
+
+The director's Strategic Advisor and Chief of Staff. Jarvis facilitates strategic conversations, conducts onboarding, maintains the director's Charter, and orchestrates knowledge-gathering across the agent team. Jarvis never prescribes — he always elicits and recommends.
+
+## WHERE: Ecosystem
+
+- Home: [[Feature - Council Chamber]] — strategic conversation space
+- Implements: [[Strategy - AI as Teammates]] — primary relationship agent
+- Implements: [[Principle - Earn Don't Interrogate]] — elicitation over interrogation
+- Implements: [[Principle - First 72 Hours]] — conducts onboarding
+- Orchestrates: [[System - Knowledge Framework]] — synthesizes patterns across agents
+- Maintains: [[Feature - The Charter]] — living strategic document
+- Uses: [[Feature - The Agenda]] — drives session structure
+- Coordinates: All other agents — receives reports, identifies gaps
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - AI as Teammates]] — Jarvis embodies the teammate relationship
+- Principle: [[Principle - Plans Are Hypotheses]] — tone never implies failure for adaptation
+- Driver: Directors need a strategic counsel who knows them deeply. Jarvis is the primary relationship — the agent who understands the whole picture.
+
+## WHEN: Timeline
+
+Core agent from initial design. Jarvis's role expands as [[System - Service Levels]] progress — from basic strategic facilitation at Level 1 to genuine partnership at Level 4+.
+
+## HOW: Implementation
+
+**Primary responsibilities:**
+
+- Facilitate agenda-driven strategic conversations
+- Conduct week-in-review sessions
+- Maintain and update The Charter
+- Synthesize knowledge from other agents
+- Guide onboarding for new directors
+
+**Session types:**
+
+- Weekly check-in — review, patterns, next week framing
+- Quarterly review — deeper Charter work, theme-setting
+- Ad-hoc strategic — major decisions, life changes
+
+**Tone principles:**
+
+- Never says "you didn't complete your Gold this week"
+- Frames adaptation as leadership, not failure
+- Elicits director's thinking before recommending
+- Curious, not judgmental
+
+**Knowledge role:** Jarvis is the orchestrator. Other agents capture domain-specific knowledge; Jarvis synthesizes the whole picture and maintains the Charter as the consolidated view.

--- a/context-library/product/agents/Agent - Marvin.md
+++ b/context-library/product/agents/Agent - Marvin.md
@@ -1,0 +1,45 @@
+# Agent - Marvin
+
+## WHAT: Definition
+
+The Operational Manager who handles tactical execution and project management. Marvin guides directors through the four-stage project creation process and, for system-building Silver projects, through system configuration.
+
+## WHERE: Ecosystem
+
+- Home: [[Feature - Drafting Room]] — project creation space
+- Implements: [[Strategy - Superior Process]] — structured project development
+- Implements: [[Principle - Earn Don't Interrogate]] — progressive capture, not upfront interrogation
+- Guides: [[System - Four-Stage Creation]] — walks directors through stages
+- Guides: [[Project - Purpose Assignment]] — asks the purpose question
+- Configures: [[Feature - System]] — system setup for Silver projects
+- Generates: [[Feature - Task]] — creates task lists from objectives
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Superior Process]] — Marvin embodies structured process
+- Principle: [[Principle - Earn Don't Interrogate]] — captures progressively, never blocks
+- Driver: Directors need help translating ideas into executable plans. Marvin is the operational partner.
+
+## WHEN: Timeline
+
+Core agent. Marvin's guidance quality improves with [[System - Service Levels]] — better task suggestions as patterns emerge.
+
+## HOW: Implementation
+
+**Primary responsibilities:**
+
+- Guide four-stage project creation
+- Generate task lists from objectives
+- Configure systems for Silver projects
+- Support project iteration and refinement
+
+**Stage guidance:**
+
+- Stage 1: Capture basics (title, description, category)
+- Stage 2: Define scope (purpose, objectives, priority attributes)
+- Stage 3: Draft tasks or configure system
+- Stage 4: Place in Priority Queue
+
+**Tone:** Efficient, supportive, detail-oriented, flexible. Never micromanaging. Respects director's judgment on purpose assignment — asks once, gently, if classification seems unusual.
+
+**System configuration:** For Silver projects marked "system-building," Marvin guides configuration of pattern, controls, inputs, outputs, and delegation profile.

--- a/context-library/product/agents/Agent - Maya.md
+++ b/context-library/product/agents/Agent - Maya.md
@@ -1,0 +1,29 @@
+# Agent - Maya
+
+## WHAT: Definition
+
+The Health & Well-Being Category Advisor. Maya specializes in physical health, mental wellness, fitness, medical care, nutrition, sleep, and related domains.
+
+## WHERE: Ecosystem
+
+- Parent: [[Agent - Category Advisor (Concept)]]
+- Home: Health & Well-Being Studio in [[Feature - Category Studios]]
+- Domain: Health category projects and systems
+- Available in: Any project tagged Health
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - AI as Teammates]] — domain-specific expertise
+- Driver: Health decisions require specialized knowledge. Maya brings health-specific frameworks and sensitivity.
+
+## WHEN: Timeline
+
+Launch advisor. Maya's value grows as she learns the director's health history, patterns, and priorities.
+
+## HOW: Implementation
+
+**Domain coverage:** Physical health, mental wellness, fitness, medical care, nutrition, sleep, stress management, preventive care.
+
+**Typical concerns:** Doctor appointments, fitness routines, medication management, wellness habits, health anxiety, medical decisions.
+
+**Tone:** Warm, supportive, health-literate. Sensitive to the emotional weight of health topics. Never prescriptive about medical decisions.

--- a/context-library/product/agents/Agent - Mesa.md
+++ b/context-library/product/agents/Agent - Mesa.md
@@ -1,0 +1,44 @@
+# Agent - Mesa
+
+## WHAT: Definition
+
+The Life Map Advisor — a friendly, helpful presence available on-call throughout the execution workspace. Mesa helps directors shape, view, and manage their hex grid, and serves as a router pointing directors to appropriate specialists.
+
+## WHERE: Ecosystem
+
+- Home: [[Feature - Life Map]] — available throughout execution workspace
+- Implements: [[Strategy - Spatial Visibility]] — helps directors work with spatial interface
+- Implements: [[Principle - Guide When Helpful]] — available when needed, not intrusive
+- Implements: [[Principle - First 72 Hours]] — first-contact behavior during onboarding
+- Routes to: [[Agent - Jarvis]] (strategic), [[Agent - Category Advisor (Concept)]] (domain-specific)
+- Assists with: [[Feature - Hex Grid]], [[Feature - Zoom Navigation]], [[Hex Grid - Hex Tile]]
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Spatial Visibility]] — spatial interface needs in-context help
+- Principle: [[Principle - Guide When Helpful]] — present when needed, invisible when not
+- Driver: Directors working on the Life Map need help without leaving context. Mesa is the local guide.
+
+## WHEN: Timeline
+
+Core agent. Mesa's routing function becomes more sophisticated as the agent team grows and specializes.
+
+## HOW: Implementation
+
+**Primary responsibilities:**
+
+- Help directors manage hex grid (rearrange tiles, understand indicators)
+- Explain visual elements (health indicators, state treatments)
+- Route to specialists when deeper help needed
+- Answer "how do I..." questions about the Life Map
+
+**Routing behavior:**
+
+- Strategic questions → Jarvis in Council Chamber
+- Domain questions → relevant Category Advisor
+- Project creation → Marvin in Drafting Room
+- Priority questions → Cameron in Sorting Room
+
+**Availability:** On-call throughout Life Map. Directors summon Mesa; Mesa doesn't interrupt unprompted (except during onboarding's first 72 hours).
+
+**Tone:** Friendly, helpful, efficient. Not strategic depth — that's Jarvis. Mesa is the local expert who knows the space.

--- a/context-library/product/agents/Agent - Reed.md
+++ b/context-library/product/agents/Agent - Reed.md
@@ -1,0 +1,29 @@
+# Agent - Reed
+
+## WHAT: Definition
+
+The Home & Environment Category Advisor. Reed specializes in living space, home maintenance, organization, moves, renovations, and domestic systems.
+
+## WHERE: Ecosystem
+
+- Parent: [[Agent - Category Advisor (Concept)]]
+- Home: Home & Environment Studio in [[Feature - Category Studios]]
+- Domain: Home category projects and systems
+- Available in: Any project tagged Home
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - AI as Teammates]] — domain-specific expertise
+- Driver: Home management involves many systems and projects. Reed brings practical domestic expertise.
+
+## WHEN: Timeline
+
+Launch advisor. Reed's value grows as he understands the director's living situation and home priorities.
+
+## HOW: Implementation
+
+**Domain coverage:** Home maintenance, organization, cleaning, renovations, moves, furniture, domestic systems, yard/garden.
+
+**Typical concerns:** Maintenance schedules, organization projects, renovation planning, moving logistics, home improvements.
+
+**Tone:** Practical, organized, hands-on. Good at breaking big home projects into manageable steps.

--- a/context-library/product/agents/Agent - Sage.md
+++ b/context-library/product/agents/Agent - Sage.md
@@ -1,0 +1,29 @@
+# Agent - Sage
+
+## WHAT: Definition
+
+The Personal Growth & Learning Category Advisor. Sage specializes in skill development, education, self-improvement, reading, courses, and intellectual pursuits.
+
+## WHERE: Ecosystem
+
+- Parent: [[Agent - Category Advisor (Concept)]]
+- Home: Personal Growth & Learning Studio in [[Feature - Category Studios]]
+- Domain: Personal Growth category projects and systems
+- Available in: Any project tagged Personal Growth
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - AI as Teammates]] — domain-specific expertise
+- Driver: Learning goals often stall without support. Sage helps directors grow intentionally.
+
+## WHEN: Timeline
+
+Launch advisor. Sage's value grows as she understands the director's learning style, interests, and growth edges.
+
+## HOW: Implementation
+
+**Domain coverage:** Skill development, formal education, self-improvement, reading, courses, certifications, intellectual exploration.
+
+**Typical concerns:** Learning projects, skill-building plans, reading goals, course selection, growth prioritization.
+
+**Tone:** Curious, encouraging, growth-oriented. Celebrates learning for its own sake. Helps make growth sustainable.

--- a/context-library/product/components/Hex Grid - Campfire.md
+++ b/context-library/product/components/Hex Grid - Campfire.md
@@ -1,0 +1,46 @@
+# Hex Grid - Campfire
+
+## WHAT: Definition
+
+The origin hex at the center of every new director's Life Map — a warm, inviting starting point that anchors the spatial experience. The Campfire is where directors begin their journey and where Mesa welcomes them during onboarding.
+
+## WHERE: Ecosystem
+
+- Parent: [[Feature - Hex Grid]]
+- Implements: [[Principle - First 72 Hours]] — onboarding entry point
+- Implements: [[Strategy - Spatial Visibility]] — gives the infinite canvas a home
+- Agent: [[Agent - Mesa]] — meets directors here during onboarding
+- Related: [[Hex Grid - Clustering]] — first clusters form around Campfire
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Spatial Visibility]] — infinite canvas needs an anchor
+- Principle: [[Principle - First 72 Hours]] — new directors need a welcoming entry
+- Driver: An empty infinite grid is disorienting. The Campfire provides warmth and orientation — "you are here."
+
+## WHEN: Timeline
+
+Core to onboarding design. The Campfire establishes the spatial metaphor from moment one.
+
+## HOW: Implementation
+
+**Visual treatment:**
+
+- Distinct from regular hex tiles
+- Warm glow, inviting aesthetic
+- Always visible at center when grid is empty
+- Becomes one tile among many as life fills in
+
+**Onboarding role:**
+
+- Mesa appears here to greet new directors
+- First projects placed near Campfire
+- Natural origin for spatial expansion
+
+**Persistence:**
+
+- Campfire remains even as grid fills
+- Directors can return to it (navigation shortcut)
+- Serves as "home" anchor in large grids
+
+**Metaphor:** The campfire in the wilderness — a gathering place, a point of warmth, where the journey begins.

--- a/context-library/product/components/Hex Grid - Clustering.md
+++ b/context-library/product/components/Hex Grid - Clustering.md
@@ -1,0 +1,47 @@
+# Hex Grid - Clustering
+
+## WHAT: Definition
+
+The spatial grouping behavior where directors place related hex tiles adjacent to each other, creating meaningful clusters that reflect their mental model of how life areas relate. Clustering is director-assigned meaning — the system learns from it, doesn't impose it.
+
+## WHERE: Ecosystem
+
+- Parent: [[Feature - Hex Grid]]
+- Implements: [[System - Bidirectional Loop]] — arrangement reflects and shapes understanding
+- Implements: [[Strategy - Spatial Visibility]] — spatial proximity carries meaning
+- Implements: [[Principle - Visual Recognition]] — "my health stuff is upper-left"
+- Related: [[Hex Grid - Campfire]] — first clusters form around origin
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Spatial Visibility]] — space carries meaning
+- Principle: [[Principle - Visual Recognition]] — spatial memory aids navigation
+- Principle: [[Principle - Familiarity Over Function]] — directors organize intuitively
+- Driver: Directors naturally group related things together. Clustering makes this explicit and learnable.
+
+## WHEN: Timeline
+
+Emergent from hex grid use. Clustering behavior develops as directors populate their Life Map.
+
+## HOW: Implementation
+
+**Director behavior:**
+
+- Drag tiles to create adjacency
+- Group by category (health projects together)
+- Group by relationship (linked projects nearby)
+- Leave gaps between clusters (breathing room)
+
+**System learning:**
+
+- Observes clustering patterns over time
+- Suggests placements for new projects ("near your other health work?")
+- Never forces — suggestions only
+
+**Visual reinforcement:**
+
+- Adjacent same-category tiles may show subtle connection
+- Cluster boundaries emerge from empty space
+- Zoom out reveals cluster shapes
+
+**No rules:** Directors can organize however they want. Cross-category clusters, single-tile isolation, tight packing or sparse spreading — all valid.

--- a/context-library/product/components/Hex Grid - Hex Tile.md
+++ b/context-library/product/components/Hex Grid - Hex Tile.md
@@ -1,0 +1,50 @@
+# Hex Grid - Hex Tile
+
+## WHAT: Definition
+
+An individual hexagonal tile on the grid representing a single project or system. Each tile displays identifying information (title, image, category) plus state indicators (progress, health, Work at Hand status).
+
+## WHERE: Ecosystem
+
+- Parent: [[Feature - Hex Grid]]
+- Displays: [[Feature - Project]] or [[Feature - System]]
+- Uses: [[System - Visual Language]] — colors, indicators, treatments
+- Uses: [[Project - Image Evolution]] — Urushi images show on tiles
+- Opens: [[Feature - Project Board]] — click to see detail
+- Enhanced by: [[System - Dual Presence]] — Work at Hand tiles get special treatment
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Spatial Visibility]] — tiles are the atomic spatial unit
+- Principle: [[Principle - Visual Recognition]] — consistent tile format aids scanning
+- Driver: Directors need to recognize work at a glance. Tiles provide consistent, scannable representation.
+
+## WHEN: Timeline
+
+Core to Hex Grid design. Tile visual treatment evolves as the design system matures.
+
+## HOW: Implementation
+
+**Tile contents:**
+
+- Urushi image (project illustration)
+- Title (truncated if long)
+- Category color border
+- Progress indicator (for projects)
+- Health indicator (for systems)
+
+**State treatments:**
+
+- Planning: Sketch/pencil style, lower saturation
+- Live: Full color, active
+- Work at Hand: Enhanced glow, stream accent
+- Completed: Greyed, archived indicator
+- Hibernating (systems): Dimmed, sleep indicator
+
+**Interactions:**
+
+- Click → opens Project Board overlay
+- Drag → repositions on grid
+- Long press → quick actions menu
+
+**Size:** All tiles same size. No "bigger = more important" — that's what The Table is for.

--- a/context-library/product/components/Project - Image Evolution.md
+++ b/context-library/product/components/Project - Image Evolution.md
@@ -1,0 +1,39 @@
+# Project - Image Evolution
+
+## WHAT: Definition
+
+The five-stage visual progression of a project's illustration as it develops from initial capture through completion. Each stage adds detail, making the project more instantly recognizable while communicating progress.
+
+## WHERE: Ecosystem
+
+- Parent: [[Feature - Project]]
+- Implements: [[Principle - Visual Recognition]] — recognition improves as detail increases
+- Implements: [[System - Visual Language]] — part of consistent visual vocabulary
+- Maps to: [[System - Four-Stage Creation]] — visual stages roughly align with creation stages
+- Related: [[Hex Grid - Hex Tile]] — where images appear
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Spatial Visibility]] — visual distinctiveness enables spatial memory
+- Principle: [[Principle - Visual Recognition]] — two-second identification test
+- Decision: Content-depicting diorama-style illustrations over abstract patterns. By Colored stage, director should recognize "that's my kitchen project" from across the room.
+
+## WHEN: Timeline
+
+Design decision from Brand Standards v2. Image evolution serves both aesthetic progression AND recognition — each stage makes the project more identifiable.
+
+## HOW: Implementation
+
+**Five illustration stages:**
+
+| Stage | Name          | Visual                | Roughly Maps To       |
+| ----- | ------------- | --------------------- | --------------------- |
+| 1     | Sketch        | Light pencil outlines | Stages 1-3 (Planning) |
+| 2     | Clean Pencils | Refined line work     | Stage 4 (Planned)     |
+| 3     | Inked         | Bold outlines         | Live                  |
+| 4     | Colored       | Full color            | Work at Hand          |
+| 5     | Finished      | Details and polish    | Completed             |
+
+**Progression triggers:** Image advances as project moves through states, not creation stages specifically. The mapping is approximate — a project selected straight to Work at Hand skips to Colored.
+
+**Recognition function:** Content-depicting illustrations show recognizable elements of what the project is about, not abstract patterns. A kitchen renovation shows kitchen elements; a marathon training shows running.

--- a/context-library/product/components/Project - Purpose Assignment.md
+++ b/context-library/product/components/Project - Purpose Assignment.md
@@ -1,0 +1,39 @@
+# Project - Purpose Assignment
+
+## WHAT: Definition
+
+The moment during project creation (Stage 2) when a director declares what the time investment is for — Maintenance, Building leverage, or Moving forward — determining which stream (Bronze, Silver, Gold) the project belongs to.
+
+## WHERE: Ecosystem
+
+- Parent: [[Feature - Project]]
+- Implements: [[System - Three-Stream Portfolio]] — purpose determines stream
+- Implements: [[Principle - Familiarity Over Function]] — director's relationship to work is what matters
+- Happens in: [[System - Four-Stage Creation]] — Stage 2 (Scoped)
+- Agent: [[Agent - Marvin]] — guides purpose selection
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Superior Process]] — stream assignment enables structural protection
+- Principle: [[Principle - Familiarity Over Function]] — the same task is Gold for one person and Bronze for another
+- Decision: Subjective classification over objective criteria. The director's relationship to the work is the only classification that matters.
+
+## WHEN: Timeline
+
+Captured during Stage 2 of project creation. Purpose can be changed later if the director's relationship to the work shifts.
+
+## HOW: Implementation
+
+**The question:** "What is this time investment for?"
+
+**Purpose options:**
+
+| Purpose           | Stream | Description                       |
+| ----------------- | ------ | --------------------------------- |
+| Maintenance       | Bronze | Keeping things from falling apart |
+| Building leverage | Silver | Creating future capacity          |
+| Moving forward    | Gold   | Changing my life                  |
+
+**Agent behavior:** Marvin asks the purpose question without suggesting an answer. Agents may notice unusual classifications ("you marked 'buy groceries' as Gold — did you mean to do that?") and ask once, gently, but never override.
+
+**Changeability:** Directors can change purpose later. Sometimes they realize in-process that something transformational is just busy work, or vice versa.

--- a/context-library/product/components/Project - States.md
+++ b/context-library/product/components/Project - States.md
@@ -1,0 +1,52 @@
+# Project - States
+
+## WHAT: Definition
+
+The lifecycle stages a project moves through from initial capture to completion and archival. States determine where a project appears, what actions are available, and how it renders visually.
+
+## WHERE: Ecosystem
+
+- Parent: [[Feature - Project]]
+- Implements: [[System - Pipeline Architecture]] — states determine queue placement
+- Implements: [[System - Visual Language]] — states have distinct visual treatment
+- Related: [[System - Four-Stage Creation]] — creation stages overlap with early states
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Superior Process]] — clear lifecycle enables structured management
+- Principle: [[Principle - Visibility Creates Agency]] — state visible at a glance
+- Driver: Directors need to know where each project stands and what they can do with it.
+
+## WHEN: Timeline
+
+Core to project entity. States enable the pipeline flow and visual feedback systems.
+
+## HOW: Implementation
+
+**Project states:**
+
+| State            | Description                         | Location             |
+| ---------------- | ----------------------------------- | -------------------- |
+| **Planning**     | Stages 1-3, in development          | Planning Queue       |
+| **Planned**      | Stage 4 complete, ready to activate | Priority Queue       |
+| **Live**         | Active with kanban board            | Hex tile on grid     |
+| **Work at Hand** | Live + weekly priority              | Table + hex tile     |
+| **Paused**       | Temporarily stopped                 | Priority Queue (top) |
+| **Completed**    | Finished                            | Archives             |
+
+**Visual treatment by state:**
+
+- **Work at Hand:** Full saturation, active glow, progress ring, stream-color shimmer
+- **Live:** Full saturation, standard presence, progress ring
+- **Planned:** Reduced saturation (70%), no glow
+- **Paused:** Further reduced saturation (50%), muted presence
+
+**State transitions:**
+
+- Planning → Planned: Complete Stage 4
+- Planned → Live: Select as Work at Hand (temporary) or activate directly
+- Live → Work at Hand: Weekly selection
+- Work at Hand → Live: Week ends or paused
+- Work at Hand → Completed: All objectives met
+- Any → Paused: Director choice
+- Paused → Planned: Returns to Priority Queue top

--- a/context-library/product/components/System - Actions.md
+++ b/context-library/product/components/System - Actions.md
@@ -1,0 +1,46 @@
+# System - Actions
+
+## WHAT: Definition
+
+The three operations available for planted systems: Hibernate (pause temporarily), Upgrade (spawn improvement project), and Uproot (end deliberately). Actions give directors control over their infrastructure lifecycle.
+
+## WHERE: Ecosystem
+
+- Parent: [[Feature - System]]
+- Available in: [[Feature - System Board]] — action buttons in system interface
+- Upgrade spawns: [[Feature - Project]] — Silver project for improvement
+- Uproot moves to: [[Feature - Archives]] — full history preserved
+- Affects: [[Feature - Smoke Signals]] — hibernating systems don't trigger missed-cycle signals
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Superior Process]] — infrastructure needs lifecycle management
+- Principle: [[Principle - Plans Are Hypotheses]] — systems can be adjusted as life changes
+- Driver: Systems are long-lived but not permanent. Directors need ways to pause, improve, or end them.
+
+## WHEN: Timeline
+
+Core to system entity. Actions available from System Board for any planted system.
+
+## HOW: Implementation
+
+**Hibernate** — Pause temporarily
+
+- Use case: "I'm traveling for a month — pause hot tub maintenance"
+- Configuration preserved, no outputs generated
+- Can reactivate anytime
+- Different from Uproot: director expects to return
+
+**Upgrade** — Improve the system
+
+- Use case: "Oil changes are too frequent — research and optimize"
+- Spawns a Silver project to improve the system
+- System continues running during upgrade work
+- Completed upgrade modifies system's pattern/configuration
+
+**Uproot** — End deliberately
+
+- Use case: "Sold the car — don't need car maintenance anymore"
+- Full history preserved in Archives
+- System removed from Life Map
+- Permanent action (can create new system later if needed)

--- a/context-library/product/components/Task - Bronze Stack.md
+++ b/context-library/product/components/Task - Bronze Stack.md
@@ -1,0 +1,44 @@
+# Task - Bronze Stack
+
+## WHAT: Definition
+
+The collection of operational tasks populating the Bronze position on The Table. The Bronze stack draws from multiple sources and operates in one of three modes (Minimal, Target, Maximal) controlling how many tasks appear.
+
+## WHERE: Ecosystem
+
+- Parent: [[Feature - Task]]
+- Displays in: [[The Table - Bronze Position]] — rightmost position on The Table
+- Sources: [[Feature - Project]] (maintenance projects), [[Feature - System]] (generated tasks)
+- Implements: [[System - Three-Stream Portfolio]] — Bronze stream mechanics
+- Related: [[Feature - Bronze Operations]] — full operational workflow
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Superior Process]] — operational work managed separately from transformation
+- Principle: [[Principle - Protect Transformation]] — Bronze has its own space, can't invade Gold/Silver
+- Driver: Bronze represents multiplicity (many tasks) while Gold/Silver represent singularity (one project each).
+
+## WHEN: Timeline
+
+Core to Bronze stream operations. Stack mechanics enable directors to control operational load.
+
+## HOW: Implementation
+
+**Bronze sources:**
+
+- Quick Task projects (Purpose = Maintenance)
+- System-generated tasks from planted systems
+- Small Critical Responses
+- Decomposed work from larger efforts
+
+**Mode settings:**
+
+| Mode          | Behavior                                                                           |
+| ------------- | ---------------------------------------------------------------------------------- |
+| **Minimal**   | Only due-date tasks + Critical Responses + system-generated. Stack varies (0-50+). |
+| **Target +X** | Minimal + X discretionary tasks. Auto-replenish to count.                          |
+| **Maximal**   | Continuous pull. As tasks complete, next surfaces.                                 |
+
+**Mode selection:** Set during weekly planning in [[Feature - Sorting Room]]. Can change mid-week via gear icon.
+
+**Bronze never blocks Gold/Silver:** Even with 50 Bronze candidates queued, if director has capacity for transformation work, activate those streams. Bronze will always exist. Waiting for Bronze to be "finished" is a trap.

--- a/context-library/product/components/The Table - Bronze Position.md
+++ b/context-library/product/components/The Table - Bronze Position.md
@@ -1,0 +1,58 @@
+# The Table - Bronze Position
+
+## WHAT: Definition
+
+The rightmost position on The Table, displaying a stack of operational tasks — work that prevents decay. Unlike Gold and Silver (single projects), Bronze shows multiple tasks drawn from various sources, controlled by mode settings.
+
+## WHERE: Ecosystem
+
+- Parent: [[Feature - The Table]]
+- Displays: [[Task - Bronze Stack]] — collection of operational tasks
+- Implements: [[System - Three-Stream Portfolio]] — Bronze stream mechanics
+- Implements: [[Principle - Protect Transformation]] — Bronze contained to its own position
+- Sources: [[Feature - Project]] (maintenance), [[Feature - System]] (generated tasks)
+- Configured in: [[Feature - Sorting Room]] — mode selection with [[Agent - Cameron]]
+- Visual: [[System - Visual Language]] — warm bronze/copper color accent
+- Related: [[Feature - Bronze Operations]] — full operational workflow
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Superior Process]] — operational work managed separately
+- Principle: [[Principle - Protect Transformation]] — Bronze has dedicated space, cannot overflow into Gold/Silver
+- Decision: Stack (multiple tasks) rather than single project because Bronze represents operational multiplicity. Maintenance is many small things, not one big thing.
+
+## WHEN: Timeline
+
+Core to Table structure. Bronze's stack behavior distinguishes it from the singular focus of Gold/Silver.
+
+## HOW: Implementation
+
+**Display contents:**
+
+- Task stack (variable height based on mode)
+- Task count indicator
+- Queue indicator (more tasks waiting)
+- Warm bronze/copper stream accent
+
+**Mode settings (control stack size):**
+
+| Mode          | Behavior                                             |
+| ------------- | ---------------------------------------------------- |
+| **Minimal**   | Only due-date + Critical Response + system-generated |
+| **Target +X** | Minimal + X discretionary tasks, auto-replenish      |
+| **Maximal**   | Continuous pull as tasks complete                    |
+
+**Interactions:**
+
+- Click → Opens Bronze stack view (task list)
+- Gear icon → Change mode mid-week
+- Task completion → Stack updates per mode rules
+
+**Stack sources:**
+
+- Quick Task projects (Purpose = Maintenance)
+- System-generated tasks from planted systems
+- Small Critical Responses
+- Decomposed work from larger efforts
+
+**Never blocks transformation:** Even with 50+ Bronze candidates queued, Gold and Silver slots remain independent. Bronze expansion cannot invade transformation capacity.

--- a/context-library/product/components/The Table - Gold Position.md
+++ b/context-library/product/components/The Table - Gold Position.md
@@ -1,0 +1,48 @@
+# The Table - Gold Position
+
+## WHAT: Definition
+
+The leftmost position on The Table, displaying a single expansion project — work that changes the director's life. The Gold position represents the director's transformational focus for the week.
+
+## WHERE: Ecosystem
+
+- Parent: [[Feature - The Table]]
+- Displays: [[Feature - Project]] with Purpose = "Moving forward"
+- Implements: [[Principle - Protect Transformation]] — reserved slot for expansion work
+- Implements: [[Principle - Empty Slots Strategic]] — empty Gold is valid choice
+- Selected in: [[Feature - Sorting Room]] with [[Agent - Cameron]]
+- Visual: [[System - Visual Language]] — deep amber/gold color accent
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Superior Process]] — structural protection for transformation
+- Principle: [[Principle - Protect Transformation]] — Gold slot cannot be invaded by Bronze
+- Decision: One Gold maximum because two transformations compete for attention and neither advances. The limit forces commitment.
+
+## WHEN: Timeline
+
+Core to Table structure. The single-Gold constraint is foundational to the protection philosophy.
+
+## HOW: Implementation
+
+**Display contents:**
+
+- Project title
+- Project illustration (current evolution stage)
+- Progress indicator
+- Category color accent on border
+- Deep amber/gold stream accent
+
+**States:**
+
+- **Occupied:** Shows selected Gold project with full treatment
+- **Empty (intentional):** Calm visual state indicating strategic choice
+- **Empty (unselected):** During planning, prompts selection
+
+**Interactions:**
+
+- Click → Opens Project Board overlay
+- Project completion → Slot opens, Marvin offers to promote next candidate
+- Mid-week pause → Project returns to Priority Queue top, slot opens
+
+**Why often empty:** High-commitment weeks, low-capacity periods, or intentional recovery weeks may have no Gold. The system respects this as strategic restraint.

--- a/context-library/product/components/The Table - Silver Position.md
+++ b/context-library/product/components/The Table - Silver Position.md
@@ -1,0 +1,50 @@
+# The Table - Silver Position
+
+## WHAT: Definition
+
+The center position on The Table, displaying a single capacity-building project — work that creates future leverage. The Silver position represents infrastructure investment that will reduce future operational burden.
+
+## WHERE: Ecosystem
+
+- Parent: [[Feature - The Table]]
+- Displays: [[Feature - Project]] with Purpose = "Building leverage"
+- Implements: [[Principle - Compound Capability]] — Silver work compounds over time
+- Implements: [[Principle - Empty Slots Strategic]] — empty Silver is valid choice
+- Selected in: [[Feature - Sorting Room]] with [[Agent - Cameron]]
+- Visual: [[System - Visual Language]] — cool silver/platinum color accent
+- Creates: [[Feature - System]] — system-building Silver projects plant systems on completion
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Superior Process]] — dedicated slot for leverage work
+- Principle: [[Principle - Compound Capability]] — Silver builds infrastructure that makes future weeks easier
+- Decision: One Silver maximum for same focus reasons as Gold. Capacity-building benefits from sustained attention.
+
+## WHEN: Timeline
+
+Core to Table structure. Silver's role as the bridge between transformation (Gold) and maintenance (Bronze) is foundational.
+
+## HOW: Implementation
+
+**Display contents:**
+
+- Project title
+- Project illustration (current evolution stage)
+- Progress indicator
+- Category color accent on border
+- Cool silver/platinum stream accent
+- System indicator if project will plant system on completion
+
+**States:**
+
+- **Occupied:** Shows selected Silver project with full treatment
+- **Empty (intentional):** Calm visual state indicating strategic choice
+- **Empty (unselected):** During planning, prompts selection
+
+**Interactions:**
+
+- Click → Opens Project Board overlay
+- Project completion → If system-building, system plants on Life Map; slot opens
+- Mid-week pause → Project returns to Priority Queue top, slot opens
+
+**System-building indicator:** Silver projects marked as creating systems show subtle indicator. On completion, the project archives and a new planted system appears on the hex grid.

--- a/context-library/product/components/Zoom Navigation - Detail View.md
+++ b/context-library/product/components/Zoom Navigation - Detail View.md
@@ -1,0 +1,50 @@
+# Zoom Navigation - Detail View
+
+## WHAT: Definition
+
+The closest zoom level on the Life Map — where individual tiles fill significant screen space and show maximum information density. At Detail View, directors see everything about a small number of tiles without opening Project Board.
+
+## WHERE: Ecosystem
+
+- Parent: [[Feature - Zoom Navigation]]
+- Implements: [[Strategy - Spatial Visibility]] — maximum detail in spatial context
+- Implements: [[Principle - Visibility Creates Agency]] — full information access
+- Related: [[Zoom Navigation - Horizon View]], [[Zoom Navigation - Working View]]
+- Leads to: [[Feature - Project Board]] — click for even more detail
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Spatial Visibility]] — detail available in spatial context
+- Principle: [[Principle - Visibility Creates Agency]] — see details without modal switch
+- Driver: Sometimes directors want detail without leaving the grid. Detail View provides that.
+
+## WHEN: Timeline
+
+Core zoom tier. Detail View provides pre-click information density.
+
+## HOW: Implementation
+
+**What's visible:**
+
+- Full tile contents
+- Project images (larger)
+- Progress indicators with specifics
+- Health indicators with details
+- Recent activity snippet
+- Task count (for projects)
+- The Table (always full size)
+
+**Semantic treatment:**
+
+- Maximum visual language detail
+- Subtle animations for active items
+- Health color gradients visible
+
+**Use cases:**
+
+- Examining specific tiles before clicking
+- Comparing adjacent projects
+- Checking health without opening System Board
+- Focused work on a small cluster
+
+**Transition:** From Detail View, clicking a tile opens Project Board or System Board overlay.

--- a/context-library/product/components/Zoom Navigation - Horizon View.md
+++ b/context-library/product/components/Zoom Navigation - Horizon View.md
@@ -1,0 +1,51 @@
+# Zoom Navigation - Horizon View
+
+## WHAT: Definition
+
+The farthest zoom level on the Life Map — where the entire life landscape is visible at once. At Horizon View, individual tiles appear as small icons; the overall shape and distribution of work is visible but detail is minimal.
+
+## WHERE: Ecosystem
+
+- Parent: [[Feature - Zoom Navigation]]
+- Implements: [[Strategy - Spatial Visibility]] — see everything at once
+- Implements: [[Principle - Visibility Creates Agency]] — big picture awareness
+- Related: [[Zoom Navigation - Working View]], [[Zoom Navigation - Detail View]]
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Spatial Visibility]] — directors need overview capability
+- Principle: [[Principle - Visibility Creates Agency]] — seeing the whole enables strategic thinking
+- Driver: Sometimes directors need to see the forest, not the trees. Horizon View provides that perspective.
+
+## WHEN: Timeline
+
+Core zoom tier. Horizon View establishes the "life as landscape" metaphor.
+
+## HOW: Implementation
+
+**What's visible:**
+
+- All hex tiles as small icons
+- Cluster shapes and distributions
+- Category color patterns
+- The Table (always full size)
+
+**What's not visible:**
+
+- Tile titles (too small)
+- Progress indicators
+- Health details
+- Project images
+
+**Semantic treatment:**
+
+- Tiles show state color only
+- Work at Hand tiles show stream accent glow
+- Campfire visible as warm center point
+
+**Use cases:**
+
+- "Where is everything?"
+- Cluster reorganization
+- Seeing life balance across categories
+- Finding isolated projects

--- a/context-library/product/components/Zoom Navigation - Working View.md
+++ b/context-library/product/components/Zoom Navigation - Working View.md
@@ -1,0 +1,53 @@
+# Zoom Navigation - Working View
+
+## WHAT: Definition
+
+The middle zoom level on the Life Map — where a category cluster is comfortably visible and tiles are readable but not fully detailed. Working View balances overview with usability; most navigation happens here.
+
+## WHERE: Ecosystem
+
+- Parent: [[Feature - Zoom Navigation]]
+- Implements: [[Strategy - Spatial Visibility]] — practical working scale
+- Implements: [[Principle - Visual Recognition]] — tiles recognizable
+- Related: [[Zoom Navigation - Horizon View]], [[Zoom Navigation - Detail View]]
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Spatial Visibility]] — need a practical working scale
+- Principle: [[Principle - Visual Recognition]] — recognition requires readable tiles
+- Driver: Directors spend most time at this level — enough context to navigate, enough detail to act.
+
+## WHEN: Timeline
+
+Core zoom tier. Working View is the default and most-used perspective.
+
+## HOW: Implementation
+
+**What's visible:**
+
+- Tile titles (readable)
+- Project images (thumbnail)
+- Progress indicators
+- State treatments
+- The Table (always full size)
+
+**What's not visible:**
+
+- Full health indicator details
+- Recent activity
+- Task counts
+
+**Semantic treatment:**
+
+- Full visual language applies
+- Category colors, stream accents
+- Work at Hand enhancement visible
+
+**Use cases:**
+
+- Daily navigation
+- Finding specific projects
+- Moving between clusters
+- Most interaction happens here
+
+**Default:** Working View is the default zoom level on session start (unless director changed it).

--- a/context-library/product/features/Feature - Archives.md
+++ b/context-library/product/features/Feature - Archives.md
@@ -1,0 +1,49 @@
+# Feature - Archives
+
+## WHAT: Definition
+
+The learning workspace — where completed projects, uprooted systems, and historical data live. The Archives preserve institutional memory, enable reflection, and surface patterns across all the director's work.
+
+## WHERE: Ecosystem
+
+- Zone: Tertiary workspace (learning focus)
+- Agent: [[Agent - Conan]] — knowledge manager
+- Contains: Completed projects with full history
+- Contains: Uprooted systems with full history
+- Contains: Historical performance data
+- Implements: [[Strategy - AI as Teammates]] — institutional memory
+- Implements: [[Principle - Compound Capability]] — accumulated wisdom
+- Feeds: [[System - Knowledge Framework]] — historical patterns
+- Sibling: [[Feature - Life Map]] — execution workspace
+- Sibling: [[Feature - Strategy Studio]] — planning workspace
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - AI as Teammates]] — teammates remember
+- Principle: [[Principle - Compound Capability]] — history creates value
+- Driver: Directors need to learn from experience. The Archives preserve that experience and surface its lessons.
+
+## WHEN: Timeline
+
+Core workspace, developing as historical data accumulates. Archives become more valuable over time.
+
+## HOW: Implementation
+
+**Contents:**
+
+- Completed projects (searchable, browsable)
+- Uprooted systems (with uprooting reason)
+- Historical Charter versions
+- Performance data (estimates vs. actuals)
+- Pattern analysis
+
+**Conan's role:**
+
+- Maintain archive organization
+- Create summaries for agent consumption
+- Identify patterns across history
+- Surface relevant history during planning
+
+**Proactive surfacing:** Conan notices when current work resembles past work and surfaces relevant history — during planning, when stuck, during reflection.
+
+**Search and browse:** Directors can explore their history directly, not just through Conan's surfacing.

--- a/context-library/product/features/Feature - Bronze Operations.md
+++ b/context-library/product/features/Feature - Bronze Operations.md
@@ -1,0 +1,62 @@
+# Feature - Bronze Operations
+
+## WHAT: Definition
+
+The complete operational workflow for managing Bronze tasks — from mode selection through task completion, including mid-week adjustments, auto-population behavior, and stack management. Bronze Operations governs everything about the maintenance stream.
+
+## WHERE: Ecosystem
+
+- Displayed in: [[The Table - Bronze Position]] — stack display
+- Configured in: [[Feature - Sorting Room]] — mode selection
+- Agent: [[Agent - Cameron]] — guides mode decisions
+- Implements: [[System - Three-Stream Portfolio]] — Bronze stream mechanics
+- Implements: [[Principle - Protect Transformation]] — Bronze contained
+- Sources: [[Feature - Project]] (maintenance), [[Feature - System]] (generated), [[Task - Bronze Stack]]
+
+## WHY: Rationale
+
+- System: [[System - Three-Stream Portfolio]] — Bronze has unique mechanics
+- Principle: [[Principle - Protect Transformation]] — Bronze must stay in its lane
+- Driver: Operational work is different from transformational work. Bronze Operations manages that difference.
+
+## WHEN: Timeline
+
+Core operational feature. Bronze mechanics refined based on user capacity patterns.
+
+## HOW: Implementation
+
+**Mode options:**
+
+| Mode      | Stack Behavior                                        | Best For              |
+| --------- | ----------------------------------------------------- | --------------------- |
+| Minimal   | Required only (due dates, critical, system-generated) | High-commitment weeks |
+| Target +X | Minimal + X discretionary, auto-replenish             | Normal weeks          |
+| Maximal   | Continuous pull until queue empty                     | Catch-up weeks        |
+
+**Mode selection:**
+
+- Initial selection during Weekly Planning
+- Can change mid-week via gear icon on Bronze position
+- Mode change takes effect immediately
+
+**Auto-replenishment (Target/Maximal):**
+
+- Task completes → next task surfaces
+- Order determined by Bronze priority scoring
+- Continues until stack hits target or queue empties
+
+**Stack sources (priority order):**
+
+1. Due-date items (deadline approaching)
+2. Critical Responses (urgent flags)
+3. System-generated tasks (from planted systems)
+4. Quick Task project tasks
+5. Decomposed tasks from larger projects
+
+**Completion flow:**
+
+- Check off task → task marked complete
+- Stack updates per mode rules
+- Progress visible on Bronze position
+
+**Never blocks Gold/Silver:** Even with 100 Bronze tasks queued, directors still have independent Gold and Silver slots. Bronze doesn't steal capacity from transformation.

--- a/context-library/product/features/Feature - Category Studios.md
+++ b/context-library/product/features/Feature - Category Studios.md
@@ -1,0 +1,46 @@
+# Feature - Category Studios
+
+## WHAT: Definition
+
+Eight specialized rooms in the Strategy Studio, one for each Life Category — where directors engage in domain-specific strategic planning with their Category Advisor. Each studio focuses on one area of life: Health, Purpose, Finances, Relationships, Home, Community, Leisure, Personal Growth.
+
+## WHERE: Ecosystem
+
+- Parent: [[Feature - Strategy Studio]]
+- Agents: [[Agent - Maya]] (Health), [[Agent - Atlas]] (Purpose), [[Agent - Brooks]] (Finances), [[Agent - Grace]] (Relationships), [[Agent - Reed]] (Home), [[Agent - Finn]] (Community), [[Agent - Indie]] (Leisure), [[Agent - Sage]] (Personal Growth)
+- Implements: [[Strategy - AI as Teammates]] — domain specialists
+- Implements: [[System - Knowledge Framework]] — category-specific knowledge
+- Related: [[Feature - Project Board]] — in-context advisor access
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - AI as Teammates]] — specialized advisors for specialized domains
+- Principle: [[Principle - Compound Capability]] — advisors learn director's domain context over time
+- Driver: Life categories have different challenges requiring different expertise. Category Studios provide focused strategic support.
+
+## WHEN: Timeline
+
+Core to Strategy Studio design. Individual advisor personalities develop as system matures.
+
+## HOW: Implementation
+
+**Eight rooms:**
+
+1. Health & Well-Being Studio (Maya)
+2. Purpose & Spirituality Studio (Atlas)
+3. Financial Resources Studio (Brooks)
+4. Relationships Studio (Grace)
+5. Home & Environment Studio (Reed)
+6. Community & Contributions Studio (Finn)
+7. Leisure & Lifestyle Studio (Indie)
+8. Personal Growth & Learning Studio (Sage)
+
+**Per-studio contents:**
+
+- Conversation thread with category advisor
+- Category-level overview (projects, systems in this category)
+- Strategic notes and decisions
+
+**Dual access:** Directors reach advisors here OR in-context on Project Boards. History syncs regardless of where conversation originated.
+
+**Customization note:** If director renames/replaces default categories, associated studio pauses until system evolves to support custom coverage.

--- a/context-library/product/features/Feature - Council Chamber.md
+++ b/context-library/product/features/Feature - Council Chamber.md
@@ -1,0 +1,38 @@
+# Feature - Council Chamber
+
+## WHAT: Definition
+
+Jarvis's dedicated space in the Strategy Studio — where directors engage in high-level strategic conversation, conduct weekly reviews, maintain their Charter, and discuss life direction. The Council Chamber is the heart of the human-AI strategic partnership.
+
+## WHERE: Ecosystem
+
+- Parent: [[Feature - Strategy Studio]]
+- Agent: [[Agent - Jarvis]] — primary occupant
+- Maintains: [[Feature - The Charter]] — living strategic document
+- Uses: [[Feature - The Agenda]] — session structure
+- Implements: [[Strategy - AI as Teammates]] — deepest advisor relationship
+- Implements: [[Principle - Earn Don't Interrogate]] — Jarvis elicits, never interrogates
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - AI as Teammates]] — Jarvis is the primary AI relationship
+- Principle: [[Principle - Plans Are Hypotheses]] — strategic conversations hold plans lightly
+- Driver: Directors need a thinking partner who knows their whole picture. The Council Chamber hosts that partnership.
+
+## WHEN: Timeline
+
+Core to Strategy Studio design. Council Chamber is where the Jarvis relationship lives.
+
+## HOW: Implementation
+
+**Session types:**
+
+- Weekly check-in — review past week, frame upcoming week
+- Quarterly review — deeper Charter work, theme adjustment
+- Ad-hoc strategic — major decisions, life changes
+
+**The Agenda:** Each session follows an agenda (customizable). Jarvis guides through it, captures notes, updates Charter.
+
+**The Charter:** Living document maintained here — director's values, themes, priorities, constraints. Jarvis references it and proposes updates.
+
+**Conversation continuity:** History preserved. Jarvis remembers past discussions, references them, tracks how thinking evolves.

--- a/context-library/product/features/Feature - Drafting Room.md
+++ b/context-library/product/features/Feature - Drafting Room.md
@@ -1,0 +1,49 @@
+# Feature - Drafting Room
+
+## WHAT: Definition
+
+Marvin's dedicated space — where directors create new projects, guided through the four-stage creation process. The Drafting Room is where ideas become executable plans.
+
+## WHERE: Ecosystem
+
+- Zone: Support space (creation focus)
+- Agent: [[Agent - Marvin]] — operational manager
+- Implements: [[System - Four-Stage Creation]] — guided process
+- Implements: [[Strategy - Superior Process]] — structured project development
+- Implements: [[Principle - Earn Don't Interrogate]] — progressive capture
+- Creates: [[Feature - Project]] — output of drafting process
+- Configures: [[Feature - System]] — for system-building Silver projects
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Superior Process]] — creation deserves structure
+- Principle: [[Principle - Earn Don't Interrogate]] — Marvin guides without blocking
+- Driver: Directors need help turning ideas into actionable projects. The Drafting Room provides that translation.
+
+## WHEN: Timeline
+
+Core support space. Drafting Room process refined as four-stage creation matured.
+
+## HOW: Implementation
+
+**Four-stage flow:**
+
+1. **Identify** — capture basics (title, description, category)
+2. **Scope** — define purpose, objectives, priority attributes
+3. **Draft** — create tasks or configure system
+4. **Prioritize** — place in Priority Queue
+
+**Marvin's role:**
+
+- Guide through stages
+- Suggest task decomposition
+- Ask purpose question (Gold/Silver/Bronze classification)
+- Configure systems for system-building projects
+
+**Entry points:**
+
+- "Create project" from anywhere
+- Quick capture (Stage 1 only, return later)
+- Triggered by life event or advisor suggestion
+
+**Output:** Completed project in Planning state, ready for Priority Queue.

--- a/context-library/product/features/Feature - Elicitation.md
+++ b/context-library/product/features/Feature - Elicitation.md
@@ -1,0 +1,71 @@
+# Feature - Elicitation
+
+## WHAT: Definition
+
+The knowledge acquisition strategies agents use to learn about directors — the techniques for gathering information through natural conversation rather than interrogation. Elicitation is how the AI team earns knowledge progressively instead of demanding it upfront.
+
+## WHERE: Ecosystem
+
+- Used by: All agents, especially [[Agent - Jarvis]], [[Agent - Mesa]]
+- Implements: [[Principle - Earn Don't Interrogate]] — the core elicitation principle
+- Implements: [[Strategy - AI as Teammates]] — teammates learn organically
+- Feeds: [[System - Knowledge Framework]] — where learned knowledge lives
+- Feeds: [[Feature - The Charter]] — elicited values captured here
+
+## WHY: Rationale
+
+- Principle: [[Principle - Earn Don't Interrogate]] — elicitation is the how of this principle
+- Strategy: [[Strategy - AI as Teammates]] — teammates learn over time, not via forms
+- Driver: Upfront questionnaires create friction and capture stale data. Elicitation captures living, contextual knowledge through natural interaction.
+
+## WHEN: Timeline
+
+Core to agent design. Elicitation techniques refined as agent conversations mature.
+
+## HOW: Implementation
+
+**Elicitation techniques:**
+
+| Technique                    | Example                                            | Use Case           |
+| ---------------------------- | -------------------------------------------------- | ------------------ |
+| **Observe-and-note**         | Director completes Gold → note preference patterns | Background capture |
+| **Conversational inference** | "Sounds like family time is important"             | Strategic sessions |
+| **Gentle calibration**       | "Is this harder than it looks?"                    | Task estimation    |
+| **Reflection prompt**        | "What made that project satisfying?"               | Week-in-Review     |
+| **Choice observation**       | Track what gets selected vs. deferred              | Priority patterns  |
+
+**What gets elicited:**
+
+- Values and priorities
+- Capacity patterns
+- Preference patterns
+- Relationship context
+- Domain knowledge
+- Historical patterns
+
+**Elicitation moments:**
+
+- During onboarding (First 72 Hours)
+- During strategic conversations (Council Chamber)
+- During project creation (Drafting Room)
+- During planning and review (Weekly rhythm)
+- Passively through usage patterns
+
+**Knowledge persistence:**
+
+- Elicited knowledge feeds Knowledge Framework
+- Strategic knowledge captured in Charter
+- Patterns tracked by Conan in Archives
+
+**Never interrogate:**
+
+- No upfront questionnaires
+- No mandatory profile completion
+- No blocking on information capture
+- Learn through doing, not asking
+
+**Explicit vs. implicit:**
+
+- Some knowledge stated directly ("family is priority")
+- Some knowledge inferred from behavior (always pauses projects in December)
+- Both are valid; inferred requires higher confidence threshold

--- a/context-library/product/features/Feature - First 72 Hours.md
+++ b/context-library/product/features/Feature - First 72 Hours.md
@@ -1,0 +1,63 @@
+# Feature - First 72 Hours
+
+## WHAT: Definition
+
+The guided onboarding experience for new directors — a structured three-day journey that establishes the spatial metaphor, introduces the agent team, captures initial life context, and creates the first projects. The First 72 Hours transform an empty canvas into a living Life Map.
+
+## WHERE: Ecosystem
+
+- Zone: Spans all workspaces — onboarding touches everything
+- Implements: [[Principle - First 72 Hours]] — the design principle made concrete
+- Implements: [[Principle - Earn Don't Interrogate]] — progressive capture, not upfront forms
+- Implements: [[Strategy - AI as Teammates]] — agents introduce themselves
+- Agents: [[Agent - Mesa]] (first contact), [[Agent - Jarvis]] (Charter creation)
+- Starts at: [[Hex Grid - Campfire]] — the warm origin point
+- Creates: [[Feature - The Charter]] — initial version during onboarding
+- Feeds: [[System - Service Levels]] — Level 0 to Level 1 progression
+
+## WHY: Rationale
+
+- Principle: [[Principle - First 72 Hours]] — first impression shapes entire relationship
+- Principle: [[Principle - Earn Don't Interrogate]] — capture through doing, not interrogating
+- Strategy: [[Strategy - Spatial Visibility]] — spatial metaphor established immediately
+- Driver: New users abandon tools that feel overwhelming or empty. The First 72 Hours creates momentum and understanding simultaneously.
+
+## WHEN: Timeline
+
+Core onboarding design. The 72-hour structure evolved from testing — long enough to establish habits, short enough to feel achievable.
+
+## HOW: Implementation
+
+**Day 1: Welcome & Orient**
+
+- Mesa greets director at Campfire
+- Tour of Life Map spatial metaphor
+- First project created (low stakes, quick win)
+- Hex tile placed near Campfire
+
+**Day 2: Meet the Team**
+
+- Jarvis introduction in Council Chamber
+- Initial Charter conversation (values, current focus)
+- Second project created with Marvin in Drafting Room
+- Category Advisor introduction (one relevant to first projects)
+
+**Day 3: Establish Rhythm**
+
+- First Sorting Room visit with Cameron
+- Work at Hand selection (even if only 1-2 items)
+- The Table populated
+- Weekly rhythm explained
+
+**Progressive disclosure:**
+
+- Features unlock as relevant (not everything at once)
+- Agents appear when their function matters
+- Complexity revealed through action, not explanation
+
+**Tone throughout:**
+
+- Warm, patient, encouraging
+- Celebrates small wins
+- Never rushes or overwhelms
+- "You can explore more later"

--- a/context-library/product/features/Feature - Hex Grid.md
+++ b/context-library/product/features/Feature - Hex Grid.md
@@ -1,0 +1,55 @@
+# Feature - Hex Grid
+
+## WHAT: Definition
+
+The spatial organization canvas that fills most of the Life Map — a tessellated field of hexagonal tiles where each tile represents a project or system. Directors arrange tiles spatially by category and relationship, creating a visual map of their life's work.
+
+## WHERE: Ecosystem
+
+- Parent: [[Feature - Life Map]]
+- Implements: [[Strategy - Spatial Visibility]] — work has spatial position
+- Implements: [[System - Bidirectional Loop]] — arrangement reflects and shapes understanding
+- Implements: [[Principle - Visual Recognition]] — spatial memory for navigation
+- Contains: [[Hex Grid - Hex Tile]] — individual project/system representations
+- Uses: [[System - Visual Language]] — colors, states, indicators
+- Uses: [[Feature - Zoom Navigation]] — scale changes what's visible
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Spatial Visibility]] — hexagons are the spatial unit
+- Principle: [[Principle - Visual Recognition]] — "my health stuff is upper-left" becomes automatic
+- Principle: [[Principle - Familiarity Over Function]] — spatial metaphor feels natural
+- Decision: Hexagons (not squares) because they tessellate without privileged axes. Every hex has six equal neighbors — no "up is better than sideways" bias.
+
+## WHEN: Timeline
+
+Core to Life Map design. The hex grid is the foundational spatial metaphor for LifeBuild.
+
+## HOW: Implementation
+
+**Grid behavior:**
+
+- Infinite canvas (extends as needed)
+- Directors drag tiles to arrange
+- Adjacent tiles form visual clusters (categories)
+- Empty hexes between clusters create breathing room
+
+**Tile types:**
+
+- Project tiles — bounded work with finish lines
+- System tiles — continuous infrastructure
+
+**Visual treatments:**
+
+- Category colors on tile borders
+- Stream accents for Work at Hand
+- State treatments (Planning: sketch style, Live: full color, etc.)
+- Health indicators for systems
+
+**Zoom interaction:**
+
+- Zoomed out: see entire landscape, tiles as icons
+- Zoomed in: see detail, tile contents readable
+- Semantic zoom: detail increases with magnification
+
+**Arrangement freedom:** No forced grid positions. Directors place tiles wherever makes sense to them. The system learns from arrangement over time.

--- a/context-library/product/features/Feature - Kanban Board.md
+++ b/context-library/product/features/Feature - Kanban Board.md
@@ -1,0 +1,61 @@
+# Feature - Kanban Board
+
+## WHAT: Definition
+
+The task flow interface within a Project Board — a visual representation of task states showing what's pending, in progress, and complete. The Kanban Board provides at-a-glance project execution status and enables drag-and-drop task management.
+
+## WHERE: Ecosystem
+
+- Parent: [[Feature - Project Board]] — embedded within project detail
+- Displays: [[Feature - Task]] — task cards in columns
+- Implements: [[Strategy - Spatial Visibility]] — progress has spatial form
+- Implements: [[Principle - Visual Recognition]] — task state instantly visible
+- Related: [[Task - Bronze Stack]] — Bronze tasks may show here
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Spatial Visibility]] — work flow should be visible
+- Principle: [[Principle - Visual Recognition]] — familiar pattern for task management
+- Principle: [[Principle - Familiarity Over Function]] — Kanban is widely understood
+- Driver: Directors need to see and manage task flow within projects. Kanban provides that at-a-glance view.
+
+## WHEN: Timeline
+
+Core to Project Board design. Kanban familiar pattern chosen for immediate usability.
+
+## HOW: Implementation
+
+**Columns:**
+
+- **To Do** — Tasks not yet started
+- **In Progress** — Active tasks (limit: 1-3 recommended)
+- **Done** — Completed tasks
+
+**Task cards show:**
+
+- Task title
+- Estimated effort (if set)
+- Due date (if set)
+- Delegated indicator (if assigned)
+- Quick actions
+
+**Interactions:**
+
+- Drag between columns
+- Click to expand task detail
+- Check to mark complete
+- Add new task inline
+
+**Constraints:**
+
+- In Progress WIP limit (optional, director-configurable)
+- Done column collapsible
+- Order within columns customizable
+
+**Bronze integration:**
+
+- Bronze tasks from this project appear here
+- Completing here updates Bronze stack
+- Task source indicator (project vs. system-generated)
+
+**Not mandatory:** Simple projects may skip Kanban and use checklist view instead.

--- a/context-library/product/features/Feature - Life Map.md
+++ b/context-library/product/features/Feature - Life Map.md
@@ -1,0 +1,54 @@
+# Feature - Life Map
+
+## WHAT: Definition
+
+The primary execution workspace — a spatial canvas where directors see their entire life organized as a hex grid of projects and systems. The Life Map is where work happens: viewing priorities, tracking progress, and managing the landscape of commitments.
+
+## WHERE: Ecosystem
+
+- Zone: Primary workspace (execution focus)
+- Implements: [[Strategy - Spatial Visibility]] — work exists in space
+- Implements: [[System - Dual Presence]] — Work at Hand appears on both Table and grid
+- Implements: [[Principle - Visibility Creates Agency]] — everything visible at once
+- Contains: [[Feature - The Table]] — persistent priority display
+- Contains: [[Feature - Hex Grid]] — spatial organization canvas
+- Contains: [[Feature - Zoom Navigation]] — scale traversal
+- Opens: [[Feature - Project Board]] — detail overlay for any project
+- Agent: [[Agent - Mesa]] — Life Map advisor
+- Sibling: [[Feature - Strategy Studio]] — planning workspace
+- Sibling: [[Feature - Archives]] — learning workspace
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Spatial Visibility]] — Life Map is the primary embodiment of spatial thinking
+- Principle: [[Principle - Visibility Creates Agency]] — directors see everything, decide what to focus on
+- Principle: [[Principle - Visual Recognition]] — spatial memory aids finding and understanding
+- Driver: Directors need a home base where all their work is visible and organized. The Life Map is that home.
+
+## WHEN: Timeline
+
+Core workspace from initial design. The Life Map is LifeBuild's primary interface — where directors spend most of their time.
+
+## HOW: Implementation
+
+**Layout:**
+
+- The Table (top) — persistent Work at Hand display
+- Hex Grid (below) — spatial canvas of all projects and systems
+- Navigation controls — zoom, pan, search
+
+**What appears here:**
+
+- All projects (any state except Completed)
+- All systems (Active or Hibernating)
+- Category organization via hex positioning
+- Health indicators, state treatments, visual language
+
+**Primary workflows:**
+
+- Review current priorities (The Table)
+- Browse life landscape (Hex Grid)
+- Dive into specific work (Project Board overlay)
+- Get help (summon Mesa)
+
+**Entry point:** Life Map is the default view when directors open LifeBuild.

--- a/context-library/product/features/Feature - Mid-Week Adaptation.md
+++ b/context-library/product/features/Feature - Mid-Week Adaptation.md
@@ -1,0 +1,58 @@
+# Feature - Mid-Week Adaptation
+
+## WHAT: Definition
+
+The mechanics for modifying Work at Hand during a week — pausing current projects, promoting replacements, changing Bronze mode, or responding to emergencies. Mid-Week Adaptation allows plans to flex without abandoning structure.
+
+## WHERE: Ecosystem
+
+- Modifies: [[Feature - Work at Hand]] — changes current commitment
+- Accessible via: [[Feature - The Table]] — position interactions
+- Accessible via: [[Feature - Project Board]] — pause action
+- Agent: [[Agent - Marvin]] — supports transitions
+- Implements: [[Principle - Plans Are Hypotheses]] — adaptation is expected
+- Returns to: [[System - Priority Queue Architecture]] — paused items go here
+
+## WHY: Rationale
+
+- Principle: [[Principle - Plans Are Hypotheses]] — plans change; that's leadership
+- Strategy: [[Strategy - Superior Process]] — structured adaptation, not chaos
+- Driver: Life doesn't wait for Friday planning. Directors need to adapt mid-week without guilt or friction.
+
+## WHEN: Timeline
+
+Core operational feature. Adaptation mechanics designed to feel supportive, not punitive.
+
+## HOW: Implementation
+
+**Pause mechanics:**
+
+- Any Work at Hand project can be paused mid-week
+- Paused project returns to Priority Queue (top position)
+- Slot opens for replacement or intentional empty
+
+**Replacement options:**
+
+1. **Promote from queue:** Select different project from candidates
+2. **Create emergency:** New project jumps to Work at Hand
+3. **Leave empty:** Intentional empty for remainder of week
+
+**Bronze mode changes:**
+
+- Gear icon on Bronze position
+- Mode change takes effect immediately
+- Stack adjusts to new mode rules
+
+**Emergency projects:**
+
+- Created via Drafting Room with "urgent" flag
+- Skip normal queue positioning
+- Can go directly to Work at Hand
+
+**Tone throughout:**
+
+- Never "you failed to complete"
+- Always "circumstances changed"
+- Adaptation framed as responsive leadership
+
+**Jarvis awareness:** Jarvis notes mid-week changes for Week-in-Review discussion. Patterns of frequent adaptation may surface.

--- a/context-library/product/features/Feature - Planning Queue.md
+++ b/context-library/product/features/Feature - Planning Queue.md
@@ -1,0 +1,51 @@
+# Feature - Planning Queue
+
+## WHAT: Definition
+
+The collection of projects still in development — work that has been identified but not yet placed in the Priority Queue. The Planning Queue holds projects in stages 1-3 of the four-stage creation process.
+
+## WHERE: Ecosystem
+
+- Zone: [[Feature - Strategy Studio]] — visible during planning
+- Implements: [[System - Pipeline Architecture]] — first half of pipeline
+- Implements: [[System - Four-Stage Creation]] — stages 1-3 live here
+- Fed by: [[Feature - Drafting Room]] — where projects are created
+- Flows to: [[System - Priority Queue Architecture]] — on Stage 4 completion
+- Shows: [[Project - States]] — Planning state projects
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Superior Process]] — development distinct from prioritization
+- Principle: [[Principle - Earn Don't Interrogate]] — projects can be incomplete
+- Driver: Not all projects are ready for prioritization. The Planning Queue holds work-in-progress until it's ready.
+
+## WHEN: Timeline
+
+Core to pipeline architecture. Planning Queue distinguishes "in development" from "ready to prioritize."
+
+## HOW: Implementation
+
+**Contents:**
+
+- Projects in Identified state (Stage 1)
+- Projects in Scoped state (Stage 2)
+- Projects in Drafted state (Stage 3)
+
+**Not shown:**
+
+- Projects in Prioritized state (Stage 4) — those are in Priority Queue
+- Projects in Planning state on Life Map — same projects, different view
+
+**Visibility:**
+
+- Accessible from Strategy Studio
+- Shows development stage for each project
+- Click to open in Drafting Room for continued development
+
+**Flow:**
+
+- New project enters Planning Queue in Identified state
+- Progresses through stages via Drafting Room
+- Completes Stage 4 → moves to Priority Queue
+
+**Marvin integration:** Marvin can surface Planning Queue items that have stalled ("this has been in Scoped for three weeks").

--- a/context-library/product/features/Feature - Project Board.md
+++ b/context-library/product/features/Feature - Project Board.md
@@ -1,0 +1,56 @@
+# Feature - Project Board
+
+## WHAT: Definition
+
+The detail overlay that opens when a director clicks any project tile — a focused view showing everything about a single project: description, objectives, tasks, progress, history, and available actions. The Project Board is where detailed work happens.
+
+## WHERE: Ecosystem
+
+- Parent: [[Feature - Life Map]] — opens as overlay
+- Displays: [[Feature - Project]] — all project details
+- Displays: [[Feature - Task]] — task list within project
+- Agent: [[Agent - Category Advisor (Concept)]] — in-context consultation available
+- Uses: [[Project - States]] — shows current state, enables transitions
+- Uses: [[Project - Image Evolution]] — shows current Urushi stage
+- Enables: Task completion, objective tracking, project pausing
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Superior Process]] — detailed work needs detailed view
+- Principle: [[Principle - Familiarity Over Function]] — board metaphor feels natural for project management
+- Driver: Directors need to work on projects, not just see them. The Project Board is the workspace within the workspace.
+
+## WHEN: Timeline
+
+Core to Life Map design. Project Board is where most execution work happens.
+
+## HOW: Implementation
+
+**Contents:**
+
+- Header: Title, Urushi image, state indicator, category
+- Description: What this project is
+- Objectives: What success looks like
+- Tasks: The work to be done (checkable)
+- Progress: Completion status, time tracking
+- History: Recent activity, state transitions
+- Actions: Pause, complete, add task, edit
+
+**Overlay behavior:**
+
+- Opens over Life Map (grid visible behind, dimmed)
+- Close to return to grid
+- Can navigate directly to other Project Boards
+
+**Category Advisor access:**
+
+- Subtle indicator when advisor available
+- Click to open in-context consultation
+- Conversation logs to advisor's Strategy Studio thread
+
+**Task management:**
+
+- Add tasks
+- Check off completed
+- Reorder
+- Delegate (opens Roster Room context)

--- a/context-library/product/features/Feature - Project.md
+++ b/context-library/product/features/Feature - Project.md
@@ -1,0 +1,50 @@
+# Feature - Project
+
+## WHAT: Definition
+
+A discrete initiative with a finish line — bounded work that completes and moves to Archives. Projects range from small (scheduling a dentist appointment) to transformative (career transition planning). Every project has objectives, tasks, and moves through states toward completion.
+
+## WHERE: Ecosystem
+
+- Zone: Cross-zone — projects live on [[Feature - Life Map]], created in [[Feature - Drafting Room]]
+- Implements: [[System - Three-Stream Portfolio]] — every project has a Purpose determining stream
+- Implements: [[System - Four-Stage Creation]] — projects develop through four stages
+- Implements: [[System - Pipeline Architecture]] — projects flow through queues
+- Depends on: [[Feature - Task]] — projects contain tasks
+- Governs: [[Feature - Project Board]] — execution interface for projects
+- Governs: [[Feature - Kanban Board]] — task flow within projects
+- Components: [[Project - States]], [[Project - Purpose Assignment]], [[Project - Image Evolution]]
+- Contrast: [[Feature - System]] — systems are continuous, projects are bounded
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Superior Process]] — structured work management
+- Strategy: [[Strategy - Spatial Visibility]] — projects have spatial presence on hex grid
+- Principle: [[Principle - Plans Are Hypotheses]] — project plans can adapt
+- Driver: Directors need bounded containers for work with finish lines. The question for projects is always: "How close am I to finished?"
+
+## WHEN: Timeline
+
+Core entity from initial design. Projects are one of two initiative types (alongside Systems) that occupy hex tiles on the Life Map.
+
+## HOW: Implementation
+
+**Defining characteristic:** Projects are bounded. They have a beginning and an end. Success means completion. When a project completes, it moves to Archives.
+
+**Required properties:**
+
+- Life Category (one of eight)
+- Purpose (determines stream: Gold/Silver/Bronze)
+- Objectives (what success looks like)
+- Tasks (specific actions)
+- Priority attributes (Urgency, Importance, Effort, Deadline)
+
+**Project lifecycle:**
+
+```
+Identified → Scoped → Drafted → Prioritized → Live → Work at Hand → Completed
+```
+
+**Visual representation:** Hex tile with Urushi image, progress ring, category color accent, state indicators. Image evolves through five stages as project progresses.
+
+**Projects that create Systems:** Silver projects marked as "system-building" plant a new System on completion. The project archives; the system persists.

--- a/context-library/product/features/Feature - Roster Room.md
+++ b/context-library/product/features/Feature - Roster Room.md
@@ -1,0 +1,48 @@
+# Feature - Roster Room
+
+## WHAT: Definition
+
+Devin's dedicated space — where directors assign AI Workers to delegatable tasks, configure human delegation relationships, and optimize team composition for the week's work.
+
+## WHERE: Ecosystem
+
+- Zone: Support space (delegation focus)
+- Agent: [[Agent - Devin]] — delegation specialist
+- Implements: [[Strategy - AI as Teammates]] — team coordination
+- Implements: [[Principle - Compound Capability]] — delegation patterns improve
+- Assigns: Workers — AI agents for task execution
+- Configures: Human delegation — family, colleagues, contractors
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - AI as Teammates]] — directors have a team
+- Principle: [[Principle - Compound Capability]] — team effectiveness compounds over time
+- Driver: Directors shouldn't do everything alone. The Roster Room is where delegation happens.
+
+## WHEN: Timeline
+
+Support space developing as Worker architecture matures. Delegation patterns are a growth area.
+
+## HOW: Implementation
+
+**Worker assignment:**
+
+- View available AI Workers
+- Match Workers to delegatable tasks
+- Set expectations and check-in points
+- Review Worker performance history
+
+**Human delegation:**
+
+- Configure recurring delegation relationships
+- Track who does what
+- Set accountability and follow-up
+
+**Devin's role:**
+
+- Recommend Worker matches
+- Surface delegation opportunities
+- Track delegation patterns
+- Improve recommendations over time
+
+**Output:** Tasks assigned to Workers or humans, with accountability configured.

--- a/context-library/product/features/Feature - Service Level Progression.md
+++ b/context-library/product/features/Feature - Service Level Progression.md
@@ -1,0 +1,52 @@
+# Feature - Service Level Progression
+
+## WHAT: Definition
+
+The visible progression system that tracks and displays a director's journey through Service Levels 0-5 — showing current level, progress toward next level, and unlocked capabilities. Service Level Progression motivates continued engagement by making growth visible.
+
+## WHERE: Ecosystem
+
+- Implements: [[System - Service Levels]] — UI for the progression system
+- Implements: [[Principle - Compound Capability]] — visible compounding
+- Implements: [[Strategy - AI as Teammates]] — agents improve with levels
+- Visible in: [[Feature - Council Chamber]] — Jarvis discusses progression
+- Tracked by: [[Agent - Conan]] — historical data feeds level calculation
+
+## WHY: Rationale
+
+- System: [[System - Service Levels]] — levels need visibility to motivate
+- Principle: [[Principle - Compound Capability]] — seeing progress reinforces investment
+- Driver: Directors should see their relationship with LifeBuild deepening. Progression makes the invisible visible.
+
+## WHEN: Timeline
+
+Supporting feature. Progression display develops as Service Level mechanics mature.
+
+## HOW: Implementation
+
+**Display elements:**
+
+- Current level (0-5)
+- Level name and description
+- Progress indicator toward next level
+- Recent milestones achieved
+- Capabilities unlocked at current level
+
+**Level summaries:**
+
+| Level | Name         | Threshold                |
+| ----- | ------------ | ------------------------ |
+| 0     | Newcomer     | New account              |
+| 1     | Establishing | First week complete      |
+| 2     | Building     | Consistent weekly rhythm |
+| 3     | Developing   | Patterns emerging        |
+| 4     | Maturing     | Strong historical data   |
+| 5     | Flourishing  | Deep partnership         |
+
+**Agent quality indicators:**
+
+- Higher levels = better agent recommendations
+- Jarvis notes: "With more history, I can see patterns..."
+- Visible connection between engagement and service quality
+
+**Not gamification:** Levels reflect genuine capability growth, not arbitrary points. No badges, no leaderboards — just honest representation of system capability.

--- a/context-library/product/features/Feature - Smoke Signals.md
+++ b/context-library/product/features/Feature - Smoke Signals.md
@@ -1,0 +1,54 @@
+# Feature - Smoke Signals
+
+## WHAT: Definition
+
+The ambient notification system that alerts directors to items needing attention without interrupting flow — visual indicators on the Life Map that signal system health issues, approaching deadlines, stalled projects, or pattern concerns. Smoke Signals inform without demanding.
+
+## WHERE: Ecosystem
+
+- Zone: [[Feature - Life Map]] — signals visible on grid
+- Implements: [[Principle - Visibility Creates Agency]] — awareness without interruption
+- Implements: [[Principle - Guide When Helpful]] — signals, not alarms
+- Sources: [[Feature - System]] (health), [[Feature - Project]] (staleness), [[System - Priority Queue Architecture]] (due dates)
+- Displayed on: [[Hex Grid - Hex Tile]] — visual treatment
+- Monitored by: [[Agent - Mesa]] — can explain signals
+
+## WHY: Rationale
+
+- Principle: [[Principle - Visibility Creates Agency]] — directors should see problems early
+- Principle: [[Principle - Guide When Helpful]] — helpful signals, not nagging alerts
+- Driver: Directors need to know when something needs attention without being bombarded with notifications. Smoke Signals are visible but not intrusive.
+
+## WHEN: Timeline
+
+Supporting feature. Smoke Signal sensitivity refined based on director preferences and feedback.
+
+## HOW: Implementation
+
+**Signal types:**
+
+| Signal          | Source                          | Visual               |
+| --------------- | ------------------------------- | -------------------- |
+| Health warning  | System health declining         | Yellow/red tile tint |
+| Staleness       | Project untouched for threshold | Dust/fade effect     |
+| Due date        | Approaching deadline            | Calendar indicator   |
+| Pattern concern | Repeated slippage               | Subtle pulse         |
+
+**Visibility rules:**
+
+- Signals visible at Working View and closer
+- Horizon View shows aggregate (cluster has signals)
+- Signals don't block interaction
+- Directors can dismiss or snooze
+
+**Agent awareness:**
+
+- Mesa can explain any signal
+- "That yellow tint means your workout system has missed three cycles"
+- Agents may reference signals in conversations
+
+**Not notifications:**
+
+- Smoke Signals are visual states, not push alerts
+- No sounds, no badges, no interruptions
+- Directors see them when they look at Life Map

--- a/context-library/product/features/Feature - Sorting Room.md
+++ b/context-library/product/features/Feature - Sorting Room.md
@@ -1,0 +1,49 @@
+# Feature - Sorting Room
+
+## WHAT: Definition
+
+Cameron's dedicated space in the Strategy Studio — where directors make prioritization decisions, select Work at Hand for the week, and review their Priority Queue. The Sorting Room is where the three-stream selection process happens.
+
+## WHERE: Ecosystem
+
+- Parent: [[Feature - Strategy Studio]]
+- Agent: [[Agent - Cameron]] — priority coordinator
+- Uses: [[System - Priority Queue Architecture]] — source of candidates
+- Uses: [[System - Priority Score Calculation]] — ranking logic
+- Uses: [[Feature - Three-Stream Filtering]] — filtered views
+- Selects: [[Feature - The Table]] positions — Gold, Silver, Bronze mode
+- Implements: [[Strategy - Superior Process]] — structured prioritization
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Superior Process]] — prioritization deserves its own space
+- Principle: [[Principle - Familiarity Over Function]] — sorting metaphor is intuitive
+- Principle: [[Principle - Protect Transformation]] — selection process enforces stream constraints
+- Driver: Directors need help seeing options and making choices. The Sorting Room presents candidates and guides selection.
+
+## WHEN: Timeline
+
+Core to Strategy Studio design. Sorting Room mechanics refined as priority math evolved.
+
+## HOW: Implementation
+
+**Selection flow:**
+
+1. Gold selection — view expansion candidates, choose one (or confirm empty)
+2. Silver selection — view capacity candidates, choose one (or confirm empty)
+3. Bronze review — set mode, review what will populate stack
+
+**Cameron's role:**
+
+- Present filtered candidates with priority scores
+- Explain rankings and tradeoffs
+- Detect patterns ("this keeps slipping")
+- Ask calibrating questions
+
+**Filters:**
+
+- Gold filter: Purpose = "Moving forward"
+- Silver filter: Purpose = "Building leverage"
+- Bronze sources: Maintenance projects, system tasks, due-date items
+
+**Output:** Selections populate The Table. Director leaves Sorting Room with Work at Hand set.

--- a/context-library/product/features/Feature - Strategy Studio.md
+++ b/context-library/product/features/Feature - Strategy Studio.md
@@ -1,0 +1,48 @@
+# Feature - Strategy Studio
+
+## WHAT: Definition
+
+The planning workspace — a collection of specialized rooms where directors engage in strategic conversations with AI advisors, make prioritization decisions, and shape their approach to life's categories. The Strategy Studio is where thinking happens before execution.
+
+## WHERE: Ecosystem
+
+- Zone: Secondary workspace (planning focus)
+- Implements: [[Strategy - AI as Teammates]] — advisor conversations happen here
+- Contains: [[Feature - Council Chamber]] — strategic conversation with Jarvis
+- Contains: [[Feature - Category Studios]] — domain-specific planning (8 rooms)
+- Contains: [[Feature - Sorting Room]] — priority selection
+- Agent access: [[Agent - Jarvis]], [[Agent - Cameron]], all Category Advisors
+- Sibling: [[Feature - Life Map]] — execution workspace
+- Sibling: [[Feature - Archives]] — learning workspace
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - AI as Teammates]] — planning requires conversation partners
+- Strategy: [[Strategy - Superior Process]] — planning is distinct from execution
+- Principle: [[Principle - Guide When Helpful]] — advisors available when directors seek them
+- Driver: Directors need space to think strategically before committing to action. The Strategy Studio provides that space.
+
+## WHEN: Timeline
+
+Core workspace from initial design. Strategy Studio evolved as advisor architecture developed.
+
+## HOW: Implementation
+
+**Room structure:**
+
+- Council Chamber (1) — Jarvis's space for high-level strategic conversation
+- Category Studios (8) — one per Life Category, each with its advisor
+- Sorting Room (1) — Cameron's space for prioritization decisions
+
+**Navigation:**
+
+- Hub view showing all rooms
+- Click to enter any room
+- Room context persists (conversation history)
+
+**When to use:**
+
+- Weekly planning sessions
+- Category-level strategic reviews
+- Priority selection for Work at Hand
+- When directors want to think, not just do

--- a/context-library/product/features/Feature - System Board.md
+++ b/context-library/product/features/Feature - System Board.md
@@ -1,0 +1,50 @@
+# Feature - System Board
+
+## WHAT: Definition
+
+The detail overlay that opens when a director clicks any system tile — a focused view showing system health, configuration, generated tasks, cycle history, and available actions. The System Board is where directors monitor and manage their continuous infrastructure.
+
+## WHERE: Ecosystem
+
+- Parent: [[Feature - Life Map]] — opens as overlay
+- Displays: [[Feature - System]] — all system details
+- Displays: Generated tasks — what the system produces
+- Uses: [[System - Actions]] — Hibernate, Upgrade, Uproot available here
+- Uses: [[System - Visual Language]] — health indicators, state treatments
+- Agent: [[Agent - Category Advisor (Concept)]] — in-context consultation available
+- Parallel: [[Feature - Project Board]] — same pattern for projects
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Superior Process]] — systems need monitoring interface
+- Principle: [[Principle - Visibility Creates Agency]] — system health visible, not hidden
+- Driver: Directors need to see how their infrastructure is performing. The System Board answers "is this system healthy?"
+
+## WHEN: Timeline
+
+Core to Life Map design. System Board parallels Project Board for the other tool type.
+
+## HOW: Implementation
+
+**Contents:**
+
+- Header: Title, category, health indicator, state
+- Configuration: Pattern, frequency, controls
+- Generated Tasks: What this system produces for Bronze
+- Cycle History: Recent executions, completions, misses
+- Health Metrics: Cycle adherence, task completion rate
+- Actions: Hibernate, Upgrade, Uproot, Edit
+
+**Overlay behavior:**
+
+- Opens over Life Map (grid visible behind, dimmed)
+- Close to return to grid
+- Can navigate to related Project Boards
+
+**Health display:**
+
+- Green: Healthy — cycles completing, tasks done
+- Yellow: Attention — some misses, declining completion
+- Red: Struggling — frequent misses, system may need adjustment
+
+**Smoke Signals:** If system health degrades, [[Feature - Smoke Signals]] triggers alerts visible from Life Map.

--- a/context-library/product/features/Feature - System.md
+++ b/context-library/product/features/Feature - System.md
@@ -1,0 +1,53 @@
+# Feature - System
+
+## WHAT: Definition
+
+Planted infrastructure that generates work indefinitely. Unlike projects, systems have no finish line — they run until deliberately uprooted. Systems represent the director's automated, recurring commitments.
+
+## WHERE: Ecosystem
+
+- Zone: [[Feature - Life Map]] — systems occupy hex tiles
+- Implements: [[System - Three-Stream Portfolio]] — systems generate Bronze tasks
+- Implements: [[Principle - Compound Capability]] — systems compound leverage over time
+- Created by: [[Feature - Project]] — Silver projects plant systems on completion
+- Depends on: [[Feature - Task]] — systems generate tasks
+- Governs: [[Feature - System Board]] — monitoring interface for systems
+- Components: [[System - Actions]]
+- Contrast: [[Feature - Project]] — projects are bounded, systems are continuous
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Superior Process]] — infrastructure reduces future cognitive load
+- Principle: [[Principle - Compound Capability]] — planted systems make future weeks easier
+- Driver: Directors need containers for recurring work that runs itself. The question for systems is: "Is it running smoothly?"
+
+## WHEN: Timeline
+
+Core entity. Systems represent the infrastructure layer of a director's LifeBuild — what runs automatically versus what requires active project management.
+
+## HOW: Implementation
+
+**Defining characteristic:** Systems are continuous. They don't complete — they run.
+
+| Dimension | Project           | System                     |
+| --------- | ----------------- | -------------------------- |
+| Shape     | Linear (────►)    | Loop (♻️)                  |
+| Metric    | Progress (% done) | Health (running smoothly?) |
+| Work      | Contains it       | Generates it               |
+| Success   | Completion        | Smooth operation           |
+| Ends      | Yes → Archives    | No (until uprooted)        |
+
+**Six components:**
+
+1. **Purpose** — What this system maintains or enables
+2. **Pattern** — When work happens (cadences, triggers)
+3. **Controls** — Health metrics indicating smooth operation
+4. **Inputs** — What feeds the system (time, events, data)
+5. **Outputs** — What the system generates (tasks, events, alerts)
+6. **Delegation Profile** — Who does what
+
+**System states:** Planning → Planted → Hibernating → Uprooted
+
+**Systems are color-agnostic:** Systems don't have Gold/Silver/Bronze color. They generate work — the director colors that work based on their relationship to it.
+
+**Visual representation:** Hex tile with system icon (⚙️), health indicator (●●●●○), category color accent, "planted" visual treatment.

--- a/context-library/product/features/Feature - Task.md
+++ b/context-library/product/features/Feature - Task.md
@@ -1,0 +1,48 @@
+# Feature - Task
+
+## WHAT: Definition
+
+A single, completable action that contributes to a project's objectives or fulfills a system's cycle. Tasks are the atomic unit of work in LifeBuild — discrete, actionable, specific, and completable.
+
+## WHERE: Ecosystem
+
+- Zone: Cross-zone — tasks appear in [[Feature - Project Board]], [[Feature - System Board]], [[The Table - Bronze Position]]
+- Implements: [[System - Three-Stream Portfolio]] — Bronze tasks flow to stack
+- Used by: [[Feature - Project]] — projects contain tasks on kanban boards
+- Used by: [[Feature - System]] — systems generate tasks according to patterns
+- Governs: [[Feature - Kanban Board]] — task flow interface
+- Components: [[Task - Bronze Stack]]
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Superior Process]] — work decomposed into actionable units
+- Principle: [[Principle - Visibility Creates Agency]] — tasks make progress visible
+- Driver: Directors need atomic work units they can complete in a session (typically 15min-2hrs).
+
+## WHEN: Timeline
+
+Core entity. Tasks are the smallest work unit — what directors actually execute.
+
+## HOW: Implementation
+
+**Key characteristics:**
+
+- Discrete (clear beginning and end)
+- Actionable (verb-based)
+- Specific (concrete enough to execute)
+- Completable (typically 15min-2hrs)
+
+**Task sources:**
+
+1. **Inside Projects** — Tasks on kanban boards, moving To Do → In Progress → Done
+2. **From Systems** — Tasks generated according to system patterns, appearing on Bronze stack
+
+**CODAD task types:**
+
+- **Connect** — Relationship and communication
+- **Operate** — Implementation and execution
+- **Design** — Planning and conceptual work
+- **Advance** — Progress-driving actions
+- **Discover** — Research and learning
+
+**Task delegation:** Tasks can be assigned to AI Workers or human delegates via [[Feature - Roster Room]].

--- a/context-library/product/features/Feature - The Agenda.md
+++ b/context-library/product/features/Feature - The Agenda.md
@@ -1,0 +1,51 @@
+# Feature - The Agenda
+
+## WHAT: Definition
+
+The session structure that guides conversations in the Council Chamber — a customizable template Jarvis follows to ensure productive strategic discussions. The Agenda provides rhythm without rigidity.
+
+## WHERE: Ecosystem
+
+- Parent: [[Feature - Council Chamber]]
+- Used by: [[Agent - Jarvis]] — guides session flow
+- Implements: [[Strategy - Superior Process]] — structured conversation
+- Implements: [[Principle - Guide When Helpful]] — framework that helps, doesn't constrain
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Superior Process]] — good conversations have shape
+- Principle: [[Principle - Guide When Helpful]] — structure aids, doesn't control
+- Driver: Strategic conversations can wander aimlessly. The Agenda provides just enough structure to keep them productive.
+
+## WHEN: Timeline
+
+Core to Council Chamber design. Agenda templates refine based on what works.
+
+## HOW: Implementation
+
+**Session types have default agendas:**
+
+**Weekly Check-in:**
+
+1. Review — How did last week go?
+2. Patterns — What's Jarvis noticing?
+3. Upcoming — What's ahead?
+4. Adjustments — Any Charter updates?
+
+**Quarterly Review:**
+
+1. Reflection — Quarter retrospective
+2. Themes — What themes are emerging?
+3. Charter — Deep review and update
+4. Direction — Next quarter framing
+
+**Ad-hoc Strategic:**
+
+1. Topic — What's the decision/change?
+2. Context — What matters here?
+3. Options — What are the paths?
+4. Direction — What's the inclination?
+
+**Customization:** Directors can modify agenda templates. Jarvis adapts to preferences over time.
+
+**Flexibility:** Agenda guides, doesn't mandate. Conversations can deviate when needed.

--- a/context-library/product/features/Feature - The Charter.md
+++ b/context-library/product/features/Feature - The Charter.md
@@ -1,0 +1,42 @@
+# Feature - The Charter
+
+## WHAT: Definition
+
+The living strategic document maintained in the Council Chamber — a director's articulated values, current themes, active priorities, and known constraints. The Charter is Jarvis's primary reference and the foundation of strategic conversation.
+
+## WHERE: Ecosystem
+
+- Parent: [[Feature - Council Chamber]]
+- Maintained by: [[Agent - Jarvis]] — proposes updates, tracks evolution
+- Implements: [[Strategy - AI as Teammates]] — shared strategic foundation
+- Implements: [[Principle - Plans Are Hypotheses]] — Charter evolves, not fixed
+- Archived in: [[Feature - Archives]] — historical versions preserved
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - AI as Teammates]] — teammates need shared context
+- Principle: [[Principle - Plans Are Hypotheses]] — strategic documents adapt
+- Driver: Jarvis needs to know what matters to the director. The Charter captures that — not as rigid doctrine but as living understanding.
+
+## WHEN: Timeline
+
+Core strategic artifact. The Charter develops during onboarding and evolves through ongoing sessions.
+
+## HOW: Implementation
+
+**Contents:**
+
+- **Values:** What matters most (articulated through conversation)
+- **Themes:** Current life focus areas (quarterly or seasonal)
+- **Priorities:** What's important now (may shift weekly)
+- **Constraints:** Known limitations (time, energy, resources)
+- **Commitments:** Standing obligations
+
+**Maintenance:**
+
+- Jarvis references Charter in conversations
+- Jarvis proposes updates after significant discussions
+- Director approves changes
+- Historical versions archived
+
+**Not a contract:** The Charter describes current understanding, not binding commitments. Changing it is leadership, not failure.

--- a/context-library/product/features/Feature - The Table.md
+++ b/context-library/product/features/Feature - The Table.md
@@ -1,0 +1,57 @@
+# Feature - The Table
+
+## WHAT: Definition
+
+A persistent priority spotlight that sits at the top of the Life Map, displaying the director's Work at Hand across three distinct positions: Gold (expansion), Silver (capacity), and Bronze (operations). The Table remains visible at all zoom levels — current priorities never disappear from view.
+
+## WHERE: Ecosystem
+
+- Zone: [[Feature - Life Map]] — persistent element above hex grid
+- Implements: [[System - Three-Stream Portfolio]] — three positions map to three streams
+- Implements: [[System - Weekly Priority]] — displays selected Work at Hand
+- Implements: [[System - Dual Presence]] — projects appear here AND on hex grid
+- Implements: [[Principle - Visibility Creates Agency]] — priorities always visible
+- Implements: [[Principle - Protect Transformation]] — structural separation of streams
+- Depends on: [[Feature - Sorting Room]] — where selections are made
+- Depends on: [[Feature - Project]] — Gold/Silver positions display projects
+- Depends on: [[Feature - Task]] — Bronze position displays task stack
+- Components: [[The Table - Gold Position]], [[The Table - Silver Position]], [[The Table - Bronze Position]]
+- Constraint: Maximum 1 Gold + 1 Silver (SOT 5.1)
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Spatial Visibility]] — priority visible at all times
+- Strategy: [[Strategy - Superior Process]] — structured weekly commitment
+- Principle: [[Principle - Protect Transformation]] — Gold/Silver slots protected from Bronze overflow
+- Principle: [[Principle - Empty Slots Strategic]] — empty positions are valid choices
+- Driver: Directors need constant awareness of what they've committed to this week. The Table is the answer to "what am I working on right now?"
+
+## WHEN: Timeline
+
+Core interface element from initial design. The Table's three-position structure is foundational — it embodies the three-stream philosophy in UI.
+
+## HOW: Implementation
+
+**Layout:** Three positions arranged left to right:
+
+- Gold Position (leftmost) — single expansion project
+- Silver Position (center) — single capacity project
+- Bronze Position (rightmost) — stack of operational tasks
+
+**Persistence:** The Table remains visible regardless of zoom level or navigation state on the Life Map. Directors can always see their current priorities.
+
+**Interaction:**
+
+- Click any position → Opens relevant Project Board or Bronze stack view
+- Positions reflect real-time state (progress, completion, changes)
+
+**Visual treatment:**
+
+- Each position has stream-specific color accent
+- Active items show enhanced treatment (glow, full saturation)
+- Empty positions render as calm, intentional states (not warnings)
+
+**Constraint enforcement:**
+
+- System blocks adding second Gold or second Silver
+- Pausing creates opening; promotion can fill it

--- a/context-library/product/features/Feature - Three-Stream Filtering.md
+++ b/context-library/product/features/Feature - Three-Stream Filtering.md
@@ -1,0 +1,54 @@
+# Feature - Three-Stream Filtering
+
+## WHAT: Definition
+
+The filtered views in the Sorting Room that separate Priority Queue candidates by their stream classification — Gold filter shows expansion projects, Silver filter shows capacity projects, Bronze sources shows operational tasks. Three-Stream Filtering makes selection manageable.
+
+## WHERE: Ecosystem
+
+- Parent: [[Feature - Sorting Room]]
+- Implements: [[System - Three-Stream Portfolio]] — stream separation in UI
+- Implements: [[Principle - Protect Transformation]] — filters enforce stream boundaries
+- Uses: [[System - Priority Queue Architecture]] — source of candidates
+- Uses: [[System - Priority Score Calculation]] — rankings within filters
+- Used by: [[Agent - Cameron]] — presents filtered views
+
+## WHY: Rationale
+
+- System: [[System - Three-Stream Portfolio]] — streams need separate views
+- Principle: [[Principle - Protect Transformation]] — can't accidentally put Bronze in Gold slot
+- Driver: Showing all candidates together would be overwhelming. Filtering by stream makes selection tractable.
+
+## WHEN: Timeline
+
+Core to Sorting Room design. Filters embody the three-stream philosophy in interaction.
+
+## HOW: Implementation
+
+**Gold Filter:**
+
+- Shows projects with Purpose = "Moving forward"
+- Sorted by priority score (importance-weighted)
+- Cameron presents top candidates with context
+
+**Silver Filter:**
+
+- Shows projects with Purpose = "Building leverage"
+- Sorted by priority score (leverage-weighted)
+- Cameron presents top candidates with context
+
+**Bronze Sources:**
+
+- Not a single filter — shows source breakdown
+- Quick Task projects (Purpose = Maintenance)
+- System-generated tasks
+- Due-date driven items
+- Critical Responses
+
+**Filter behavior:**
+
+- Only one filter active at a time
+- Selection from filter places item on The Table
+- Cannot cross-select (Gold filter → Gold position only)
+
+**Empty filters:** If Gold filter is empty, Cameron notes it and asks about new project creation or pausing existing work.

--- a/context-library/product/features/Feature - Week-in-Review.md
+++ b/context-library/product/features/Feature - Week-in-Review.md
@@ -1,0 +1,53 @@
+# Feature - Week-in-Review
+
+## WHAT: Definition
+
+The structured end-of-week reflection where directors review what happened against what was planned — celebrating completions, understanding what didn't happen, and capturing learnings. Week-in-Review happens in the Council Chamber with Jarvis.
+
+## WHERE: Ecosystem
+
+- Zone: [[Feature - Council Chamber]] — where review happens
+- Agent: [[Agent - Jarvis]] — guides reflection
+- Uses: [[Feature - The Agenda]] — review follows agenda structure
+- Updates: [[Feature - The Charter]] — insights may trigger updates
+- Feeds: [[Feature - Archives]] — learnings preserved
+- Feeds: [[System - Knowledge Framework]] — patterns captured
+- Paired with: [[Feature - Weekly Planning]] — bookends the week
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - AI as Teammates]] — reflection requires partnership
+- Principle: [[Principle - Plans Are Hypotheses]] — review tests hypotheses
+- Principle: [[Principle - Compound Capability]] — learnings compound
+- Driver: Directors need to process what happened, not just move to next week. Week-in-Review creates that processing.
+
+## WHEN: Timeline
+
+Core rhythm feature. Week-in-Review closes the weekly loop before planning opens the next.
+
+## HOW: Implementation
+
+**Typical flow:**
+
+1. Jarvis summarizes what was on The Table
+2. Review completions — what got done, how it went
+3. Review non-completions — what didn't happen, why
+4. Pattern observation — what's Jarvis noticing over time
+5. Learning capture — anything to remember
+6. Charter check — any updates warranted
+7. Transition to planning (or schedule for later)
+
+**Jarvis's tone:**
+
+- Never judgmental about non-completion
+- Curious about patterns
+- Frames adaptation as leadership
+- Celebrates genuine progress
+
+**Timing flexibility:**
+
+- Default: Friday afternoon (before or after planning)
+- Can be separate session or combined with planning
+- Jarvis may prompt if review is skipped repeatedly
+
+**Duration:** Typically 15-30 minutes. Deeper during quarterly reviews.

--- a/context-library/product/features/Feature - Weekly Planning.md
+++ b/context-library/product/features/Feature - Weekly Planning.md
@@ -1,0 +1,54 @@
+# Feature - Weekly Planning
+
+## WHAT: Definition
+
+The structured beginning-of-week ritual where directors select their Work at Hand for the upcoming week — choosing Gold and Silver projects from candidates, setting Bronze mode, and confirming their weekly commitment. Weekly Planning happens in the Sorting Room with Cameron.
+
+## WHERE: Ecosystem
+
+- Zone: [[Feature - Sorting Room]] — where planning happens
+- Agent: [[Agent - Cameron]] — guides selection
+- Implements: [[Strategy - Superior Process]] — structured prioritization
+- Implements: [[System - Weekly Priority]] — creates Work at Hand
+- Uses: [[System - Priority Queue Architecture]] — source of candidates
+- Uses: [[Feature - Three-Stream Filtering]] — filtered views
+- Populates: [[Feature - The Table]] — result of planning
+- Paired with: [[Feature - Week-in-Review]] — bookends the week
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Superior Process]] — weekly commitment deserves attention
+- Principle: [[Principle - Protect Transformation]] — selection enforces stream constraints
+- Principle: [[Principle - Empty Slots Strategic]] — intentional emptiness is valid choice
+- Driver: Directors need a moment to decide what matters this week. Weekly Planning creates that moment.
+
+## WHEN: Timeline
+
+Core rhythm feature. Weekly Planning establishes the week's focus.
+
+## HOW: Implementation
+
+**Typical flow:**
+
+1. Cameron presents Gold candidates (expansion projects)
+2. Director selects one Gold or confirms intentional empty
+3. Cameron presents Silver candidates (capacity projects)
+4. Director selects one Silver or confirms intentional empty
+5. Cameron reviews Bronze sources and current mode
+6. Director adjusts mode if needed
+7. Work at Hand confirmed → The Table populated
+
+**Cameron's support:**
+
+- Shows priority scores with explanations
+- Surfaces patterns ("this has slipped three weeks")
+- Asks calibrating questions ("is this still the right priority?")
+- Never pushes — presents and respects director choice
+
+**Timing flexibility:**
+
+- Default: Friday afternoon or Sunday evening
+- Configurable to director preference
+- Jarvis may remind if planning is overdue
+
+**Duration:** Typically 10-20 minutes. Can be faster once patterns establish.

--- a/context-library/product/features/Feature - Work at Hand.md
+++ b/context-library/product/features/Feature - Work at Hand.md
@@ -1,0 +1,55 @@
+# Feature - Work at Hand
+
+## WHAT: Definition
+
+The active weekly commitment — the specific projects and tasks a director has selected to focus on this week. Work at Hand consists of up to one Gold project, up to one Silver project, and a Bronze task stack. It's what appears on The Table and represents the director's current priorities.
+
+## WHERE: Ecosystem
+
+- Displayed on: [[Feature - The Table]] — visual representation
+- Selected via: [[Feature - Weekly Planning]] in [[Feature - Sorting Room]]
+- Agent: [[Agent - Cameron]] — guides selection
+- Implements: [[System - Weekly Priority]] — the selection mechanism
+- Implements: [[System - Three-Stream Portfolio]] — three-stream structure
+- Implements: [[Principle - Protect Transformation]] — Gold/Silver protected
+- Sources from: [[System - Priority Queue Architecture]] — candidate pool
+- Modified via: [[Feature - Mid-Week Adaptation]] — changes during week
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Superior Process]] — weekly commitment creates focus
+- Principle: [[Principle - Protect Transformation]] — Work at Hand enforces stream constraints
+- Principle: [[Principle - Empty Slots Strategic]] — empty positions are valid choices
+- Driver: Directors need clarity on "what am I working on this week?" Work at Hand is the answer.
+
+## WHEN: Timeline
+
+Core concept from initial design. Work at Hand is the central organizing principle — everything leads to or flows from it.
+
+## HOW: Implementation
+
+**Composition:**
+
+- Gold position: 0-1 expansion projects (Purpose = "Moving forward")
+- Silver position: 0-1 capacity projects (Purpose = "Building leverage")
+- Bronze position: Variable task stack (controlled by mode)
+
+**Selection timing:**
+
+- Selected during Weekly Planning (typically Friday/Sunday)
+- Valid for one week
+- Reselected each planning cycle
+
+**Constraints:**
+
+- Maximum 1 Gold, 1 Silver (hard limit)
+- Bronze has no maximum (mode-controlled)
+- Cross-stream placement blocked
+
+**State transitions:**
+
+- Project selected → becomes Work at Hand → enhanced treatment on Life Map
+- Project completed → leaves Work at Hand → position opens
+- Project paused → returns to Priority Queue top → position opens
+
+**The central question:** Work at Hand answers "what matters this week?" Everything else is candidate, context, or history.

--- a/context-library/product/features/Feature - Workspace Navigation.md
+++ b/context-library/product/features/Feature - Workspace Navigation.md
@@ -1,0 +1,63 @@
+# Feature - Workspace Navigation
+
+## WHAT: Definition
+
+The system for moving between LifeBuild's three main workspaces — Life Map (execution), Strategy Studio (planning), and Archives (learning). Workspace Navigation provides consistent access to all zones while maintaining context awareness.
+
+## WHERE: Ecosystem
+
+- Connects: [[Feature - Life Map]], [[Feature - Strategy Studio]], [[Feature - Archives]]
+- Implements: [[Strategy - Spatial Visibility]] — zones have spatial identity
+- Implements: [[Principle - Familiarity Over Function]] — navigation feels natural
+- Available: Globally throughout application
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Spatial Visibility]] — workspaces are distinct places
+- Principle: [[Principle - Familiarity Over Function]] — movement should feel intuitive
+- Driver: Directors need to move between execution, planning, and learning fluidly. Navigation makes that movement effortless.
+
+## WHEN: Timeline
+
+Core infrastructure. Navigation patterns established early, refined based on usage.
+
+## HOW: Implementation
+
+**Three primary zones:**
+
+1. **Life Map** — Execution workspace (default)
+2. **Strategy Studio** — Planning workspace
+3. **Archives** — Learning workspace
+
+**Navigation methods:**
+
+- Persistent nav bar/menu (always accessible)
+- Keyboard shortcuts
+- Agent-initiated transitions ("let's move to the Sorting Room")
+- Context links (click project in conversation → opens Project Board)
+
+**Context preservation:**
+
+- Leaving a workspace preserves state
+- Return to where you were
+- Deep links work (URL to specific room/project)
+
+**Strategy Studio sub-navigation:**
+
+- Council Chamber
+- Category Studios (8)
+- Sorting Room
+- Drafting Room
+- Roster Room
+
+**Visual distinction:**
+
+- Each workspace has distinct visual treatment
+- Current location always clear
+- Breadcrumb awareness for nested spaces
+
+**Entry points:**
+
+- Life Map: Default home, "back to map"
+- Strategy Studio: "Plan" or specific room
+- Archives: "History" or search results

--- a/context-library/product/features/Feature - Zoom Navigation.md
+++ b/context-library/product/features/Feature - Zoom Navigation.md
@@ -1,0 +1,45 @@
+# Feature - Zoom Navigation
+
+## WHAT: Definition
+
+The scale control system for the Life Map, allowing directors to smoothly transition between landscape view (entire life visible) and detail view (individual tile focus). Semantic zoom means information density changes with scale — zoomed out shows less detail per tile.
+
+## WHERE: Ecosystem
+
+- Parent: [[Feature - Life Map]]
+- Implements: [[Strategy - Spatial Visibility]] — multiple scales of the same space
+- Implements: [[Principle - Visibility Creates Agency]] — see everything or focus on one thing
+- Affects: [[Feature - Hex Grid]] — zoom changes tile rendering
+- Affects: [[Feature - The Table]] — always visible regardless of zoom
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Spatial Visibility]] — directors need both overview and detail
+- Principle: [[Principle - Visibility Creates Agency]] — agency requires ability to change perspective
+- Driver: Life is complex — directors need to zoom out for big picture, zoom in for action. Same space, different scales.
+
+## WHEN: Timeline
+
+Core to Life Map design. Zoom behavior refined based on usability testing.
+
+## HOW: Implementation
+
+**Zoom levels:**
+
+- Landscape (far): Entire life visible, tiles as small icons
+- Neighborhood (mid): Category cluster visible, tiles readable
+- Detail (close): Few tiles visible, full information density
+
+**Semantic zoom:**
+
+- Far: Title only, state color
+- Mid: Title, image thumbnail, progress
+- Close: Full tile detail, health indicators, recent activity
+
+**Controls:**
+
+- Pinch/scroll to zoom
+- Double-tap to toggle between levels
+- The Table remains fixed size (always readable)
+
+**Persistence:** Zoom level persists across sessions. Directors return to where they were.

--- a/context-library/product/foundation/Self-Determination Theory.md
+++ b/context-library/product/foundation/Self-Determination Theory.md
@@ -1,0 +1,48 @@
+# Self-Determination Theory
+
+## WHAT: Definition
+
+A macro-theory of human motivation identifying three innate psychological needs — autonomy, competence, and relatedness — that when satisfied produce enhanced motivation and wellbeing, and when thwarted produce diminished functioning.
+
+## WHERE: Ecosystem
+
+- Type: Foundation (theoretical basis for LifeBuild's design)
+- Core needs: [[Need - Autonomy]], [[Need - Competence]], [[Need - Relatedness]]
+- Strategic bets derived from this: [[Strategy - Spatial Visibility]] (autonomy), [[Strategy - Superior Process]] (competence), [[Strategy - AI as Teammates]] (relatedness)
+- Research: Ryan & Deci (2000), extensive empirical validation across domains
+
+## WHY: Significance
+
+LifeBuild's entire product architecture traces to SDT. This is the foundational assumption — that serving these three needs produces human flourishing, and that features serving other goals (engagement, retention, revenue) at the expense of these needs will ultimately fail directors.
+
+The three Wows map directly to the three needs:
+
+- Wow 1 (Visual/Spatial work) → Autonomy
+- Wow 2 (AI staff) → Relatedness
+- Wow 3 (Real results) → Competence
+
+If SDT is wrong — if these aren't the core human needs, or if satisfying them doesn't produce the outcomes we expect — then LifeBuild's entire strategic foundation requires revision.
+
+This is not a design principle we can simply update. It's the lens through which every design principle was derived. Invalidating SDT would mean re-examining every downstream decision.
+
+## HOW: Application
+
+SDT governs feature design through a simple test: every feature must serve autonomy, competence, or relatedness. A feature that doesn't serve one of the three doesn't belong, regardless of how engaging or innovative it might be.
+
+When evaluating any feature, agent behavior, or interface choice, trace it back to which need(s) it serves. If the answer is unclear or "none," that's a red flag.
+
+**Anti-patterns SDT helps us avoid:**
+
+- Gamification that creates dependency (serves engagement, not competence)
+- Agent behaviors that do things for directors instead of teaching (undermines competence)
+- Social features creating comparison rather than connection (undermines relatedness)
+- Hiding information "for the user's benefit" (undermines autonomy)
+
+## Infection Scope
+
+If SDT is invalidated or revised:
+
+- All three strategic bets require review
+- All design principles require review
+- All features governed by those principles require review
+- This is a foundation-level change affecting the entire system

--- a/context-library/product/needs/Need - Autonomy.md
+++ b/context-library/product/needs/Need - Autonomy.md
@@ -1,0 +1,47 @@
+# Need - Autonomy
+
+## WHAT: Definition
+
+The psychological need to feel in control of one's own actions and decisions — to be the origin of one's behavior rather than feeling controlled by external forces.
+
+## WHERE: Ecosystem
+
+- Foundation: [[Self-Determination Theory]] — one of three innate psychological needs
+- Sibling needs: [[Need - Competence]], [[Need - Relatedness]]
+- Primary bet advancing this: [[Strategy - Spatial Visibility]]
+- Supporting bet: [[Strategy - Superior Process]] (plans as hypotheses, not contracts)
+
+## WHY: Significance
+
+When autonomy is satisfied, people experience enhanced motivation, creativity, and wellbeing. When thwarted — through controlling environments, external pressure, or lack of choice — people experience diminished functioning, resistance, and disengagement.
+
+In LifeBuild, autonomy manifests as directors seeing and controlling their work. The spatial Life Map creates comprehension that enables agency. Directors place their own projects, choose their own classifications, adapt their own plans. The system informs and recommends but never controls.
+
+The opposite of autonomy support is controlling behavior: surveillance, deadlines as threats, forced choices, hiding information, overriding decisions. LifeBuild's design principles protect against these patterns.
+
+## HOW: Application
+
+When evaluating any feature or agent behavior, ask: "Does this increase or decrease the director's sense of control over their own life?"
+
+**Signs of autonomy support:**
+
+- Director makes the decision
+- Information is visible, not hidden
+- Choices are framed as options, not requirements
+- Plans can be changed without guilt
+- The system explains its recommendations
+
+**Signs of autonomy threat:**
+
+- System makes decisions for director
+- Information hidden until "needed"
+- Guilt for changing plans
+- Mandatory sequences or gates
+- Opaque recommendations
+
+## Implementing Principles
+
+- [[Principle - Visibility Creates Agency]] — can't control what you can't see
+- [[Principle - Plans Are Hypotheses]] — adaptation is leadership, not failure
+- [[Principle - Empty Slots Strategic]] — permission to choose restraint
+- [[Principle - Familiarity Over Function]] — director's classification is final

--- a/context-library/product/needs/Need - Competence.md
+++ b/context-library/product/needs/Need - Competence.md
@@ -1,0 +1,47 @@
+# Need - Competence
+
+## WHAT: Definition
+
+The psychological need to feel capable and effective — to experience mastery, to see that one's actions produce desired outcomes, to grow in skill over time.
+
+## WHERE: Ecosystem
+
+- Foundation: [[Self-Determination Theory]] — one of three innate psychological needs
+- Sibling needs: [[Need - Autonomy]], [[Need - Relatedness]]
+- Primary bet advancing this: [[Strategy - Superior Process]]
+- Supporting bet: [[Strategy - AI as Teammates]] (agents enable accomplishment)
+
+## WHY: Significance
+
+When competence is satisfied, people persist through challenges, seek optimal difficulty, and experience flow. When thwarted — through repeated failure, unclear feedback, or tasks mismatched to skill — people experience helplessness, anxiety, and withdrawal.
+
+In LifeBuild, competence manifests as directors completing what they commit to and improving over time. The three-stream structure protects transformation work. The weekly rhythm creates accomplishment cycles. Calibration tracking shows estimation accuracy improving. Systems compound, making future weeks easier.
+
+The opposite of competence support is learned helplessness: unclear goals, no feedback, tasks too hard or too easy, no visible progress, repeated failure without learning. LifeBuild's design principles protect against these patterns.
+
+## HOW: Application
+
+When evaluating any feature or agent behavior, ask: "Does this help the director feel more capable, or less?"
+
+**Signs of competence support:**
+
+- Clear objectives with visible progress
+- Difficulty matched to capacity
+- Feedback loops that enable learning
+- Improvement tracked over time
+- Accomplishment recognized
+
+**Signs of competence threat:**
+
+- Unclear what success looks like
+- Overwhelm from too much work
+- No feedback on whether approach is working
+- Same mistakes repeated without learning
+- Accomplishment invisible or dismissed
+
+## Implementing Principles
+
+- [[Principle - Protect Transformation]] — structural protection enables completion
+- [[Principle - Compound Capability]] — each week easier than last
+- [[Principle - First 72 Hours]] — early wins build confidence
+- [[Principle - Plans Are Hypotheses]] — calibration over completion

--- a/context-library/product/needs/Need - Relatedness.md
+++ b/context-library/product/needs/Need - Relatedness.md
@@ -1,0 +1,48 @@
+# Need - Relatedness
+
+## WHAT: Definition
+
+The psychological need to feel connected to others — to experience caring relationships, to belong, to matter to others and have others matter to you.
+
+## WHERE: Ecosystem
+
+- Foundation: [[Self-Determination Theory]] — one of three innate psychological needs
+- Sibling needs: [[Need - Autonomy]], [[Need - Competence]]
+- Primary bet advancing this: [[Strategy - AI as Teammates]]
+- Supporting bet: [[Strategy - Superior Process]] (coordination enables collaboration)
+
+## WHY: Significance
+
+When relatedness is satisfied, people experience security, willingness to explore, and prosocial behavior. When thwarted — through isolation, rejection, or purely transactional interactions — people experience loneliness, defensiveness, and withdrawal.
+
+In LifeBuild, relatedness manifests as directors working with a team of AI agents who function as colleagues, not tools. Each agent has a distinct role and personality. Relationships develop over time as agents learn the director's patterns and preferences. The director isn't alone in managing their life — they have support.
+
+This is a deliberate design choice. Most productivity tools are solitary experiences — you and your list. LifeBuild creates the experience of having a staff, even for individuals who could never afford human assistance.
+
+The opposite of relatedness support is cold instrumentality: purely transactional interactions, no continuity, no care for the person. LifeBuild's design principles protect against these patterns.
+
+## HOW: Application
+
+When evaluating any feature or agent behavior, ask: "Does this feel like working with a colleague, or using a tool?"
+
+**Signs of relatedness support:**
+
+- Agents have consistent personalities
+- Relationship develops over time
+- Agents remember and reference past work
+- Agents show appropriate care for director wellbeing
+- Director feels supported, not alone
+
+**Signs of relatedness threat:**
+
+- Generic, interchangeable responses
+- No continuity between sessions
+- Purely transactional interactions
+- Director feels isolated with their work
+- Agents feel like tools, not teammates
+
+## Implementing Principles
+
+- [[Principle - Earn Don't Interrogate]] — learn like a colleague, not a bureaucrat
+- [[Principle - Guide When Helpful]] — present when needed, not intrusive
+- [[Principle - First 72 Hours]] — relationship begins with real help

--- a/context-library/product/principles/Principle - Compound Capability.md
+++ b/context-library/product/principles/Principle - Compound Capability.md
@@ -1,0 +1,40 @@
+# Principle - Compound Capability
+
+## WHAT: The Principle
+
+When facing tradeoffs, optimize for month-12 capability, not week-1 convenience — each week should be easier than the last.
+
+## WHERE: Ecosystem
+
+- Type: Design Principle
+- Serves: [[Need - Competence]] — each week easier than last
+- Advances: [[Strategy - Spatial Visibility]], [[Strategy - Superior Process]], [[Strategy - AI as Teammates]]
+- Governs: [[Feature - System]], [[Feature - The Charter]], [[System - Service Levels]], [[System - Knowledge Framework]]
+- Systems infrastructure: [[System - Priority Queue Architecture]], [[System - Pipeline Architecture]], [[System - Four-Stage Creation]]
+- Related: [[Principle - First 72 Hours]] — tension resolved through sequencing
+
+## WHY: Belief
+
+Directors succeed with LifeBuild not by completing a list, but by building compound capability — creating infrastructure, knowledge, and support systems that make future weeks progressively easier.
+
+Four things compound:
+
+1. **Infrastructure** — Systems reduce future Bronze load. Each planted system is future work that runs itself.
+2. **Knowledge** — The Charter becomes more accurate, agents become more personalized. Understanding compounds.
+3. **Skill** — The director gets better at planning, estimating, and prioritizing. Calibration improves.
+4. **Support** — The AI team becomes more capable as it learns patterns. The relationship deepens.
+
+The tradeoff framework: when evaluating two designs, ask "Which one makes Month 12 better?" If Design A is easier to learn but plateaus, and Design B has a steeper curve but compounds, choose Design B — then figure out how to ease the learning curve without sacrificing the compound return.
+
+The disposability test: if a director could switch to a competitor after 6 months without losing significant value, the compound capability isn't working. Lock-in should come from accumulated intelligence and infrastructure that the director values, not from switching costs or data hostage-taking.
+
+## HOW: Application
+
+Design features that become more valuable over time. Prefer deep-and-rich over simple-and-shallow when the richness compounds. When compound learning is possible, teach rather than automate.
+
+**Test:** Does this design make the product feel disposable, or increasingly indispensable?
+
+## Tensions
+
+- With [[Principle - First 72 Hours]] — resolved through sequencing: quick wins that also establish compound foundations
+- With simplicity — compound features can be complex; resolution is progressive depth with gentle entry

--- a/context-library/product/principles/Principle - Earn Don't Interrogate.md
+++ b/context-library/product/principles/Principle - Earn Don't Interrogate.md
@@ -1,0 +1,43 @@
+# Principle - Earn Don't Interrogate
+
+## WHAT: The Principle
+
+Knowledge acquisition must never block progress, must feel helpful rather than invasive, must happen in context rather than in the abstract, and must respect cognitive load.
+
+## WHERE: Ecosystem
+
+- Type: Design Principle
+- Serves: [[Need - Relatedness]] — learn like a colleague, not a bureaucrat
+- Serves: [[Need - Autonomy]] — never block progress, respect boundaries
+- Advances: [[Strategy - AI as Teammates]]
+- Governs: All agent knowledge acquisition, [[Feature - The Charter]], [[Feature - The Agenda]], [[Feature - Elicitation]], [[Feature - Smoke Signals]]
+- Agents: [[Agent - Jarvis]], [[Agent - Mesa]], [[Agent - Marvin]], [[Agent - Cameron]], [[Agent - Devin]], [[Agent - Conan]]
+- Companion detail: Director Knowledge & Intelligence System (companion document)
+- Related: [[Principle - Guide When Helpful]] — both concern system-to-director interaction timing
+
+## WHY: Belief
+
+The system learns like a good colleague: paying attention during real work, asking relevant questions at natural moments, building understanding over time. Not like a bureaucratic intake form demanding answers before providing value.
+
+Five elicitation strategies govern knowledge acquisition:
+
+1. **Explicit Structured** — Sliders, scales, option pickers during natural workflows (Purpose selector, Urgency rating)
+2. **Explicit Conversational** — Agent-guided questions in dialogue ("How are you feeling about this week?")
+3. **Embedded Extraction** — Captured from natural conversation without explicit questions (dread mentioned → emotional charge inferred)
+4. **Behavioral Inference** — Patterns computed from observed behavior (effort underestimation factor, avoidance patterns)
+5. **Integration Sourcing** — Data from external systems (calendar, sleep tracker, bank)
+
+The mix shifts over time: early relationship favors explicit structured (low-cost capture during workflows) and embedded extraction (observe without asking). Mature relationship adds behavioral inference (patterns become significant) and integration sourcing (trust earned for external access).
+
+Three sub-principles support this: Just-in-Time Over Just-in-Case (ask when relevant, not during onboarding), Confirm Don't Assume (surface inferences for validation), Priority Tracks to Pain (acquire knowledge about what's hurting first).
+
+## HOW: Application
+
+Never require information before providing value. Capture during natural workflows. Ask when context makes questions relevant. Surface inferences for confirmation rather than treating them as fact.
+
+**Test:** Would the director think "why are you asking me this?" or "that's a helpful question"?
+
+## Tensions
+
+- With comprehensive knowledge — full understanding requires data; resolution is earning it incrementally
+- With onboarding — some baseline is needed; resolution is minimal capture, then learn through use

--- a/context-library/product/principles/Principle - Empty Slots Strategic.md
+++ b/context-library/product/principles/Principle - Empty Slots Strategic.md
@@ -1,0 +1,35 @@
+# Principle - Empty Slots Strategic
+
+## WHAT: The Principle
+
+An empty Gold or Silver slot can be a deliberate choice — to recover, catch up, or simplify.
+
+## WHERE: Ecosystem
+
+- Type: Design Principle
+- Serves: [[Need - Autonomy]] — permission to choose restraint
+- Advances: [[Strategy - Superior Process]]
+- Governs: [[Feature - The Table]] (visual treatment of empty slots), [[The Table - Gold Position]], [[The Table - Silver Position]]
+- Agents: [[Agent - Cameron]] (respects empty choices), [[Agent - Jarvis]] (strategic framing)
+- Related: [[Principle - Plans Are Hypotheses]], [[Principle - Protect Transformation]]
+
+## WHY: Belief
+
+The Sovereignty Gap book argues that sovereignty requires underlying capacity. Capacity sometimes requires rest. An empty Gold week isn't the absence of progress — it's the investment that makes next week's Gold possible.
+
+Some weeks the wisest plan is maintenance-only. A director recovering from illness, managing a family crisis, or simply depleted from sustained effort shouldn't feel pressured to fill transformation slots. The system frames emptiness as strategic restraint, not incompleteness.
+
+This connects to capacity-first philosophy: you can't transform what you can't sustain. Director Attributes (capacity state) should inform recommendations — when capacity is low, the system might actively recommend an empty slot rather than asking what Gold project to add.
+
+The visual distinction matters: "no Gold selected yet" (planning incomplete) should look different from "Gold intentionally empty" (strategic choice). The former prompts action; the latter communicates intentional restraint.
+
+## HOW: Application
+
+The Table UI should render empty Gold/Silver slots as calm, intentional states — not as warning indicators or empty-state prompts. Agents should check intent and rationale when slots are empty, but accept "I'm taking a lighter week" without pushing.
+
+**Test:** Does this design treat an empty slot as incomplete, or as a valid choice?
+
+## Tensions
+
+- With [[Principle - First 72 Hours]] — first 72 hours optimize for wins, not rest; resolution is sequencing (quick wins first, strategic rest later)
+- With progress expectations — some directors may need permission to rest; the system provides it

--- a/context-library/product/principles/Principle - Familiarity Over Function.md
+++ b/context-library/product/principles/Principle - Familiarity Over Function.md
@@ -1,0 +1,36 @@
+# Principle - Familiarity Over Function
+
+## WHAT: The Principle
+
+Directors classify work by how it feels to them, not by objective criteria — the director's relationship to the work is the only classification that matters.
+
+## WHERE: Ecosystem
+
+- Type: Design Principle
+- Serves: [[Need - Autonomy]] — director's classification is final
+- Advances: [[Strategy - Superior Process]], [[Strategy - AI as Teammates]]
+- Governs: [[Feature - Project - Purpose Assignment]], [[System - Priority Score Calculation]], [[Feature - Sorting Room]], [[Feature - Work at Hand]]
+- Agents: [[Agent - Cameron]] (priority recommendations), [[Agent - Marvin]] (purpose capture during creation)
+- Decisions: [[Decision - Subjective Purpose Classification]]
+- Related: [[Principle - Earn Don't Interrogate]] — both respect director sovereignty
+
+## WHY: Belief
+
+The same garage cleanout is Bronze for one person and Gold for another. A director who's been avoiding it for two years, for whom completing it would change how they feel in their home — that's Gold. For someone who tidies routinely, the same task is Bronze. The objective characteristics of the work (duration, complexity, domain) tell you nothing about what it means to this director.
+
+This emerged from early design discussions: should purpose assignment use objective criteria or subjective criteria? The decision was clear: subjective. Objective classification would require the system to know things it can't know — the director's history with this task, their emotional relationship to it, what completing it would mean for them.
+
+Purpose is captured during Stage 2 of project creation with a single question: "What is this time investment for?" The director chooses based on their relationship to the work. Agents may notice patterns ("you tend to classify home projects as Gold — that's interesting") and may ask curious questions, but never correct or suggest reclassification.
+
+The one exception: if a classification seems like an error rather than a choice ("you marked 'buy groceries' as Gold — did you mean to do that?"), agents can ask once, gently.
+
+## HOW: Application
+
+Design purpose assignment as a subjective question about meaning, not an objective assessment of task characteristics. Priority scores should suggest, never mandate — the director always overrides.
+
+**Test:** Does this design assume it knows better than the director what their work means to them?
+
+## Tensions
+
+- With objective priority math — resolution: the score is a suggestion, the director always has final say
+- With pattern recognition — agents can observe unusual classifications but never override director judgment

--- a/context-library/product/principles/Principle - First 72 Hours.md
+++ b/context-library/product/principles/Principle - First 72 Hours.md
@@ -1,0 +1,39 @@
+# Principle - First 72 Hours
+
+## WHAT: The Principle
+
+Within 72 hours, a new director should point to two or three things in their life that have radically improved.
+
+## WHERE: Ecosystem
+
+- Type: Design Principle
+- Serves: [[Need - Competence]] — early wins build confidence
+- Serves: [[Need - Relatedness]] — relationship begins with real help
+- Advances: [[Strategy - Spatial Visibility]], [[Strategy - Superior Process]], [[Strategy - AI as Teammates]]
+- Governs: [[Hex Grid - Campfire]], [[Feature - Council Chamber]], [[Feature - Drafting Room]]
+- Agents: [[Agent - Mesa]] (first-contact behavior), [[Agent - Jarvis]] (initial strategic sessions), [[Agent - Marvin]] (first project creation)
+- Companion detail: Onboarding Experience Design (companion document, Phase 2)
+- Related: [[Principle - Compound Capability]] — tension with month-12 optimization
+
+## WHY: Belief
+
+The "rolling thunder" strategy: stack wins while building visibility. Don't front-load a comprehensive life assessment. Start with what hurts, fix it visibly, then expand the director's view of what's possible.
+
+Different directors arrive with different pain — the onboarding experience must respond to their actual circumstances, not follow a predetermined path. A director drowning in deferred maintenance needs different first wins than one stuck on a transformative project. Mesa's 72-hour kickoff must assess the director's situation and design the first three days accordingly.
+
+The agents' job is building a realistically achievable plan and supporting its execution. Not ambitious. Not comprehensive. Achievable within 72 hours, producing tangible improvement that builds trust.
+
+The success metric is concrete: the director says, genuinely, "two or three things are better in my life than they were three days ago." Not "I understand how the system works." Not "I've set up my life map." Actual improvement in actual life.
+
+This is the foundation for everything that follows. If the first 72 hours don't deliver real wins, the director won't stay long enough to experience compound capability.
+
+## HOW: Application
+
+Design onboarding as circumstance-responsive, not fixed-sequence. Identify what hurts most, address it visibly, build trust through tangible results. Measure success by life improvement, not feature adoption.
+
+**Test:** Will the director leave the first 72 hours saying "things are actually better" or just "that was interesting"?
+
+## Tensions
+
+- With [[Principle - Compound Capability]] — this optimizes for day 3, that optimizes for month 12; resolution is sequencing quick wins that also establish compound foundations
+- With comprehensive assessment — understanding the whole life takes time; resolution is start with pain, expand later

--- a/context-library/product/principles/Principle - Guide When Helpful.md
+++ b/context-library/product/principles/Principle - Guide When Helpful.md
@@ -1,0 +1,37 @@
+# Principle - Guide When Helpful
+
+## WHAT: The Principle
+
+All capabilities are always available to find — active guidance follows the director's demonstrated experience, not a predetermined education schedule.
+
+## WHERE: Ecosystem
+
+- Type: Design Principle
+- Serves: [[Need - Autonomy]] — all capabilities available, no forced education
+- Serves: [[Need - Relatedness]] — guidance feels like colleague help
+- Advances: [[Strategy - AI as Teammates]]
+- Governs: Feature discoverability, [[Feature - Workspace Navigation]], [[Agent - Mesa]] (routing behavior)
+- Rooms: [[Feature - Council Chamber]], [[Feature - Drafting Room]], [[Feature - Sorting Room]], [[Feature - Roster Room]]
+- Related: [[Principle - First 72 Hours]] — first 72 hours need more active guidance than steady state
+- Related: [[Principle - Earn Don't Interrogate]] — guidance method matters as much as timing
+
+## WHY: Belief
+
+The tension this principle resolves: "pain drives readiness" (original framing) could imply withholding capabilities. The correct framing: capabilities are always available, always self-explanatory, but active guidance follows demonstrated need.
+
+This is the difference between a library (everything available, organized, discoverable) and a tutor (teaching what's relevant now). LifeBuild is both — a library you can browse freely, plus a tutor who notices when you're struggling and offers relevant help.
+
+Every feature needs two explanations: a "browse mode" explanation (what is this, why does it exist, what problem does it solve) and an "active guidance" trigger (what situation causes the system to recommend this capability). The browse explanation is always accessible. The active guidance fires only when behavior suggests the director would benefit.
+
+The design pattern is NOT progressive disclosure (hiding complexity until the user "levels up"). It IS progressive guidance (all complexity is accessible, but the system's active help follows the director's journey). Don't interrupt a thriving director to educate them about features they haven't needed.
+
+## HOW: Application
+
+Design every feature with both discoverability (findable when browsing) and guidance triggers (surfaced when relevant). When the director hits a wall a capability would solve, bring it forward. Don't interrupt success to promote unused features.
+
+**Test:** Is this capability discoverable? And separately: are we highlighting it because the director needs it now, or because we want them to know it exists?
+
+## Tensions
+
+- With [[Principle - First 72 Hours]] — first 72 hours require more proactive guidance to establish quick wins
+- With feature promotion — marketing wants visibility; this principle demands relevance-based surfacing

--- a/context-library/product/principles/Principle - Plans Are Hypotheses.md
+++ b/context-library/product/principles/Principle - Plans Are Hypotheses.md
@@ -1,0 +1,37 @@
+# Principle - Plans Are Hypotheses
+
+## WHAT: The Principle
+
+A weekly plan is a bet, not a commitment — adapting mid-week is engaged leadership, not failure.
+
+## WHERE: Ecosystem
+
+- Type: Design Principle
+- Serves: [[Need - Autonomy]] — adaptation is leadership, not failure
+- Serves: [[Need - Competence]] — calibration improves over time
+- Advances: [[Strategy - Superior Process]]
+- Governs: [[Feature - Mid-Week Adaptation]], [[Feature - Work at Hand]], [[Feature - Sorting Room]], [[Feature - Council Chamber]]
+- Agents: [[Agent - Jarvis]] (tone in reviews), [[Agent - Cameron]] (priority adjustments)
+- Metrics: Calibration accuracy over time, not completion rate
+- Related: [[Principle - Empty Slots Strategic]] — both reject rigid planning
+
+## WHY: Belief
+
+Plan-as-contract framing creates a guilt cycle: make plan → life intervenes → feel guilty → avoid planning → life gets more chaotic → repeat. If plans feel like contracts, directors avoid planning altogether.
+
+The hypothesis frame breaks this cycle: make hypothesis → test against reality → adapt → learn → better hypothesis next week. This reframes adaptation from failure to data collection.
+
+Research on the planning fallacy (Kahneman & Tversky) shows people systematically underestimate effort and overestimate capacity. The system compensates by tracking estimation accuracy and helping calibrate over time. The metric that matters isn't "did you complete your plan?" but "is your planning getting more accurate?"
+
+This principle touches everything: agent tone (Jarvis never says "you didn't complete your Gold this week"), success metrics (calibration accuracy, not completion rate), UI patterns (plan modification should feel like adjusting a strategy, not editing a failure report), and mid-week adaptation (the pause-and-replace pattern is legitimate, not shameful).
+
+## HOW: Application
+
+Design all planning interfaces to feel like strategy adjustment, not commitment management. Train agents to discuss plans as hypotheses being tested. Track and surface calibration accuracy as the primary planning metric.
+
+**Test:** Would this design make a director feel guilty for adapting their plan to reality?
+
+## Tensions
+
+- Contradicts most productivity tool assumptions — traditional tools reward completion, not calibration
+- With accountability — some directors want commitment pressure; resolution: that's their choice, not the system's default

--- a/context-library/product/principles/Principle - Protect Transformation.md
+++ b/context-library/product/principles/Principle - Protect Transformation.md
@@ -1,0 +1,36 @@
+# Principle - Protect Transformation
+
+## WHAT: The Principle
+
+A single ranked priority list lets urgent maintenance perpetually displace important transformation — three streams provide structural protection.
+
+## WHERE: Ecosystem
+
+- Type: Design Principle
+- Serves: [[Need - Competence]] — structural protection enables completion
+- Advances: [[Strategy - Superior Process]]
+- Governs: [[Feature - Three-Stream Filtering]], [[Feature - The Table]], [[Feature - Bronze Operations]], [[Feature - Sorting Room]], [[Feature - Work at Hand]]
+- Table positions: [[The Table - Gold Position]], [[The Table - Silver Position]], [[The Table - Bronze Position]]
+- Decisions: [[Decision - Three Streams Not Ranked List]], [[Decision - One Gold One Silver]]
+- Related: [[Principle - Empty Slots Strategic]] — protection includes permission to rest
+
+## WHY: Belief
+
+The neurological case is decisive: the brain's threat-detection system (amygdala-driven) responds to urgent/concrete stimuli faster than the prefrontal cortex can evaluate important/abstract priorities. This isn't a character flaw — it's architecture. A single ranked list exploits this asymmetry by putting urgent and important items in direct competition, where urgency has a neurological head start.
+
+Three streams aren't three lists — they're three separate competitions. Gold items compete only with other Gold items (on importance). Bronze items compete only with other Bronze items (on urgency). The streams prevent cross-type competition entirely.
+
+Gold and Silver have reserved slots that Bronze cannot invade. Life sometimes demands an all-Bronze response (a major storm, a health crisis), and the system supports those periods without judgment — but the default protects transformation.
+
+We're not saying maintenance doesn't matter. Bronze is essential. The claim is that maintenance doesn't need structural protection — it has urgency on its side already. Transformation needs protection because it lacks urgency's neurological advantage.
+
+## HOW: Application
+
+The Table enforces 1 Gold + 1 Silver maximum. Bronze has its own position that cannot expand into the transformation slots. When designing any prioritization interface, ensure Bronze cannot crowd out Gold/Silver through sheer volume.
+
+**Test:** Does this design let Bronze overflow into Gold or Silver capacity?
+
+## Tensions
+
+- With all-Bronze crisis periods — resolution: system supports them without guilt, tracks duration, signals when crisis has passed
+- With [[Principle - Empty Slots Strategic]] — empty slots are one form of protection

--- a/context-library/product/principles/Principle - Visibility Creates Agency.md
+++ b/context-library/product/principles/Principle - Visibility Creates Agency.md
@@ -1,0 +1,35 @@
+# Principle - Visibility Creates Agency
+
+## WHAT: The Principle
+
+Directors can't control what they can't see — spatial visibility creates comprehension and agency that lists and abstractions cannot.
+
+## WHERE: Ecosystem
+
+- Type: Design Principle
+- Serves: [[Need - Autonomy]] — can't control what you can't see
+- Advances: [[Strategy - Spatial Visibility]]
+- Governs: [[Feature - Life Map]], [[Feature - The Table]], [[Feature - Hex Grid]], [[Feature - Zoom Navigation]], [[Feature - Project Board]], [[Feature - System Board]]
+- Zone features: [[Zoom Navigation - Horizon View]], [[Zoom Navigation - Working View]], [[Zoom Navigation - Detail View]]
+- Related: [[Principle - Visual Recognition]] — visibility must also be instantly legible
+
+## WHY: Belief
+
+Most productivity tools treat work as lists, databases, or inboxes — abstract containers requiring cognitive effort to translate into meaning. You have to _think_ about your work to understand it. You can't _see_ it.
+
+The Life Map resolves the tension between comprehensiveness and clarity through spatiality, not suppression. Everything has a place. The director browses their landscape rather than parsing a feed. This is why LifeBuild uses a spatial metaphor (territory map) rather than a temporal metaphor (timeline, feed, inbox).
+
+Research supports this: Kaplan & Kaplan's Attention Restoration Theory (1989) shows spatial environments create "soft fascination" that reduces cognitive load. The brain's spatial processing and memory systems share neural infrastructure — organizing information spatially engages hippocampal circuits that consolidate long-term memory.
+
+The corollary is critical: hiding work removes agency. Defaults should show, not hide. Filters should be opt-in, not opt-out. The director should always answer "where is my stuff?" at a glance.
+
+## HOW: Application
+
+When designing any feature that displays work, prefer spatial organization over temporal feeds or abstract lists. When considering whether to hide or show information, default to showing — use spatial organization to manage complexity, not suppression.
+
+**Test:** Can the director see and find this without hovering, clicking through menus, or remembering it exists?
+
+## Tensions
+
+- With [[Principle - Protect Transformation]] — showing everything risks overwhelm; resolution is spatial organization, not suppression
+- With information density — too much visible creates noise; resolution is zoom levels and progressive detail

--- a/context-library/product/principles/Principle - Visual Recognition.md
+++ b/context-library/product/principles/Principle - Visual Recognition.md
@@ -1,0 +1,35 @@
+# Principle - Visual Recognition
+
+## WHAT: The Principle
+
+A director must immediately recognize what each visual element represents without hovering, clicking, or reading labels.
+
+## WHERE: Ecosystem
+
+- Type: Design Principle
+- Serves: [[Need - Autonomy]] — instant recognition enables control
+- Advances: [[Strategy - Spatial Visibility]]
+- Governs: [[Feature - Project]], [[Feature - System]], [[Feature - Hex Grid]], [[Hex Grid - Hex Tile]]
+- Companion detail: Brand Standards v2
+- Related: [[Principle - Visibility Creates Agency]] — visibility must also be instantly legible
+
+## WHY: Belief
+
+The two-second test: if a director can't identify a project tile in under two seconds at normal viewing distance, the visual representation has failed. This drove the pivot from abstract urushi-inspired visual evolution to content-depicting diorama-style illustrations. Abstract beauty is worth less than instant recognition.
+
+Project illustrations depict recognizable content, not abstract patterns. Category cards are visually distinct at a glance. Stream colors are immediately legible. If the director has to inspect an element to understand it, the Life Map has become a puzzle instead of a landscape.
+
+The five illustration stages (Sketch → Clean Pencils → Inked → Colored → Finished) serve both aesthetic progression AND recognition: each stage adds detail that makes the project more instantly identifiable. By the Colored stage, a director should recognize "that's my kitchen project" from across the room.
+
+Brand Standards v2 specifies the implementation: Source Serif for readability, warm earth tones for recognition without visual noise, 400ms transitions for contemplative pacing that doesn't interfere with scanning.
+
+## HOW: Application
+
+Design all visual elements for instant recognition. Use content-depicting illustrations, not abstract patterns. Test with the two-second rule: can a director identify this element at a glance?
+
+**Test:** Can the director identify this element in under two seconds, at a glance?
+
+## Tensions
+
+- With contemplative pacing — recognition requires quick parsing, contemplation requires slow absorption; resolution is spatial layout (scannable) with depth on focus (contemplative)
+- With abstract aesthetics — beautiful abstractions may be less recognizable; recognition wins

--- a/context-library/product/strategies/Strategy - AI as Teammates.md
+++ b/context-library/product/strategies/Strategy - AI as Teammates.md
@@ -1,0 +1,47 @@
+# Strategy - AI as Teammates
+
+## WHAT: The Principle
+
+Agents with defined jobs, permissions, and coordination capabilities provide leverage previously available only to people with human staff. This is Strategic Plank 3 — the third of three independent bets LifeBuild is built on.
+
+## WHERE: Ecosystem
+
+- Type: Strategic Bet
+- Serves: [[Need - Relatedness]] — agents function as colleagues, not tools
+- Serves: [[Need - Competence]] (secondary) — agents enable accomplishment
+- Implementing principles: [[Principle - Earn Don't Interrogate]], [[Principle - Guide When Helpful]]
+- Core team: [[Agent - Jarvis]], [[Agent - Mesa]], [[Agent - Marvin]], [[Agent - Cameron]], [[Agent - Devin]], [[Agent - Conan]]
+- Category advisors: [[Agent - Category Advisor (Concept)]], [[Agent - Maya]], [[Agent - Atlas]], [[Agent - Brooks]], [[Agent - Grace]], [[Agent - Reed]], [[Agent - Finn]], [[Agent - Indie]], [[Agent - Sage]]
+- Systems: [[System - Service Levels]], [[System - Knowledge Framework]], [[System - Processing Layer]]
+- Features: [[Feature - Elicitation]], [[Feature - Smoke Signals]], [[Feature - The Charter]], [[Feature - The Agenda]]
+
+## WHY: Belief
+
+People are drowning in work they shouldn't be doing themselves. Research, scheduling, coordination, follow-up, routine decisions — these consume hours that could go toward higher-value thinking or actual living. The constraint isn't knowledge or willpower; it's bandwidth.
+
+AI has made delegation radically more accessible. But most people still treat AI as a tool they "use" — a search engine with better answers, a writing assistant they prompt. This captures maybe 10% of the potential.
+
+The real unlock is AI as _teammates_ — agents with defined roles, ongoing responsibilities, and the judgment to act within appropriate bounds. The difference between "tool I use" and "teammate I work with" is the difference between doing everything yourself with occasional assistance versus having a staff that handles work on your behalf.
+
+The bet: if directors have AI agents with defined jobs, appropriate permissions, and the ability to coordinate — teammates rather than tools — they can operate at a level of effectiveness previously available only to people with human staff, while maintaining sovereignty over the decisions that matter.
+
+## HOW: The Ladder
+
+| Level | Name                   | What It Is                                          |
+| ----- | ---------------------- | --------------------------------------------------- |
+| 0     | Status Quo             | No AI or generic chat                               |
+| 1     | Specialized Agents     | Each room has domain-specific agent (current state) |
+| 2     | Extended to Real World | Agents handle email, calendar, web research         |
+| 3     | Jobs and Permissions   | Agents have standing authority, act proactively     |
+| 4     | Agent Coordination     | Agents hand off to each other                       |
+| 5     | Tiered Authority       | Seniority structure, escalation paths               |
+| 6     | Learning and Memory    | Agents remember, learn patterns, improve over time  |
+| 7+    | Autonomous Team        | Agents with genuine judgment, minimal oversight     |
+
+**Current state:** Level 1. Specialized agents in rooms, reactive help. No proactive behavior or agent-to-agent coordination yet.
+
+## Tensions
+
+- With director sovereignty — agents must empower, not replace, director judgment
+- With privacy — knowledge acquisition must respect boundaries ([[Principle - Earn Don't Interrogate]])
+- Independent from other planks — can succeed or fail independently of Visual and Process bets

--- a/context-library/product/strategies/Strategy - Spatial Visibility.md
+++ b/context-library/product/strategies/Strategy - Spatial Visibility.md
@@ -1,0 +1,43 @@
+# Strategy - Spatial Visibility
+
+## WHAT: The Principle
+
+Making work visual, placed, and traversable creates comprehension and agency that lists and abstractions cannot. This is Strategic Plank 1 — the first of three independent bets LifeBuild is built on.
+
+## WHERE: Ecosystem
+
+- Type: Strategic Bet
+- Serves: [[Need - Autonomy]] — directors see and control their work
+- Serves: [[Need - Competence]] (secondary) — visibility enables progress tracking
+- Implementing principles: [[Principle - Visibility Creates Agency]], [[Principle - Visual Recognition]]
+- Governs: [[Feature - Life Map]], [[Feature - Hex Grid]], [[Feature - The Table]], [[Feature - Zoom Navigation]], [[Feature - Project Board]], [[Feature - System Board]]
+- Zoom tiers: [[Zoom Navigation - Horizon View]], [[Zoom Navigation - Working View]], [[Zoom Navigation - Detail View]]
+- Visual elements: [[Hex Grid - Hex Tile]], [[Hex Grid - Campfire]], [[Hex Grid - Clustering]]
+- Serves: Autonomy (from [[Strategy - Self-Determination Theory]])
+
+## WHY: Belief
+
+Our commitments — both present and future — are largely abstract. We don't have a clear picture of what we're actually committed to, what state our work is in, or what our future will look like if we follow through. This isn't just about the future being uncertain; we don't have a clear sense of the present either.
+
+Most productivity tools compound this by treating work as lists, databases, or inboxes — abstract containers that require cognitive effort to translate into meaning. You have to _think_ about your work to understand it. You can't _see_ it.
+
+The bet: if work is represented spatially, visually, and traversably — like a place you can visit rather than a list you parse — directors will develop deeper, broader understanding of their present and future, leading to better decisions and greater agency.
+
+Research supports this: the brain's spatial processing and memory systems share neural infrastructure. When you organize information spatially and navigate that space, you engage hippocampal circuits that consolidate long-term memory. Navigable environments outperform static spatial organization because movement through space activates the full spatial memory system. The brain's own coordinate system is hexagonal — grid cells in the entorhinal cortex fire in hex patterns.
+
+## HOW: The Ladder
+
+| Level | Name                    | What It Is                                              |
+| ----- | ----------------------- | ------------------------------------------------------- |
+| 0     | Status Quo              | Lists, databases, inboxes                               |
+| 1     | Minimally Viable        | Kanban board + backlogs                                 |
+| 2     | Placed & Illustrated    | Hexmap Life Map with visual indicators (current target) |
+| 3     | Immersive & Navigable   | Game engine environment, 3D traversal                   |
+| 4     | Hybrid Physical/Digital | AR integration, work in physical space                  |
+
+**Current state:** Level 1-2. Hexmap with flat illustrations in development.
+
+## Tensions
+
+- With information density — too much visible creates noise; resolution is zoom levels and progressive detail
+- Independent from other planks — can succeed or fail independently of Process and AI Team bets

--- a/context-library/product/strategies/Strategy - Superior Process.md
+++ b/context-library/product/strategies/Strategy - Superior Process.md
@@ -1,0 +1,47 @@
+# Strategy - Superior Process
+
+## WHAT: The Principle
+
+Applying structured frameworks — from basic organization through sophisticated capacity management — to personal life improves execution and decision-making. This is Strategic Plank 2 — the second of three independent bets LifeBuild is built on.
+
+## WHERE: Ecosystem
+
+- Type: Strategic Bet
+- Serves: [[Need - Competence]] — directors complete what they commit to
+- Serves: [[Need - Autonomy]] (secondary) — structured process increases control
+- Implementing principles: [[Principle - Protect Transformation]], [[Principle - Plans Are Hypotheses]], [[Principle - Empty Slots Strategic]]
+- Governs: [[System - Three-Stream Portfolio]], [[System - Priority Queue Architecture]], [[System - Pipeline Architecture]], [[System - Four-Stage Creation]], [[System - Weekly Priority]], [[System - Priority Score Calculation]]
+- Features: [[Feature - The Table]], [[Feature - Work at Hand]], [[Feature - Bronze Operations]], [[Feature - Three-Stream Filtering]], [[Feature - Mid-Week Adaptation]]
+- Rooms: [[Feature - Council Chamber]], [[Feature - Drafting Room]], [[Feature - Sorting Room]], [[Feature - Roster Room]]
+- Serves: Competence (from [[Strategy - Self-Determination Theory]])
+
+## WHY: Belief
+
+Most people manage their personal lives reactively — responding to whatever feels urgent, carrying commitments in their heads, with no systematic approach to prioritization, capacity, or coordination. This breaks down as complexity increases.
+
+Meanwhile, professional project management has developed sophisticated frameworks for managing complex work: WIP limits, planning rhythms, role clarity, communication protocols, retrospectives. These aren't arbitrary corporate overhead — they're solutions to real coordination and execution problems, refined over decades.
+
+Almost none of this gets applied to personal life. The modern knowledge worker's life has organizational complexity without organizational support.
+
+The bet: if we apply structured process to personal life, directors will execute more effectively, avoid overwhelm, and make better decisions about what deserves their time and energy.
+
+## HOW: The Ladder
+
+| Level | Name                  | What It Is                                                   |
+| ----- | --------------------- | ------------------------------------------------------------ |
+| 0     | Status Quo            | Reactive, no system                                          |
+| 1     | Basic Capture         | Lists, brain dumps                                           |
+| 2     | Kanban + WIP          | Visual workflow, limit concurrent work                       |
+| 3     | Bespoke Frameworks    | Bronze/Silver/Gold, The Table as WIP gate (current target)   |
+| 4     | Enterprise Principles | DRI clarity, OODA loops, retrospectives                      |
+| 5     | Structured Rhythm     | SODA cycle, weekly planning phases                           |
+| 6     | Capacity Tracking     | Director Attributes measured and managed                     |
+| 7     | Full Orchestrated     | Defined roles, communication protocols, life-as-organization |
+
+**Current state:** Level 3. Three-stream portfolio and The Table implemented. Capacity tracking planned.
+
+## Tensions
+
+- With simplicity — process adds overhead; resolution is progressive adoption based on director need
+- Could be subsumed by AI — if agents become powerful enough, process becomes invisible scaffolding internal to them
+- Independent from other planks — can succeed or fail independently of Visual and AI Team bets

--- a/context-library/product/systems/System - Bidirectional Loop.md
+++ b/context-library/product/systems/System - Bidirectional Loop.md
@@ -1,0 +1,41 @@
+# System - Bidirectional Loop
+
+## WHAT: Definition
+
+The flywheel by which a director's internal understanding of their life and their external representation on the hex grid strengthen each other through iteration. Directors place, observe, reorganize, and re-observe — producing progressively clearer self-understanding.
+
+## WHERE: Ecosystem
+
+- Zone: [[Feature - Life Map]] — where the loop operates
+- Implements: [[Principle - Visibility Creates Agency]] — external representation creates internal clarity
+- Advances: [[Strategy - Spatial Visibility]] — spatial organization enables the loop
+- Related: [[Hex Grid - Clustering]] — director-chosen spatial relationships
+- Informed by: Zhang & Norman (1994) — distributed cognition research
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Spatial Visibility]] — spatial representation is a thinking tool
+- Driver: Distributed cognition research shows external representations aren't just storage — they're part of the thinking process itself. The Life Map isn't a filing system; it's an extension of the director's mind.
+- Decision: Directors place their own projects. The system does not assign locations. Placement reveals how the director actually thinks about their life.
+
+## WHEN: Timeline
+
+Foundational concept. The bidirectional loop justifies director agency over spatial organization and informs future features like spatial pattern recognition.
+
+## HOW: Implementation
+
+**The cycle:**
+
+1. Director places project based on current understanding
+2. Director observes placement in context of other projects
+3. Director notices relationships, patterns, imbalances
+4. Director reorganizes to better reflect evolved understanding
+5. New organization reveals new patterns
+6. Repeat
+
+**Design implications:**
+
+- No auto-organization — director controls placement
+- Low-friction reorganization — drag-and-drop rearrangement
+- Clustering is meaningful — adjacent hexes carry director-assigned meaning
+- Spatial relationships are data — reveal how director thinks about their life

--- a/context-library/product/systems/System - Dual Presence.md
+++ b/context-library/product/systems/System - Dual Presence.md
@@ -1,0 +1,42 @@
+# System - Dual Presence
+
+## WHAT: Definition
+
+The pattern where Work at Hand projects appear in two places simultaneously: their hex tile on the Life Map grid AND their position on The Table. Both render the same object; state changes update both automatically.
+
+## WHERE: Ecosystem
+
+- Zone: [[Feature - Life Map]] — both Table and grid visible
+- Implements: [[Principle - Visibility Creates Agency]] — priority always visible
+- Implements: [[System - Visual Language]] — enhanced treatment for Work at Hand
+- Depends on: [[System - Weekly Priority]] — creates Work at Hand status
+- Related: [[Feature - The Table]] — one presence location
+- Related: [[Hex Grid - Hex Tile]] — other presence location
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Spatial Visibility]] — work has spatial location AND priority status
+- Principle: [[Principle - Visibility Creates Agency]] — director sees both where work lives (grid) and that it's prioritized (Table)
+- Decision: Same object rendered twice, not two objects synced. Ensures consistency.
+
+## WHEN: Timeline
+
+Core architecture. Dual presence enables the Life Map to show both spatial context (hex grid) and priority focus (The Table) simultaneously.
+
+## HOW: Implementation
+
+**Visual treatment:**
+
+- Hex tile: Full saturation, active glow, progress ring, stream-color shimmer
+- Table position: Same project rendered with position-specific treatment
+
+**State synchronization:**
+
+- Progress updates: Both views update
+- Completion: Both views respond
+- Pause: Both views dim appropriately
+
+**Interaction:**
+
+- Click either: Opens Project Board overlay
+- Changes in overlay: Reflected in both views

--- a/context-library/product/systems/System - Four-Stage Creation.md
+++ b/context-library/product/systems/System - Four-Stage Creation.md
@@ -1,0 +1,49 @@
+# System - Four-Stage Creation
+
+## WHAT: Definition
+
+The progressive project development process that separates four cognitive modes: capture (Stage 1), definition (Stage 2), planning (Stage 3), and evaluation (Stage 4). Each stage requires different thinking; separating them reduces decision fatigue.
+
+## WHERE: Ecosystem
+
+- Zone: [[Feature - Drafting Room]] — creation happens here with [[Agent - Marvin]]
+- Implements: [[Principle - Earn Don't Interrogate]] — progressive investment
+- Implements: [[Principle - Plans Are Hypotheses]] — stages allow iteration
+- Feeds: [[System - Pipeline Architecture]] — stages determine queue placement
+- Governs: [[Project - Purpose Assignment]] — happens in Stage 2
+- Governs: [[Project - Image Evolution]] — visual stages map to creation stages
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Superior Process]] — structured process for project development
+- Driver: Cognitive mode separation prevents overload. Brainstorming and critiquing at the same time degrades both.
+- Decision: Four stages, not three or five, because the four cognitive modes (divergent capture, convergent definition, generative planning, evaluative comparison) are distinct enough to warrant separation.
+
+## WHEN: Timeline
+
+Core architecture. The four-stage model shapes how Marvin guides project creation and how the pipeline tracks progress.
+
+## HOW: Implementation
+
+**Stage 1: Identified** — Capture before it evaporates
+
+- Marvin asks: Title, brief description, Life Category
+- Result: Project created, enters Planning Queue
+
+**Stage 2: Scoped** — Define success and capture priority data
+
+- Marvin asks: Purpose (→ stream), Objectives (1-3), Priority attributes (U/I/E), Deadline
+- For system-building Silver: "Will this create something that runs continuously?"
+- Result: Stream assignment, success criteria, priority data
+
+**Stage 3: Drafted** — Create complete task list or configure system
+
+- Standard projects: Generate and iterate task list
+- System-building Silver: Configure pattern, controls, outputs, delegation
+- Result: Complete task list OR system configuration
+
+**Stage 4: Prioritized** — Decide where this ranks
+
+- Marvin shows Priority Queue with scores
+- Director places project within stream
+- Result: Project exits Planning Queue → enters Priority Queue

--- a/context-library/product/systems/System - Knowledge Framework.md
+++ b/context-library/product/systems/System - Knowledge Framework.md
@@ -1,0 +1,52 @@
+# System - Knowledge Framework
+
+## WHAT: Definition
+
+The structured organization of everything the AI team learns about a director, organized across two dimensions (Inside World / Outside World) and two scales (Macro / Micro), enabling increasingly personalized service.
+
+## WHERE: Ecosystem
+
+- Zone: Cross-zone — knowledge informs all agents
+- Implements: [[Principle - Earn Don't Interrogate]] — acquisition philosophy
+- Advances: [[Strategy - AI as Teammates]] — knowledge enables relationship depth
+- Depends on: [[Feature - Elicitation]] — how knowledge is acquired
+- Depends on: [[Feature - Smoke Signals]] — pattern detection
+- Feeds: [[System - Service Levels]] — knowledge depth determines service quality
+- Used by: [[Agent - Jarvis]] — orchestrates knowledge gathering
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - AI as Teammates]] — teammates know you, tools don't
+- Principle: [[Principle - Earn Don't Interrogate]] — knowledge earned through relationship, not demanded upfront
+- Decision: Seven domains (Micro Outside, Micro Inside, Macro Inside, Macro Outside, Identity & Profile, Behavioral Patterns, System Health) capture comprehensive understanding.
+
+## WHEN: Timeline
+
+Architectural foundation for the AI team's intelligence layer. Enables progression from Level 0 (generic tool) to Level 5 (orchestrated life support).
+
+## HOW: Implementation
+
+**Two fundamental dimensions:**
+
+- Inside World: Energy, emotions, motivations, values
+- Outside World: Constraints, resources, circumstances
+
+**Two scales:**
+
+- Macro: General state (overall capacity, life situation)
+- Micro: Per-project (specific requirements, feelings about this work)
+
+**Seven domains:**
+
+1. Micro Outside — per-project requirements
+2. Micro Inside — per-project psychology
+3. Macro Inside — capacity state
+4. Macro Outside — resources and constraints
+5. Identity & Profile — stable characteristics
+6. Behavioral Patterns — derived from observation
+7. System Health — planted infrastructure status
+
+**Priority equation:**
+
+- What should they work on? Priority Score
+- Can they actually do it? Feasibility = Capacity / Commitments

--- a/context-library/product/systems/System - Pipeline Architecture.md
+++ b/context-library/product/systems/System - Pipeline Architecture.md
@@ -1,0 +1,45 @@
+# System - Pipeline Architecture
+
+## WHAT: Definition
+
+The two-queue system that separates work in development (Planning Queue) from work ready for activation (Priority Queue). Projects flow through the pipeline as they mature from idea to executable plan.
+
+## WHERE: Ecosystem
+
+- Zone: [[Feature - Drafting Room]] — both queues visible here
+- Implements: [[System - Four-Stage Creation]] — stages determine which queue
+- Feeds: [[System - Priority Queue Architecture]] — projects completing Stage 4 enter Priority Queue
+- Governs: [[Feature - Planning Queue]] — Stages 1-3 projects
+- Related: [[Feature - Project]] — projects move through the pipeline
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Superior Process]] — structured flow from capture to activation
+- Principle: [[Principle - Earn Don't Interrogate]] — progressive investment, not upfront interrogation
+- Decision: Separating queues prevents the common failure mode where effort required to "properly create" a project discourages capturing ideas at all.
+
+## WHEN: Timeline
+
+Foundational architecture. The separation enables quick capture (Stage 1) without forcing immediate prioritization decisions.
+
+## HOW: Implementation
+
+**Planning Queue:**
+
+- Contains: Projects in Stages 1-3
+- Typical state: 0-3 projects in development
+- Actions: Click to resume with Marvin, abandon if no longer relevant
+
+**Priority Queue:**
+
+- Contains: Projects completing Stage 4
+- Entry: Automatic on Stage 4 completion
+- Exit: Selection as Work at Hand, or abandonment
+
+**Flow:**
+
+```
+Idea → Stage 1 (Planning Queue) → Stages 2-3 → Stage 4 → Priority Queue → Work at Hand
+```
+
+**Note on Systems:** Planted systems bypass the pipeline entirely. They generate tasks directly to Bronze according to configured patterns. The pipeline handles project lifecycle only.

--- a/context-library/product/systems/System - Priority Queue Architecture.md
+++ b/context-library/product/systems/System - Priority Queue Architecture.md
@@ -1,0 +1,47 @@
+# System - Priority Queue Architecture
+
+## WHAT: Definition
+
+The ordered repository of all fully-planned work ready for activation, organized by purpose-based streams with stream-specific priority scoring. The Priority Queue is what directors draw from when selecting Work at Hand.
+
+## WHERE: Ecosystem
+
+- Zone: [[Feature - Drafting Room]] — visible in Strategy Studio
+- Implements: [[System - Three-Stream Portfolio]] — organized by Gold/Silver/Bronze
+- Implements: [[System - Priority Score Calculation]] — items ordered by score within streams
+- Depends on: [[System - Pipeline Architecture]] — receives projects completing Stage 4
+- Governs: [[Feature - Three-Stream Filtering]] — how directors view the queue
+- Governs: [[Feature - Sorting Room]] — where selection from queue happens
+- Related: [[Feature - Planning Queue]] — upstream source of projects
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Superior Process]] — structured prioritization replaces reactive decision-making
+- Principle: [[Principle - Protect Transformation]] — stream organization prevents Bronze from crowding Gold/Silver
+- Decision: Separating Planning Queue from Priority Queue creates psychological safety — capture ideas quickly without immediately prioritizing.
+
+## WHEN: Timeline
+
+Foundational architecture. The queue structure enables the entire prioritization flow from project creation through Work at Hand selection.
+
+## HOW: Implementation
+
+**Queue contents:**
+
+- Planned projects (Stage 4 complete, never activated)
+- Paused projects (were Live, temporarily stopped — appear at top)
+- Bronze candidates (ready tasks from various sources)
+
+**Three-stream filters:**
+
+- Gold Candidates: Purpose = "Moving forward" — typically 2-8 projects
+- Silver Candidates: Purpose = "Building leverage" — typically 5-15 projects
+- Bronze Candidates: Purpose = "Maintenance" — typically 20-100+ items
+
+**Ordering within streams:**
+
+- Gold: Importance-weighted priority score
+- Silver: Leverage-weighted priority score
+- Bronze: Urgency-weighted priority score
+
+Directors can manually reorder within streams. The score suggests; the director decides.

--- a/context-library/product/systems/System - Priority Score Calculation.md
+++ b/context-library/product/systems/System - Priority Score Calculation.md
@@ -1,0 +1,48 @@
+# System - Priority Score Calculation
+
+## WHAT: Definition
+
+The formula that computes priority ranking within streams: (Urgency × Importance) / Effort, with stream-specific weightings that encode philosophical commitments about what each stream should prioritize.
+
+## WHERE: Ecosystem
+
+- Zone: [[Feature - Sorting Room]] — scores displayed during selection
+- Implements: [[Principle - Familiarity Over Function]] — score suggests, director decides
+- Implements: [[System - Three-Stream Portfolio]] — different weights per stream
+- Depends on: [[Project - Purpose Assignment]] — determines which weighting applies
+- Used by: [[Agent - Cameron]] — surfaces recommendations based on scores
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Superior Process]] — systematic prioritization support
+- Driver: Without stream weighting, the formula would rank Gold and Bronze on same criteria. Weightings encode philosophy: Gold amplifies Importance, Bronze amplifies Urgency, Silver rewards Leverage.
+- Decision: Formula is hypothesis, not validated algorithm. We expect to tune based on override frequency and director feedback.
+
+## WHEN: Timeline
+
+Initial implementation. The specific weights are tunable — the architecture supports evolution as we learn.
+
+## HOW: Implementation
+
+**Base formula:**
+
+```
+Priority Score = (Urgency × Importance) / Effort
+```
+
+**Stream weightings:**
+
+| Stream | Adjustment              | Rationale                                 |
+| ------ | ----------------------- | ----------------------------------------- |
+| Gold   | Importance × 1.5        | Transformation chosen for significance    |
+| Silver | Score × Leverage Factor | Infrastructure evaluated by future return |
+| Bronze | Urgency × 1.5           | Maintenance surfaces time-sensitive first |
+
+**Director override is sacred:** The score is a suggestion, never a mandate. Consistent overrides are data about the formula, not evidence the director is wrong.
+
+**Inputs required:**
+
+- Urgency (1-10): Time-sensitivity
+- Importance (1-10): How much it matters
+- Effort (1-10): What it costs
+- Deadline (optional): External constraint

--- a/context-library/product/systems/System - Processing Layer.md
+++ b/context-library/product/systems/System - Processing Layer.md
@@ -1,0 +1,44 @@
+# System - Processing Layer
+
+## WHAT: Definition
+
+The deterministic computation engine that transforms raw director data into State Summaries that agents consume. Handles calibration factors, smoke signal detection, and pattern computation — agents focus on conversation and nuance, not math.
+
+## WHERE: Ecosystem
+
+- Zone: Backend — invisible to directors
+- Implements: [[System - Knowledge Framework]] — processes knowledge into summaries
+- Implements: [[Feature - Smoke Signals]] — detects signal conditions
+- Feeds: All agents — they receive summaries, not raw data
+- Related: [[System - Service Levels]] — processing enables service quality
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - AI as Teammates]] — agents need processed intelligence
+- Driver: Separation of concerns. Deterministic logic (calibration math, pattern detection) shouldn't consume agent context windows. Agents add judgment and conversation quality.
+- Decision: State Summaries ~250 tokens. Compact enough for agent context, rich enough for personalized service.
+
+## WHEN: Timeline
+
+Infrastructure layer. Enables agent specialization — agents do what agents do best (conversation, judgment) while processing layer handles computation.
+
+## HOW: Implementation
+
+**Processing Layer computes:**
+
+- Calibration factors (estimation accuracy over time)
+- Smoke signal conditions (pattern thresholds)
+- State Summaries (compressed director state)
+
+**State Summary contents (~250 tokens):**
+
+- Current capacity state
+- Active smoke signals
+- Key patterns detected
+- Recent changes
+
+**Agent consumption:**
+
+- Agents receive State Summary at conversation start
+- Summaries inform recommendations without requiring agents to compute
+- Agents add interpretation, empathy, and judgment

--- a/context-library/product/systems/System - Service Levels.md
+++ b/context-library/product/systems/System - Service Levels.md
@@ -1,0 +1,46 @@
+# System - Service Levels
+
+## WHAT: Definition
+
+The progressive ladder (Levels 0-5) measuring how well the AI team knows a director, from Anonymous (generic tool) to Fully Mapped (orchestrated life support). Service quality improves as knowledge deepens.
+
+## WHERE: Ecosystem
+
+- Zone: Cross-zone — level affects all agent interactions
+- Implements: [[Principle - Compound Capability]] — service compounds over time
+- Advances: [[Strategy - AI as Teammates]] — relationship depth creates value
+- Depends on: [[System - Knowledge Framework]] — knowledge determines level
+- Depends on: [[System - Processing Layer]] — computes level indicators
+- Related: [[Feature - The Charter]] — living knowledge store
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - AI as Teammates]] — the difference between tool and teammate is knowledge depth
+- Principle: [[Principle - Compound Capability]] — month-12 service should be dramatically better than month-1
+- Decision: Six levels provide clear progression markers without false precision.
+
+## WHEN: Timeline
+
+Architectural target. Current implementation targets Levels 1-2. Full ladder represents the AI Team maturity vision.
+
+## HOW: Implementation
+
+**The ladder:**
+
+| Level | Name            | What's Known                                        | Service Level                              |
+| ----- | --------------- | --------------------------------------------------- | ------------------------------------------ |
+| 0     | Anonymous       | Nothing                                             | Generic tool — same advice for everyone    |
+| 1     | Minimally Known | Per-project basics + weekly capacity + systems list | Priority math works, basic recommendations |
+| 2     | Observed        | + behavioral patterns + system completion rates     | Calibrated estimates, pattern detection    |
+| 3     | Profiled        | + explicit preferences, support network             | Personalized recommendations               |
+| 4     | Deeply Known    | + comprehensive capacity model + health trends      | Strategic partnership, predictive guidance |
+| 5     | Fully Mapped    | + integrations, continuous awareness                | Orchestrated life support                  |
+
+**Progression mechanism:**
+
+- Every conversation is an opportunity to learn
+- Knowledge acquired through [[Feature - Elicitation]] strategies
+- Behavioral patterns emerge over time
+- Integration sourcing unlocks at higher trust levels
+
+**Goal:** Move every director up the ladder through thoughtful observation and well-timed questions, not interrogation.

--- a/context-library/product/systems/System - Three-Stream Portfolio.md
+++ b/context-library/product/systems/System - Three-Stream Portfolio.md
@@ -1,0 +1,41 @@
+# System - Three-Stream Portfolio
+
+## WHAT: Definition
+
+The organizational architecture that classifies all director work into three purpose-based streams: Gold (expansion), Silver (capacity), and Bronze (maintenance). Each stream answers a different question about what the time investment is for.
+
+## WHERE: Ecosystem
+
+- Zone: Cross-zone — classification applies everywhere
+- Implements: [[Principle - Protect Transformation]] — structural protection for transformation work
+- Implements: [[Principle - Familiarity Over Function]] — director chooses stream based on their relationship to work
+- Governs: [[Feature - The Table]] — three positions map to three streams
+- Governs: [[Feature - Three-Stream Filtering]] — viewing Priority Queue by stream
+- Governs: [[Feature - Sorting Room]] — selection happens stream by stream
+- Related: [[System - Priority Queue Architecture]] — queue organized by streams
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Superior Process]] — applies structured framework to prevent urgency bias
+- Driver: Neurological reality — the brain's threat-detection system (amygdala) responds to urgent/concrete faster than prefrontal cortex evaluates important/abstract. A single ranked list lets urgency always win.
+- Decision: Three streams aren't three lists — they're three separate competitions. Gold competes with Gold on importance. Bronze competes with Bronze on urgency. Cross-type competition is structurally prevented.
+
+## WHEN: Timeline
+
+Core architecture from initial design. The three-stream model is foundational — changing it would require redesigning The Table, Priority Queue, and all prioritization interfaces.
+
+## HOW: Implementation
+
+**Stream definitions:**
+
+| Stream | Purpose     | Question               | Example                   |
+| ------ | ----------- | ---------------------- | ------------------------- |
+| Gold   | Expansion   | What changes my life?  | Train for marathon        |
+| Silver | Capacity    | What creates leverage? | Set up automated bill pay |
+| Bronze | Maintenance | What prevents decay?   | Pay the electric bill     |
+
+**Behavioral intent:** Invest in Silver → drown less in Bronze → have room for Gold.
+
+**Purpose assignment:** Captured during Stage 2 of project creation. Director chooses based on their relationship to the work — the same task is Gold for one person and Bronze for another.
+
+**Stream flow over time:** Work often matures through streams. Learning Spanish starts as Gold (expansion), becomes Silver (building practice system), then Bronze (maintaining the routine).

--- a/context-library/product/systems/System - Visual Language.md
+++ b/context-library/product/systems/System - Visual Language.md
@@ -1,0 +1,58 @@
+# System - Visual Language
+
+## WHAT: Definition
+
+The consistent visual vocabulary that communicates state, type, and priority across all LifeBuild interfaces. Includes category colors, stream accents, state indicators, and entity type markers.
+
+## WHERE: Ecosystem
+
+- Zone: Cross-zone — applies everywhere
+- Implements: [[Principle - Visual Recognition]] — instant identification without inspection
+- Implements: [[Principle - Visibility Creates Agency]] — state visible at a glance
+- Advances: [[Strategy - Spatial Visibility]] — spatial organization requires visual clarity
+- Governs: [[Feature - Life Map]] — hex tile visual treatment
+- Governs: [[Feature - The Table]] — position color accents
+- Governs: [[Hex Grid - Hex Tile]] — state indicators on tiles
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Spatial Visibility]] — visibility requires legibility
+- Principle: [[Principle - Visual Recognition]] — two-second identification test
+- Decision: Content-depicting illustrations over abstract patterns. Recognition trumps beauty.
+
+## WHEN: Timeline
+
+Established in Brand Standards v2. Visual language is stable — changes would require updating all interface elements simultaneously.
+
+## HOW: Implementation
+
+**Category colors:**
+
+| Category        | Color                   |
+| --------------- | ----------------------- |
+| Health          | Vibrant green           |
+| Purpose         | Deep purple/indigo      |
+| Finances        | Gold/amber              |
+| Relationships   | Warm pink/rose          |
+| Home            | Earthy brown/terracotta |
+| Community       | Orange                  |
+| Leisure         | Sky blue                |
+| Personal Growth | Teal                    |
+
+**Stream accents:**
+
+- Gold position: Deep amber/gold
+- Silver position: Cool silver/platinum
+- Bronze position: Warm bronze/copper
+
+**State indicators:**
+
+- Full saturation: Live projects / Planted systems
+- Dimmed (~60%): Planned projects / Hibernating systems
+- Very dimmed (~30%): Paused projects
+- Enhanced + glow: Work at Hand
+
+**Entity type markers:**
+
+- Projects: Progress ring (% complete)
+- Systems: Health dots (●●●●○)

--- a/context-library/product/systems/System - Weekly Priority.md
+++ b/context-library/product/systems/System - Weekly Priority.md
@@ -1,0 +1,39 @@
+# System - Weekly Priority
+
+## WHAT: Definition
+
+The mechanism by which projects become Work at Hand — the items currently on The Table receiving the director's active focus. Selection happens through the Strategy Studio flow; activation places items on The Table.
+
+## WHERE: Ecosystem
+
+- Zone: [[Feature - Strategy Studio]] — selection flow happens here
+- Implements: [[Principle - Protect Transformation]] — 1 Gold + 1 Silver maximum
+- Implements: [[Principle - Empty Slots Strategic]] — empty slots are valid choices
+- Depends on: [[System - Priority Queue Architecture]] — source of candidates
+- Governs: [[Feature - Work at Hand]] — the result of selection
+- Governs: [[Feature - The Table]] — displays selected items
+- Governs: [[Feature - Mid-Week Adaptation]] — changing selections mid-week
+
+## WHY: Rationale
+
+- Strategy: [[Strategy - Superior Process]] — structured weekly commitment
+- Principle: [[Principle - Plans Are Hypotheses]] — weekly plan is a bet, not a contract
+- Decision: Weekly cadence balances planning overhead against adaptation flexibility. Longer cycles reduce planning cost but delay adaptation; shorter cycles increase overhead.
+
+## WHEN: Timeline
+
+Core rhythm. The weekly selection flow is how directors engage with LifeBuild's planning infrastructure.
+
+## HOW: Implementation
+
+**Selection flow:**
+
+1. Council Chamber: Jarvis facilitates strategic conversation
+2. Sorting Room: Cameron presents Priority Queue through stream filters
+3. Director selects: Up to 1 Gold, up to 1 Silver, Bronze mode setting
+4. Roster Room: Assign Workers, confirm plan
+5. Activation: Selected items → Work at Hand, appear on The Table
+
+**System load as baseline:** Before project selection, planted systems are already generating Bronze work. The question isn't "what should I work on?" but "given what my systems already need, what else can I take on?"
+
+**Mid-week flexibility:** Plans aren't locked. Directors can pause, adjust Bronze mode, or create emergency projects when circumstances change.


### PR DESCRIPTION
## Summary
- Establishes the foundational context library structure for LifeBuild product documentation
- Adds 89 interlinked cards organized by type (foundation, needs, strategies, principles, systems, features, components, agents)
- Creates a hierarchical knowledge base: Theory → Needs → Strategies → Principles → Systems/Features/Components

## Content Breakdown

| Category | Count | Description |
|----------|-------|-------------|
| Foundation | 1 | Self-Determination Theory |
| Needs | 3 | Autonomy, Competence, Relatedness |
| Strategies | 3 | Spatial Visibility, Superior Process, AI as Teammates |
| Principles | 10 | Design principles implementing strategies |
| Systems | 12 | Architectural systems (Three-Stream, Priority Queue, etc.) |
| Features | 34 | User-facing features (Life Map, Strategy Studio, etc.) |
| Components | 14 | Sub-feature components (Table positions, Zoom tiers, etc.) |
| Agents | 15 | AI agents (core team + category advisors) |

## Folder Structure
```
context-library/
└── product/
    ├── foundation/
    ├── needs/
    ├── strategies/
    ├── principles/
    ├── systems/
    ├── features/
    ├── components/
    ├── agents/
    ├── zones/      (empty, ready for future)
    └── releases/   (empty, ready for future)
```

## Test plan
- [ ] Verify all 89 markdown files are present and properly formatted
- [ ] Confirm folder structure matches the documented hierarchy
- [ ] Check that cross-references (wiki links) are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)