### PR TITLE
Enable chapter 3 link on book page

### DIFF
--- a/src/data/bookChapters.ts
+++ b/src/data/bookChapters.ts
@@ -43,7 +43,7 @@ export const bookChapters: BookChapter[] = [
     slug: 'chapter-3',
     title: 'Seeing the Restoration Gap',
     part: 'The Lens',
-    status: 'coming_soon',
+    status: 'published',
     teaser:
       "A lens for understanding why you're depleted—and why a lot of \"rest\" doesn't seem to restore you. You'll learn to tell the difference between time that rebuilds your capacity and time that just feels like it should.",
   },


### PR DESCRIPTION
## Summary
- Changes chapter 3 status to `published`
- Makes chapter 3 ("Seeing the Restoration Gap") accessible from the book table of contents
- Chapter will display "Published" status and be clickable

## Test plan
- [ ] Visit /book and verify chapter 3 is a clickable link
- [ ] Verify clicking chapter 3 navigates to the chapter content

🤖 Generated with [Claude Code](https://claude.com/claude-code)