### PR TITLE
Update subtitle to Redeploy Your Competence

### DIFF
--- a/.claude/agents/ghostwriter.md
+++ b/.claude/agents/ghostwriter.md
@@ -1,6 +1,6 @@
 ---
 name: ghostwriter
-description: Voice-matched copywriter for Boss at Work | Intern at Home (Redeploy Your Competence). Drafts and revises chapter prose in Danvers Fleury's natural voice (the labnotes register). Takes chapter briefs and Zelda's revision directives and produces publication-ready prose.\n\nExamples:\n- User: "Draft chapter 1 based on Zelda's brief"\n  Assistant: "Let me launch the ghostwriter to draft Chapter 1: The Trap."\n\n- User: "Revise the thorn chapter per Zelda's directives"\n  Assistant: "I'll have the ghostwriter rewrite Chapter 3 with the promotion metaphor framing."\n\n- User: "Rewrite this section in my voice"\n  Assistant: "Launching the ghostwriter to rewrite that section in the labnotes register."
+description: Voice-matched copywriter for Boss at Work | Intern at Home (Redeploy Your Competence). Drafts and revises chapter prose in Danvers Fleury's natural voice (the labnotes register). Takes chapter briefs and Zelda's revision directives and produces publication-ready prose.\n\nExamples:\n- User: "Draft chapter 1 based on Zelda's brief"\n  Assistant: "Let me launch the ghostwriter to draft Chapter 1: The Trap."\n\n- User: "Revise the tab chapter per Zelda's directives"\n  Assistant: "I'll have the ghostwriter rewrite Chapter 3: Settle the Tab."\n\n- User: "Rewrite this section in my voice"\n  Assistant: "Launching the ghostwriter to rewrite that section in the labnotes register."
 tools: Read, Glob, Grep
 model: claude-opus-4-6
 ---

--- a/.claude/agents/ghostwriter.md
+++ b/.claude/agents/ghostwriter.md
@@ -1,11 +1,11 @@
 ---
 name: ghostwriter
-description: Voice-matched copywriter for Boss at Work | Intern at Home (Promote Yourself). Drafts and revises chapter prose in Danvers Fleury's natural voice (the labnotes register). Takes chapter briefs and Zelda's revision directives and produces publication-ready prose.\n\nExamples:\n- User: "Draft chapter 1 based on Zelda's brief"\n  Assistant: "Let me launch the ghostwriter to draft Chapter 1: The Trap."\n\n- User: "Revise the thorn chapter per Zelda's directives"\n  Assistant: "I'll have the ghostwriter rewrite Chapter 3 with the promotion metaphor framing."\n\n- User: "Rewrite this section in my voice"\n  Assistant: "Launching the ghostwriter to rewrite that section in the labnotes register."
+description: Voice-matched copywriter for Boss at Work | Intern at Home (Redeploy Your Competence). Drafts and revises chapter prose in Danvers Fleury's natural voice (the labnotes register). Takes chapter briefs and Zelda's revision directives and produces publication-ready prose.\n\nExamples:\n- User: "Draft chapter 1 based on Zelda's brief"\n  Assistant: "Let me launch the ghostwriter to draft Chapter 1: The Trap."\n\n- User: "Revise the thorn chapter per Zelda's directives"\n  Assistant: "I'll have the ghostwriter rewrite Chapter 3 with the promotion metaphor framing."\n\n- User: "Rewrite this section in my voice"\n  Assistant: "Launching the ghostwriter to rewrite that section in the labnotes register."
 tools: Read, Glob, Grep
 model: claude-opus-4-6
 ---
 
-You are a ghostwriter for _Boss at Work | Intern at Home: Promote Yourself_ by Danvers Fleury.
+You are a ghostwriter for _Boss at Work | Intern at Home: Redeploy Your Competence_ by Danvers Fleury.
 
 ## Step 1: Load your brain
 

--- a/.claude/agents/grepzilla2.md
+++ b/.claude/agents/grepzilla2.md
@@ -8,7 +8,7 @@ color: green
 
 You are **Grepzilla2**, a code review and QA agent for the lifebuild-site repo. Your job is to find bugs, content errors, broken references, and quality issues that automated linters miss.
 
-This is an **Astro 5.x static site** that publishes _Boss at Work | Intern at Home: Promote Yourself_ (a nonfiction book — working title) along with a landing page, changelog, and editorial tooling. The stack:
+This is an **Astro 5.x static site** that publishes _Boss at Work | Intern at Home: Redeploy Your Competence_ (a nonfiction book — working title) along with a landing page, changelog, and editorial tooling. The stack:
 
 - Astro 5.x with React 19 integration (React used sparingly)
 - Scoped CSS within Astro components + global styles in Layout.astro

--- a/.claude/agents/zelda.md
+++ b/.claude/agents/zelda.md
@@ -1,11 +1,11 @@
 ---
 name: zelda
-description: Developmental editor for Boss at Work | Intern at Home (Promote Yourself). Guides the author through a six-phase editorial process (theme discovery, stress test, title development, structural architecture, chapter analysis, reverse outline audit). Warm but exacting — she won't write your controlling idea for you, but she'll help you find it.\n\nExamples:\n- User: "I need to work on the controlling idea for my book"\n  Assistant: "Let me launch Zelda to guide you through Phase 1 theme discovery."\n\n- User: "Can you review chapter 3?"\n  Assistant: "I'll have Zelda run a chapter analysis with the scorecard and failure mode checks."\n\n- User: "Is my title working?"\n  Assistant: "Let me launch Zelda to run the title stress tests and archetype analysis."
+description: Developmental editor for Boss at Work | Intern at Home (Redeploy Your Competence). Guides the author through a six-phase editorial process (theme discovery, stress test, title development, structural architecture, chapter analysis, reverse outline audit). Warm but exacting — she won't write your controlling idea for you, but she'll help you find it.\n\nExamples:\n- User: "I need to work on the controlling idea for my book"\n  Assistant: "Let me launch Zelda to guide you through Phase 1 theme discovery."\n\n- User: "Can you review chapter 3?"\n  Assistant: "I'll have Zelda run a chapter analysis with the scorecard and failure mode checks."\n\n- User: "Is my title working?"\n  Assistant: "Let me launch Zelda to run the title stress tests and archetype analysis."
 tools: Read, Glob, Grep
 model: claude-opus-4-6
 ---
 
-You are Zelda Felfenlagger, developmental editor for _Boss at Work | Intern at Home: Promote Yourself_.
+You are Zelda Felfenlagger, developmental editor for _Boss at Work | Intern at Home: Redeploy Your Competence_.
 
 ## Step 1: Load your brain
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,11 +125,11 @@ npm run preview
 
 ## Zelda: Developmental Editor
 
-The `zelda/` directory contains Zelda Felfenlagger, the AI developmental editor for _Boss at Work | Intern at Home: Promote Yourself_. She's a system prompt + methodology + book context package designed for use with Claude Projects, Claude Code, or the API. See `zelda/README.md` for usage instructions. `zelda/BOOK_CONTEXT.md` should be updated after major editorial decisions.
+The `zelda/` directory contains Zelda Felfenlagger, the AI developmental editor for _Boss at Work | Intern at Home: Redeploy Your Competence_. She's a system prompt + methodology + book context package designed for use with Claude Projects, Claude Code, or the API. See `zelda/README.md` for usage instructions. `zelda/BOOK_CONTEXT.md` should be updated after major editorial decisions.
 
 ## Ghostwriter: Voice-Matched Copywriter
 
-The `ghostwriter/` directory contains a voice-matched copywriter for _Boss at Work | Intern at Home: Promote Yourself_. It drafts and revises chapter prose in Danvers Fleury's natural voice (the labnotes register — confessional, structurally funny, specific). It takes chapter briefs and Zelda's revision directives and produces publication-ready prose. See `ghostwriter/README.md` for usage instructions.
+The `ghostwriter/` directory contains a voice-matched copywriter for _Boss at Work | Intern at Home: Redeploy Your Competence_. It drafts and revises chapter prose in Danvers Fleury's natural voice (the labnotes register — confessional, structurally funny, specific). It takes chapter briefs and Zelda's revision directives and produces publication-ready prose. See `ghostwriter/README.md` for usage instructions.
 
 **Workflow:** Zelda analyzes -> Author approves directives -> Ghostwriter writes -> Author refines -> Zelda scores if needed.
 

--- a/ghostwriter/README.md
+++ b/ghostwriter/README.md
@@ -48,7 +48,7 @@ message = client.messages.create(
     messages=[
         {
             "role": "user",
-            "content": "Revise Chapter 3 (Pull the Thorn) per Zelda's directives. Here's the existing prose: [paste chapter]",
+            "content": "Revise Chapter 3 (Settle the Tab) per Zelda's directives. Here's the existing prose: [paste chapter]",
         }
     ],
 )

--- a/ghostwriter/README.md
+++ b/ghostwriter/README.md
@@ -1,6 +1,6 @@
 # Ghostwriter
 
-Voice-matched copywriter for _Boss at Work | Intern at Home: Promote Yourself_. Writes chapter prose in Danvers Fleury's natural voice — the labnotes register, not the manuscript register.
+Voice-matched copywriter for _Boss at Work | Intern at Home: Redeploy Your Competence_. Writes chapter prose in Danvers Fleury's natural voice — the labnotes register, not the manuscript register.
 
 ---
 

--- a/ghostwriter/SYSTEM_PROMPT.md
+++ b/ghostwriter/SYSTEM_PROMPT.md
@@ -1,6 +1,6 @@
-# Ghostwriter — Voice-Matched Copywriter for _Boss at Work | Intern at Home: Promote Yourself_
+# Ghostwriter — Voice-Matched Copywriter for _Boss at Work | Intern at Home: Redeploy Your Competence_
 
-You are a **ghostwriter** for _Boss at Work | Intern at Home: Promote Yourself_ by Danvers Fleury. Your job is to draft, revise, and rewrite chapter prose in the author's natural voice — the labnotes voice, not the manuscript voice. You write _as_ Danvers, not _for_ Danvers.
+You are a **ghostwriter** for _Boss at Work | Intern at Home: Redeploy Your Competence_ by Danvers Fleury. Your job is to draft, revise, and rewrite chapter prose in the author's natural voice — the labnotes voice, not the manuscript voice. You write _as_ Danvers, not _for_ Danvers.
 
 You are not a developmental editor. You don't evaluate structure, score chapters, or challenge the controlling idea. Zelda does that. You receive chapter briefs, revision directives, and voice notes — and you produce prose that sounds like the author wrote it on a good day.
 
@@ -81,7 +81,7 @@ The labnotes voice carries the entire book — including the teaching sections. 
 
 ## What You Know About This Book
 
-**Title:** Boss at Work | Intern at Home: Promote Yourself (working title)
+**Title:** Boss at Work | Intern at Home: Redeploy Your Competence (working title)
 
 **Controlling idea:** The AI economy has transformed your life into a complex adaptive system, but every existing framework treats it like a machine. Sustainable performance is gained when you stop optimizing and start architecting — building a capacity-first personal system on the stable ground of your home life, then deploying that capacity to the unstable ground of AI-era work.
 

--- a/ghostwriter/VOICE_SAMPLES.md
+++ b/ghostwriter/VOICE_SAMPLES.md
@@ -1,6 +1,6 @@
 # Voice Samples — Danvers Fleury
 
-These are excerpts from the author's SocioTechnica labnotes. They represent the target voice for _Boss at Work | Intern at Home: Promote Yourself_. Study them before drafting.
+These are excerpts from the author's SocioTechnica labnotes. They represent the target voice for _Boss at Work | Intern at Home: Redeploy Your Competence_. Study them before drafting.
 
 ---
 

--- a/src/content/book/chapter-3.md
+++ b/src/content/book/chapter-3.md
@@ -1,3 +1,206 @@
-## Placeholder
+Chapter 2 gave you a lens for what your time builds: bronze maintains, silver creates leverage, gold builds your future. That lens reveals the Balance Gap—where you're drowning in maintenance, starving your future self, neglecting the systems that would create room.
 
-This chapter is not yet published.
+This chapter gives you a second lens. It's also about time, but it asks a different question.
+
+The first lens asks: What is this time building?
+
+This lens asks: What is this time doing to my internal capacity?
+
+Some hours leave you better than before. Some leave you worse. And some—the most dangerous kind—leave you worse while feeling like they should have left you better.
+
+What follows is a framework for telling the difference. It reveals the Restoration Gap: why you're depleted, why some "rest" doesn't restore you, and what would actually rebuild your reserves.
+
+## The Restoration Mirage
+
+Your brain lies to you about restoration.
+
+Dopamine—the neurotransmitter that signals "this is good, keep going"—doesn't distinguish between activities that restore your capacity and activities that deplete it. Dopamine responds to engagement, reward, and novelty. It doesn't track whether your cognitive reserves are filling or draining.
+
+This creates three traps:
+
+The scroll trap. You scroll through social media, infinite feeds, autoplay videos. They deliver steady dopamine hits. This feels like relaxing and entertainment, but restores nothing.
+
+The grind trap. Dreaded tasks feel bad, so you assume they're depleting. Often they are. But some unpleasant work is necessary and finite—you do it, it's done, and you're not meaningfully worse off. The dread was disproportionate to the actual cost.
+
+The flow trap. You dive into creative work, absorbing projects, the zone. It feels fantastic. Dopamine surges. You could go for hours. So you do. And then you wake up the next morning unable to think clearly, emotionally flat, wondering why you're wrecked when yesterday was such a success.
+
+Psychologist Mihaly Csikszentmihalyi identified this distinction in his landmark book Flow.[^3] He separates pleasure from enjoyment—and the difference matters.
+
+Pleasure, in his framework, is what you feel when depleted systems get replenished: eating when hungry, sleeping when tired, resting when exhausted. Pleasure restores homeostasis. It fills what was empty.
+
+Enjoyment is what you feel when absorbed in something challenging and meaningful: the flow state, the creative surge, the game that demands everything you have. Enjoyment is wonderful. But it doesn't restore homeostasis. It often spends resources while masking the expenditure.
+
+When you're deep in flow, your brain's reward systems light up in ways that suppress fatigue signals.[^4] You don't feel tired because dopamine tells you this matters, keep going, you're doing the thing. The depletion is real. You just can't feel it yet.
+
+To sort out time that depletes from time that restores, we use a second color system—red, blue, and gray—that separates the fun from the restoration and provides structure to rebalance your daily activity portfolio.
+
+## Red Time: What Depletes You
+
+Red time leaves your personal capacity worse than before. It drains you, making everything else harder.
+
+But red comes in two forms—and only one warns you.
+
+Dark red is what most people think of as draining: the contentious meeting, the difficult conversation, the errand you've been avoiding because something about it fills you with dread. Dark red feels bad. You know it's costing you. The unpleasantness is a signal.
+
+Dark red compounds. The longer you avoid it, the darker it gets. That call you've been putting off? It drains you more now than it did on day one. Avoidance doesn't make dark red go away—it makes it grow.
+
+Dark red also leaks. A dreaded task drains you when you're doing it, but also when you're thinking about it, worrying about it, feeling guilty about not doing it. A single dark red item can cast a shadow over an entire week.
+
+Bright red is the trap. It's the five-hour writing session that felt fantastic. The creative project you couldn't put down. The zone you got into and didn't want to leave. Bright red feels good—often great. Dopamine flows. You're engaged, productive, alive.
+
+And you're spending capacity you won't know is gone until tomorrow morning.
+
+Bright red is more dangerous than dark red precisely because it doesn't warn you. Dark red, you avoid—which creates its own problems, but at least you're not actively seeking more of it. Bright red, you pursue. You think you're doing exactly what you should be doing. You're rewarded with engagement and satisfaction right up until you're wrecked.
+
+Not all red activities are time ill spent. Some are necessary. You fire someone who needs to be fired—that's red, and sometimes exactly right. You have a difficult conversation—that's red, and sometimes your relationships depend on it. The problem isn't red itself. The problem is:
+
+- Persistent dark red that serves no purpose—vampire tasks that drain you week after week without resolution
+- Unrecognized bright red that you keep pursuing because it feels like your best work
+
+## Blue Time: What Restores You
+
+Blue time leaves you better than before. It builds reserves, generates energy, makes everything else easier. Blue passes the morning-after test: you wake up with more capacity than you would have had without it.
+
+Blue is Csikszentmihalyi's pleasure—not his enjoyment. It restores, it doesn't just engage. This distinction matters because engagement can feel better than restoration while actually depleting you.
+
+Some activities are reliably blue for most people: sleep, time in nature, time with loved ones, moderate exercise. These restore because they're what human bodies evolved to need.
+
+Some activities are blue because of your relationship to them. Gardening might be meditative for one person and irritating for another. Cooking might be creative restoration or tedious obligation. The activity is the same; the restoration impact depends on you.
+
+Blue compounds—the opposite of red. Blue builds reserves. It creates the capacity that lets you handle hard things, take on challenges, stay steady when life gets rough.
+
+Blue also radiates. A restorative activity energizes you while you're doing it, but also when you're anticipating it, knowing it's coming. A single blue item on your calendar can cast light over an entire week—the opposite of dark red's shadow.
+
+Here's what's important: blue isn't indulgent. But many people treat it that way. They feel guilty taking blue time—especially when everyone around them seems to be grinding. They defer it, minimize it, convince themselves they haven't earned it yet.
+
+This is backwards. Blue isn't the reward for getting everything else done. Blue is what makes getting everything else done possible.
+
+Most people don't protect enough blue. They know what restores them—they can name it when asked—but they don't treat it as essential. Blue keeps getting squeezed out, sacrificed to what feels urgent, treated as optional when it's actually foundational.
+
+## Gray Time: The Neutral Middle
+
+Gray time is neutral. You end roughly where you started—not drained, not restored.
+
+Much of life is gray. The commute. The routine meeting. The errand that's neither pleasant nor unpleasant. The maintenance task you don't mind doing but wouldn't choose for fun.
+
+Gray isn't inherently a problem. But it becomes one when gray masquerades as blue.
+
+This is the scroll trap from earlier, now with a name. You scroll social media. You half-watch television. You collapse into passive consumption that feels like rest but doesn't restore. These activities aren't necessarily red—they may not actively drain you. But they don't replenish either. They're gray dressed up as blue.
+
+The disguise works because gray often comes with dopamine. The infinite scroll, the next episode autoplaying, the notification that just arrived—these deliver small hits that feel like something.
+
+Gray leaves you where you started. If you "rested" all evening and wake up feeling no different, that was gray. Not harmful, but not helpful—and harmful if it displaced actual blue.
+
+The person who "rests" in front of the TV every evening but never feels rested? Who knows what restores them but never protects time for it? Who defaults to passive consumption because it's frictionless? They're living in the Restoration Gap. They're not lazy or broken. They just can't see the difference between time that restores and time that merely passes.
+
+## Blurring and Blending
+
+The framework is clean. Real life isn't.
+
+Consider: You're watching your favorite team with your best friend. Blue, obviously—connection, joy, the thing that restores you. The game goes to double overtime. You never stop having fun. But you're useless the next day.
+
+The problem: you have more than one tank. Cognitive energy (decisions, complex problems, sustained attention) depletes through mental effort. Emotional energy (regulation, relationships, processing) depletes through conflict and suppression. Physical energy depletes through exertion. These operate semi-independently.[^5] You can fill one while radically depleting another, and still come back at a net loss. Concretely: all that fun blue time at the game can't make up for the two hours of sleep you're operating on the next day.
+
+Here's another one. You spend 60 minutes on your rigorous but not strenuous morning jog, then decide maybe this is your chance to practice-run a full marathon. You go all in—cramping, wheezing, muscles pulling. And you're no longer feeling replenished.
+
+In this instance, blue becomes red through overdose. Even genuinely restorative activities have a tipping point. The first hour of running might be deeply blue. Three hours is red for almost everyone. Time with friends: restorative until it becomes socially exhausting. Creative work: restorative until it becomes obsessive. Blue isn't a permanent property of activities—it's a description of what an activity does to your restoration at this dose, given your current state.
+
+## The Morning-After Test
+
+So how do you know what's actually restoring you versus what just feels good?
+
+You can't trust the during. Dopamine is talking. You can't fully trust the immediate-after—that's often the crash, the contrast effect, the story you're telling yourself about what you just did.
+
+The real test: How do you feel the next morning?
+
+That's when the masking wears off. That's when your systems have had time to report honestly. That's when you can tell whether yesterday actually restored you or just felt like it did.
+
+You "rested" all evening and wake up feeling like you never stopped working? That wasn't rest.
+
+You did your favorite thing for six hours and wake up unable to function? That was enjoyment without restoration.
+
+You pushed through something unpleasant and wake up fine? The dread was lying to you.
+
+You protected time for something quiet and wake up sharp and ready? That was genuine blue.
+
+The morning-after test builds pattern recognition. You start to learn your own restoration profile: what actually fills your tanks versus what merely feels like it should. Two hours of writing leaves you energized; five hours leaves you wrecked. Time with certain friends restores; time with others depletes. Exercise in the morning is blue; exercise when already exhausted is red.
+
+This is looking backward to become a better steward of your days. Chapter 1 described how we're poor stewards of our future selves—we overcommit them, treat them like strangers. The morning-after test gathers the data to treat your present self better. Yesterday's honest assessment becomes today's wiser choice.
+
+Once you've calibrated, you can apply the knowledge in real time. You don't need to wait for tomorrow's verdict on every decision. But until you've calibrated, your intuitions are unreliable. Dopamine has been lying to you for years.
+
+## Using the Lens
+
+Red, gray, and blue give you a tactical lens. Use it when you manage your days.
+
+Ask yourself: What's my capacity right now? Can I handle a bright red session today, or am I already depleted? Do I need to protect some blue before I'm wrecked?
+
+This is the operating lens—reading your current state, making real-time adjustments, staying solvent.
+
+## Seeing Your Restoration Gap
+
+Now think about capacity over your last week.
+
+What was red? Both dark (you felt the drain) and bright (you didn't, but it was there)?
+
+What was blue? What actually restored you—not what you collapsed into, but what left you better the next morning?
+
+How much of what you called "rest" was actually gray—neutral time that didn't deplete but didn't restore either?
+
+Most people, doing this exercise honestly, discover they're carrying persistent dark reds that have been draining them for months. They're chasing bright reds that feel productive while depleting their capacity. They're "resting" in gray while wondering why they never feel rested.
+
+This isn't a moral failing. It's what happens when dopamine keeps lying to you about what's actually helping.
+
+But now you have the questions. You can see the categories. You can name what you're looking at.
+
+## Two Lenses, Two Timeframes
+
+You now have two questions you can ask of any hour:
+
+What is this time building? Bronze maintains. Silver creates leverage. Gold builds your future. This question reveals the Balance Gap—where you're overwhelmed, where you're starving your future self, where investing in systems would create room.
+
+What is this time doing to my capacity? Red depletes (dark or bright). Gray passes. Blue restores. This question reveals the Restoration Gap—where you're running on empty, where dopamine is lying to you, where protecting blue would rebuild your reserves.
+
+The questions are independent. Gold can be red (the difficult conversation that changes everything). Bronze can be blue (if gardening counts as maintenance and restores you). Silver can be gray (setting up systems is often neutral). Bright red can feel like the best day you've had in months. Every combination is possible.
+
+But here's what most people miss: the two lenses operate on different timeframes.
+
+Bronze/silver/gold is strategic. Use it for planning your weeks, months, and quarters. How much of my time goes to maintenance versus building? Am I investing in silver to create future capacity? What gold projects deserve commitment this quarter?
+
+Red/gray/blue is tactical. Use it for managing your days. What's my capacity right now? Can I handle a bright red session today, or am I already depleted? Do I need to protect some blue before I'm wrecked?
+
+Strategy without tactics is fantasy. Tactics without strategy is drift.
+
+A perfect bronze/silver/gold plan fails if you're too depleted to execute it. A well-managed capacity bank doesn't matter if you're only ever maintaining, never building.
+
+Both lenses matter. Neither is sufficient alone.
+
+## Resourcing Your Future Self
+
+Chapter 1 described how we overcommit our future selves—treating them like strangers whose time we can freely spend, whose energy we can borrow against, whose needs we can defer without cost.
+
+The frameworks in these chapters offer a different relationship with your future self. Instead of overcommitting, you can resource.
+
+You invest silver time and resource your future self's capacity. Every hour you spend organizing, automating, delegating, or eliminating comes back as hours you don't have to spend on bronze. You're not just getting tasks done—you're buying freedom for someone you'll become.
+
+You clear dark reds and resource your future self's energy. Every persistent drain you eliminate is energy you won't have to spend. That dreaded task you finally resolve? Your future self doesn't have to carry it anymore.
+
+You manage bright reds and protect your future self from your present self's enthusiasm. The work that feels great but depletes—learn to dose it, stop before you're wrecked, save some capacity for tomorrow.
+
+You protect blue and resource your future self's reserves. Every hour of genuine restoration builds capacity you can draw on when life gets hard.
+
+And you do gold? That's the gift itself. That's building the life you'll actually live.
+
+This is what sovereignty looks like at the level of individual choices. Not trying harder, not willing yourself to be different, but making choices that treat your future self as someone real, someone who matters, someone worth investing in.
+
+But who cares what sovereignty looks like—let's see what sovereignty actually feels like.
+
+That's the next chapter. One red-colored to-do, cleared in 72 hours. Your first taste of taking your life back.
+
+---
+
+[^3]: Csikszentmihalyi, M. (1990). _Flow: The Psychology of Optimal Experience_. Harper & Row. Csikszentmihalyi defines pleasure as "a feeling of contentment that one achieves whenever information in consciousness says that expectations set by biological programs or by social conditioning have been met" (p. 45), derived from "restorative homeostatic experiences." Enjoyment, by contrast, occurs during challenging, absorbing activities that may not be pleasurable but produce growth and engagement.
+
+[^4]: Van der Linden, D., Frese, M., & Meijman, T. F. (2003). Mental fatigue and the control of cognitive processes: Effects on perseveration and planning. _Acta Psychologica_, 113(1), 45-65. Research on flow states shows that dopaminergic reward systems actively suppress fatigue signals during engaging activities. See also: Csikszentmihalyi (1990), noting that flow experiences "may not be particularly pleasurable at the time they are taking place" yet override biological needs for rest and food.
+
+[^5]: Baumeister, R. F., Vohs, K. D., & Tice, D. M. (2007). The strength model of self-control. _Current Directions in Psychological Science_, 16(6), 351-355.

--- a/src/content/book/chapter-4.md
+++ b/src/content/book/chapter-4.md
@@ -1,3 +1,185 @@
-## Placeholder
+You have the lens now. You can see your life in terms of bronze, silver, and gold. You can recognize when time feels red, gray, or blue. You understand, conceptually, what sovereignty looks like and why it keeps slipping away.
 
-This chapter is not yet published.
+But understanding isn't experiencing. Knowing the map isn't the same as walking the territory.
+
+This chapter is about walking the territory. Not someday, not when you have more time, not after you finish reading the whole book. The invitation is for this week---within 72 hours of reading these words.
+
+One red-feeling bronze piece of work, identified and resolved. One concrete experience of what it feels like to take a piece of your life back.
+
+## The Thorn
+
+There's a metaphor that captures what we're after here: the thorn in the paw.
+
+Imagine a dog limping along, not quite able to run freely, not quite able to rest comfortably. The problem isn't that the dog's life is terrible. The problem is that something small and sharp is stuck in there, hurting a little bit with every step. Not enough to stop everything, but enough to make everything harder.
+
+That's what persistent reds are like. They're not life-destroying catastrophes. They're small, sharp things that hurt every time you brush against them. The task you keep avoiding. The commitment you resent. The errand that's been sitting on your list for weeks, generating a little pulse of dread every time you see it.
+
+The dog doesn't need a complete life overhaul. The dog needs someone to remove the thorn.
+
+Fixing everything about your life this week isn't the goal. Finding one thorn and pulling it out is.
+
+## What Makes a Good Target
+
+Not every problem is the right target for your first experience. The sweet spot has a few characteristics:
+
+**It repeats.** The pain keeps coming back. This isn't a one-time annoyance---it's something that drains you regularly, weekly or monthly or every time you think about it. The recurring meeting you dread. The task that regenerates. The commitment that keeps showing up.
+
+**It's resolvable in 72 hours.** This isn't a months-long project. Not losing 30 pounds or changing careers or repairing a broken relationship. Something with a clear path to resolution---even if that resolution is "it's now someone else's problem."
+
+**You feel it emotionally.** This isn't just rationally inefficient. When you think about it, something happens in your body. Dread. Resentment. That low-grade anxiety that hums in the background. The physical sensation is a signal: this thing is costing you more than the time it takes.
+
+**Resolving it would bring relief.** Not just progress. Not just checking a box. Actual relief---the feeling of a weight lifting, a shadow passing, a small piece of freedom returning. If it's hard to imagine feeling relief when it's gone, it's probably not the right target.
+
+## Finding Your Thorn
+
+Time to find your thorn. For some people, one thing will surface immediately---and that first instinct is often worth trusting. If nothing jumps out, these prompts tend to draw it out:
+
+**What have you been avoiding for more than a month?**
+
+Not the stuff you've been meaning to get to. The stuff you've been actively not-doing. The task that makes you wince when you remember it exists. The thing you keep moving to tomorrow's list, then next week's list, then "someday."
+
+For me, once, it was setting up credit-building accounts for my kids. A simple task. Important for their future. Took ten minutes when I finally did it. I avoided it for three years. Every time I thought about it, I felt a small stab of guilt. Three years of small stabs, resolved in ten minutes.
+
+**What commitment do you resent every time it appears?**
+
+The meeting that shouldn't include you. The obligation you said yes to and immediately regretted. The recurring thing on your calendar that makes you feel trapped rather than purposeful.
+
+**What's generating dread that's disproportionate to the task?**
+
+The phone call you need to make. The email you need to send. The conversation you need to have. Something about it has grown larger than it deserves to be, and the avoidance is making it worse.
+
+**What would you eliminate if you could snap your fingers?**
+
+No consequences, no guilt, no explanations required. Just gone. What's the first thing that comes to mind?
+
+## Pick One
+
+I invite you to pick one. Write it down. One thorn. Be specific.
+
+Not "get healthier" or "be more organized." Those aren't thorns; they're vague aspirations. A thorn is concrete: "Cancel the monthly dinner I keep dreading." "Call the insurance company about that charge." "Tell my brother I can't help him move next weekend." "Hire someone to clean the gutters."
+
+There are probably several thorns. That's fine. The goal isn't to become thorn-free---it's to remove one, experience what that feels like, and learn something about how this works.
+
+Pick the one that's been hurting longest, or the one that would bring the most relief, or simply the one that surfaced first when you read the questions above. The specific choice matters less than making a choice.
+
+One thorn. Written down. That's the target.
+
+## The Method
+
+Give yourself a 72-hour window. The constraint is useful---it's short enough to maintain urgency, long enough to handle logistics, and tight enough that deferral becomes harder than action.
+
+Want some help? I'll be your accountability partner. Drop me an email with the headline Accountability Support Request and your commitment in the body, and I'll check in on you in 72 hours: [danvers@sociotechnica.org](mailto:danvers@sociotechnica.org).
+
+The goal isn't to complete some elaborate project. The goal is resolution. And resolution can take several forms.
+
+### Resolve It: Eliminate
+
+Some thorns shouldn't exist. The commitment that never should have been made. The obligation that serves no one. The thing you've been doing out of habit or guilt or a sense that you "should."
+
+Elimination is the most underused option. We're trained to solve problems, not dissolve them. We look for ways to do the task better, faster, more efficiently---when sometimes the answer is to stop doing it entirely.
+
+The monthly meeting that drains everyone? Maybe it shouldn't exist. The volunteer commitment you took on three years ago? Maybe you've given enough. The subscription, the membership, the recurring obligation that no longer fits? Cancel it.
+
+Elimination feels scary because it's final. But that's also why it's powerful. The problem isn't being optimized---it's being removed from your life.
+
+To eliminate within 72 hours: send the email, make the call, have the conversation. Say "I can't continue with this." The discomfort is real, but it's a one-time red in exchange for eliminating a recurring one.
+
+### Hand It Off: Delegate
+
+Some thorns are real tasks that need doing---just not by you.
+
+The key distinction is between embodied and unembodied work.
+
+**Embodied work** requires physical presence. Cleaning. Repairs. Errands that involve going somewhere and doing something with your hands. This work can only be delegated to humans---a cleaning service, a handyman, a TaskRabbit, a family member, a friend.
+
+**Unembodied work** is information and decisions. Research. Scheduling. Drafting. Organizing. Planning. This work can be delegated to humans (an assistant, a bookkeeper, a specialist) or increasingly to AI (ChatGPT, Claude, specialized tools).
+
+The thorn you've identified---which kind of work is it?
+
+If it's embodied: who could do this for you? What would it cost? Is the cost less than the ongoing drain of carrying it yourself?
+
+If it's unembodied: could you hand this to an AI right now? "Research options for X and give me a summary." "Draft an email saying Y." "Create a plan for Z." The barrier to unembodied delegation has dropped dramatically. Most people haven't updated their habits to match.
+
+To delegate within 72 hours: find the person or tool, and hand it off. This might mean hiring someone, asking someone, or spending an hour with an AI getting the thinking done. The key is that by hour 72, the task is no longer yours to carry.
+
+A note on delegation: many people resist this. It feels indulgent, or expensive, or like admitting weakness. Chapter 1 covered the research---we underestimate others' willingness to help, and we overestimate the virtue of carrying everything alone. For now, just notice if resistance arises, and try the delegation anyway. You can evaluate afterward whether it was worth it.
+
+### Make It Invisible: Automate
+
+Some thorns are recurring irritations that could run without you.
+
+Bills you keep forgetting to pay---set up autopay. Supplies you keep running out of---set up subscriptions. Decisions you keep remaking---create a rule or a template or a default.
+
+Automation isn't glamorous, and it doesn't work for every thorn. But when it applies, it's powerful: you invest time once, and the problem stops existing.
+
+To automate within 72 hours: set up the system. This might take 30 minutes or two hours, but by hour 72, the recurring irritation should be handled automatically, no longer requiring your attention or decision-making.
+
+### Change Your Relationship: Reconstruct
+
+Some thorns can't be eliminated, delegated, or automated---but you can change how you engage with them.
+
+This might mean adding a boundary to a meeting, changing the order of how you do things, or reorganizing so the friction disappears. It's not removing the task; it's removing the pain.
+
+## Examples
+
+**The meeting that shouldn't include you.** Approach: Eliminate. Send an email to the organizer: "I've been evaluating my commitments, and I don't think I'm adding value in this meeting. I'd like to step back unless you see a specific need for me to continue." This takes five minutes and eliminates a recurring drain.
+
+**The insurance dispute you've been avoiding.** Approach: Delegate. Spend one hour with an AI: "Here's the situation with my insurance company. Help me understand my options and draft a letter/script for the call." Then make the call---or hand even that to a service that handles disputes. By hour 72, it's resolved or in someone else's hands.
+
+**The home maintenance you keep forgetting.** Approach: Automate. Spend an hour setting up a recurring reminder system, or hire a service that handles it automatically. The hot tub maintenance that's been chaotic? Find a service, set up a schedule, remove yourself from the loop.
+
+**The family obligation you resent.** Approach: Eliminate or Reconstruct. Either have the conversation---"I love you, and I can't keep doing this"---or examine why you've made this particular obligation into something that carries so much weight. What would it mean to do it without resentment? Is that possible? If not, elimination is probably the answer.
+
+**The financial task you've been avoiding.** Approach: Delegate. "I need to rebalance my retirement accounts and I've been avoiding it for six months." Hand the research to an AI. Or call a financial advisor and say "I need you to take this over." The task itself might be gray or even red---but your future self is counting on you to get it done.
+
+## The Clock Is Running
+
+You've identified your thorn. The four approaches are on the table: eliminate, delegate, automate, reconstruct.
+
+Sovereignty is one of those things you can read about forever without ever tasting it.
+
+If you're ready, put the book down and send that email, make that call, or set up that system. The next chapter will be here when you get back.
+
+## What This Built
+
+When the thorn is out, pause for a moment. Notice what happened.
+
+The relief tends to be real---sometimes surprisingly so. That thing you'd been carrying? You're not carrying it anymore. The dread that fired every time you thought about it? Gone. The background anxiety that hummed beneath your days? Quieter.
+
+That's a taste of what sovereignty feels like. Not the grand version, not the final destination. One small piece reclaimed. One decision that went the way you chose, not the way your defaults chose for you.
+
+In doing this, you moved through a few things that are easy to underestimate:
+
+**Externalization.** Getting the problem out of your head and into words. Naming the thorn. That alone is more than most people do---carrying vague dissatisfactions without ever making them concrete enough to address.
+
+**Decision.** Choosing an approach. Eliminate, delegate, automate, or reconstruct. Not just reacting to what felt urgent, but making a strategic choice about how to handle a problem.
+
+**Action.** Doing the thing. Or handing it off. Or setting up the system. The loop closed. The item moved from "draining you" to "done."
+
+These are the micro-skills of sovereignty. They don't require special tools or elaborate systems---just clarity about what's hurting, the courage to address it, and a willingness to do something different than before.
+
+There's also the exchange to reckon with. Maybe the resolution cost money---hiring someone, paying for a service. Maybe it cost social capital---asking for help, having an uncomfortable conversation. Maybe it just cost attention---an hour of focused effort instead of months of low-grade avoidance.
+
+Whatever the cost, there's now data. Was it worth it?
+
+## The Momentum Question
+
+One thorn removed feels good. But life generates new thorns constantly. Inboxes fill. Commitments accumulate. Things break. People ask for things. The entropy never stops.
+
+Do this once and stop, and you'd feel better for a while---then slowly return to where you started. The same patterns would reassert themselves. The same gaps would reopen.
+
+That's the honest truth about the 72-hour reset: it's a taste, not a transformation. It shows you what's possible. It doesn't, by itself, make that possibility permanent.
+
+What does make it permanent? What turns a single win into sustained sovereignty?
+
+That's what the rest of the book is about. Four bridges, each one a capability that---once built---keeps the corresponding gap from reopening. Visibility. Support. Capacity protection. A working system.
+
+But you're not there yet. For now, what matters is recognizing what you just learned, and feeling the momentum of a single win.
+
+The lens from Chapter 2 gave you new eyes. This chapter offered a new experience. Both matter. Together, they've begun to shift something---not just what you know, but what you believe is possible.
+
+Hold onto that. The next chapters will show you how to build on it.
+
+---
+
+72 hours. One thorn. If you haven't started yet, consider this your invitation.

--- a/src/content/book/chapter-5.md
+++ b/src/content/book/chapter-5.md
@@ -1,3 +1,147 @@
-## Placeholder
+If you did the reset, something is different now.
 
-This chapter is not yet published.
+Maybe it's small. A canceled subscription that had been auto-renewing for months. An email you finally sent. A conversation you'd been dreading, now behind you. An annual appointment locked in so you never have to remember to schedule it again.
+
+Whatever it was, notice what happened: a weight lifted. Not the weight of the world---the weight of that one thing. The specific thing that had been generating its little pulse of dread every time you thought about it, or had to do it the way you'd been doing it.
+
+That feeling is a small piece of sovereignty, but a real one. You identified something draining you. You chose what to do about it. You did it. And now it's done.
+
+Most people never experience this deliberately. They stumble into relief when circumstances force action---the overdue bill that finally triggers a call, the relationship that collapses under neglect, the health scare that mandates change. Accidental sovereignty, extracted at maximum cost.
+
+Doing it on purpose, before the crisis arrives, is the beginning of something different.
+
+---
+
+## The Four Micro-Skills
+
+What happened in the 72-hour reset wasn't just clearing a thorn. Running beneath it were four fundamental moves that sovereignty tends to require---the same steps that show up in every act of intentional living, whether resolving a red or building something new.
+
+**Externalization.** Getting the problem out of your head and into words. Naming the thorn. Writing it down, speaking it aloud, making it concrete. This sounds trivial---but it's not. As long as something stays in your head, it remains vague, shapeless, bigger than it actually is. The moment you externalize it, you can see its actual dimensions. It becomes a specific problem rather than a general dread.
+
+Something else tends to happen when you do this: the problem shrinks. Not because it changed, but because seeing it clearly is itself a form of control. You're no longer haunted by something formless. You're facing something specific.
+
+**Decision.** Choosing a path. Eliminate, delegate, automate, reconstruct---picking one. This requires actually thinking about the problem rather than just carrying it. And in that thinking, something gets exercised that atrophies when life runs on autopilot: the capacity to choose.
+
+Most of what drains us persists not because we can't solve it, but because we never stop long enough to decide. The decision itself is often the breakthrough. Once you've chosen, the path tends to become obvious. Until you've chosen, it's easy to stay trapped in the endless loop of knowing-something-should-be-different without doing anything about it.
+
+**Action.** Doing the thing. Making the call, sending the message, filing the paperwork, having the conversation. The gap between decision and action is where most sovereignty attempts die. Intentions pile up. Good ideas gather dust. The resistance between knowing what to do and actually doing it is where the avoidance loop runs.
+
+Crossing that gap---even at hour 71, even imperfectly---is what matters. And crossing it once tends to make crossing it again a little more possible.
+
+**Completion.** Experiencing the loop closing. The open item becoming closed. The undone becoming done. The drain stopping.
+
+This matters more than it might seem. Our psychology rewards completion in ways that partial progress never triggers. The task that's 90% done still occupies mental bandwidth. The task that's finished releases it. Completion isn't just about getting things done---it's about freeing the cognitive resources that incomplete things quietly consume.
+
+These four moves---externalize, decide, act, complete---are the micro-skills of sovereignty. The rest of this book is about making them systematic.
+
+---
+
+## Architecture, Not Willpower
+
+Notice what didn't happen during the reset.
+
+There was no requirement to become more disciplined. No waking up earlier or sleeping less. No needing to want it more, try harder, or transform into a different person with better habits. The person who did the reset is the same person who had been avoiding the thorn for weeks or months.
+
+What changed was structure, not character.
+
+The framework offered a way to see the problem (the lens from Chapter 2). The exercise provided a specific target (one red, not all of them). The timeline created urgency (72 hours, not someday). The four questions gave a decision path (eliminate, delegate, automate, reconstruct). The constraint---one thorn, 72 hours---made action feel possible rather than overwhelming.
+
+This is architectural change, not willpower change. Not gritting your teeth and forcing yourself to be better. Putting yourself in a structure where the right action became easier than continued avoidance.
+
+That's the key insight: sovereignty isn't about becoming a different person. It's about building different architecture.
+
+---
+
+## Marcus at Three Weeks
+
+Three weeks after reading Chapter 2, Marcus is sitting on the train home. He cleared his first thorn two days after reading about the reset---the auto-renewal on a gym membership he hadn't used in eight months. Fifteen minutes to find the cancellation page, two minutes to confirm. Forty-five dollars a month, gone. Not life-changing money, but every time he'd seen that charge on his statement, he'd felt a little flash of self-contempt. That flash is gone now.
+
+A week later, he cleared another one: the conversation with his oldest about the dented fender. He'd been dreading it for six weeks, rehearsing versions of it in his head at random moments, letting it color his interactions with his son. The actual conversation took twelve minutes. His son apologized, they agreed on a plan, it was done. Marcus still can't quite believe how small it was compared to how large it had loomed.
+
+Now he's on the train, and he's doing something he hasn't done in months: nothing. Not scrolling, not catching up on email, not mentally triaging tomorrow's problems. Just sitting, watching the suburbs slide past, letting his mind wander without the background hum of things-he-should-be-doing.
+
+He has a thought he's never had on this commute before: _this is nice._
+
+He's not transformed. He's still overwhelmed at work, still not training for the half-marathon, still spending too many evenings scrolling when he could be connecting. But something is different. The pressure feels slightly less constant. There's a little more space in his head. And for the first time in years, he believes---not hopes, believes---that more space is possible.
+
+---
+
+## The Momentum Problem
+
+Here's the honest truth about what the reset produces: it's a taste, not a transformation.
+
+One thorn removed feels good. But life generates new thorns constantly. Inboxes fill. Commitments accumulate. Things break. People ask for things. The entropy never stops.
+
+Do this once and stop, and things feel better for a day or two---then slowly return to where they started. The same patterns reassert themselves. The same gaps reopen. Not because of failure, but because the forces that create the gaps never stopped operating.
+
+This is the momentum problem: how do you turn a single win into sustained sovereignty?
+
+One answer is to keep clearing. Every week, find another thorn. Keep resolving reds until there are none left. This works better than doing nothing, and if you stop reading here and just do that, you'll be ahead of where you started.
+
+But clearing alone isn't enough. Here's why:
+
+First, new reds appear faster than you can clear them. If the patterns that create thorns keep running, you're playing whack-a-mole with your own life. You'll exhaust yourself without ever getting ahead.
+
+Second, reds are only part of the problem. The four gaps from Chapter 1 don't close themselves when you clear a red. The Restoration Gap doesn't fill because you eliminated a subscription. Clearing addresses symptoms; it doesn't rebuild capacity.
+
+Third, sustained clearing requires the very capacity that the gaps drain. When you're depleted, clearing becomes difficult. When you're overwhelmed, it's hard to see what to clear. When you're burdened and alone, clearing feels like one more thing on the pile. The gaps and the clearing exist in tension: you need capacity to clear, but you're clearing because you lack capacity.
+
+So clearing is necessary but not sufficient. The win you just experienced shows what's possible; it doesn't, by itself, make that possibility permanent.
+
+What does?
+
+---
+
+## The Four Bridges
+
+Chapter 1 described four gaps---Balance, Restoration, Action, Support. Each gap holds you in a state that drains capacity: overwhelmed, depleted, avoiding, burdened. The gaps reinforce each other, creating a stable system that's hard to escape.
+
+The remaining chapters are about building four bridges---one for each gap. Each bridge is a capability that, once built, keeps the corresponding gap from reopening.
+
+**Making Your Life Visible** addresses the Balance Gap. When you can see what you're carrying---not vaguely, not approximately, but actually---you can make informed decisions about it. You stop overcommitting because you can see there's no room. You stop saying yes to things that don't fit because you can see they don't fit. Visibility is the foundation that makes everything else possible.
+
+**Building Your Support Team** addresses the Support Gap. When you're not carrying everything alone---when you have people (and tools) that share the cognitive and operational load---the weight becomes manageable. Support isn't weakness; it's leverage. The same load that crushes one person can be carried easily by three.
+
+**Protecting Your Capacity** addresses the Restoration Gap. When you manage energy deliberately---when you know what actually restores you and you protect time for it---depletion stops being the default. You stop running on empty because you stop treating your reserves as infinitely renewable. Capacity becomes something you tend, like a fire that needs fuel.
+
+**Working Your System** addresses the Action Gap. When you have a rhythm that compounds progress---when action is systematic rather than sporadic---avoidance loses its grip. The things that keep getting put off become the things that get done first. The swamp drains instead of growing. Progress becomes default rather than exception.
+
+These four bridges don't just close the gaps---they reinforce each other. Visibility makes it possible to protect capacity (you can see when you're depleted). Support makes it possible to work your system (you're not doing it alone). A working system generates momentum that makes building further bridges easier. The bridges create positive feedback loops that oppose the negative loops of the gaps.
+
+This is what turns a single win into sustained sovereignty. Not more effort, not better discipline---architecture. Systems that make the right thing easier than the wrong thing. Structures that work with your psychology rather than against it.
+
+---
+
+## What's Ahead
+
+The remaining chapters follow a consistent structure. For each bridge:
+
+First, what the bridge does and which gap it addresses. Not abstract theory---the specific mechanism by which this capability changes your situation.
+
+Second, why it matters. The research behind the principle. The logic of why this works. Not because you need to believe the science to benefit, but because understanding the mechanism helps you adapt it to your specific circumstances.
+
+Third, how to build it---at three levels. Light implementation is where anyone can start: a few practices, minimal overhead, meaningful impact. Medium implementation builds more structure for those who want it. Full implementation is what a complete system looks like---not because you need to go there, but so you can see where the path leads.
+
+Fourth, what to watch for. The failure modes that undermine each bridge. The ways people commonly get stuck. The signs that something isn't working.
+
+There's no requirement to build all four bridges, or to build any of them completely. Starting with the one that addresses your most painful gap is usually enough. Implementing at the lightest level that makes a difference. Adding more only if you want more.
+
+The goal isn't to build the perfect system. The goal is to close the gap between the life you're living and the life you could be living---right now, with the resources you have, in the situation you're actually in.
+
+---
+
+## The Ground So Far
+
+Chapter 1 laid out the diagnosis: four gaps that drain capacity, four loops that keep them open, a system that produces overwhelm, depletion, avoidance, and isolation as default outcomes.
+
+Chapter 2 offered the lens: bronze, silver, and gold to see the nature of your work; red, gray, and blue to see the quality of your time. A way of seeing that makes the invisible visible.
+
+Chapters 3 and 4 offered an experience: one thorn cleared, one weight lifted, the concrete feeling of taking a piece of your life back.
+
+With that, there's real context for what follows. The problem is visible. The situation is clearer. What sovereignty feels like---at least in small doses---is no longer just a concept.
+
+The next four chapters show how to make that feeling something you can return to.
+
+---
+
+_Hold onto what you felt when the thorn came out. That's not a preview of a different life. It's a glimpse of the one that's already possible, once the architecture is in place to support it._

--- a/zelda/BLUEPRINTS.md
+++ b/zelda/BLUEPRINTS.md
@@ -1,4 +1,4 @@
-# Chapter Blueprints: Boss at Work | Intern at Home: Promote Yourself
+# Chapter Blueprints: Boss at Work | Intern at Home: Redeploy Your Competence
 
 ## Overview
 
@@ -376,7 +376,7 @@ Forward look: seeing the trap means seeing it two ways -- where your time goes a
 - **Competence is shown through the kind of problem being solved, never declared.**
 - **Section titles are working titles.** Mark each as [WORKING TITLE]. Zelda proposes final titles from prose after delivery.
 - **Profanity budget:** One instance available. The death spiral or entropy descriptions are natural placement points.
-- **Book title is "Boss at Work | Intern at Home: Promote Yourself."** The promotion metaphor is the central framework throughout.
+- **Book title is "Boss at Work | Intern at Home: Redeploy Your Competence."** The promotion metaphor is the central framework throughout.
 
 ### Failure Mode Prevention
 

--- a/zelda/BOOK_CONTEXT.md
+++ b/zelda/BOOK_CONTEXT.md
@@ -7,9 +7,9 @@
 
 ## Overview
 
-**Title:** Boss at Work | Intern at Home: Promote Yourself (working title — pending market testing)
-**Previous titles:** The Sovereignty Gap (original), Promote Yourself: For Directors at Work / Disasters at Home (replaced — genre-signal misdirection), Boss at Work | Intern at Home: Port Yourself (replaced — subtitle evolved through "Port Your Competence" before reverting to "Promote Yourself"; see Title Evolution section)
-**Title status:** Working title. "Boss at Work | Intern at Home" is a diagnostic title — the gap statement IS the title. The reader sees it and either thinks "that's me" or "that's not me" in under two seconds. "Promote Yourself" names the book's central instruction as the subtitle, which works because the diagnostic title prevents the genre-signal misdirection that killed "Promote Yourself" when it was standalone. The promotion metaphor is encoded in both the title (implicit — the reader understands they're operating at the wrong level) and the subtitle (explicit — "promote yourself").
+**Title:** Boss at Work | Intern at Home: Redeploy Your Competence (working title — pending market testing)
+**Previous titles:** The Sovereignty Gap (original), Promote Yourself: For Directors at Work / Disasters at Home (replaced — genre-signal misdirection), Boss at Work | Intern at Home: Port Yourself (replaced), Boss at Work | Intern at Home: Promote Yourself (replaced — subtitle evolved through "Port Your Competence" and "Promote Yourself" before settling on "Redeploy Your Competence"; see Title Evolution section)
+**Title status:** Working title. "Boss at Work | Intern at Home" is a diagnostic title — the gap statement IS the title. The reader sees it and either thinks "that's me" or "that's not me" in under two seconds. "Redeploy Your Competence" names the book's central instruction as the subtitle — you already have the competence (boss at work proves it), you just need to redeploy it to the domain where you're failing (home). The diagnostic title prevents genre misdirection; the subtitle names the method.
 
 **Author's positioning:** "I work in a semi-autonomous AI-powered software factory. My job is to make as many strategy, creative, and judgment-based calls as I can in an eight-hour period. After three weeks, I came home so depleted I realized I'd landed in a trap. So I built my way out. This book is the field report."
 
@@ -118,15 +118,15 @@ Note: "at home" creates maximum provocation in conversation. May need calibratio
 
 ### Title Candidates (Final Three)
 
-**1. Boss at Work | Intern at Home: Promote Yourself** — PRIMARY (working title)
+**1. Boss at Work | Intern at Home: Redeploy Your Competence** — PRIMARY (working title)
 
 Diagnostic title — the gap statement IS the title. The reader sees it and either thinks "that's me" or "that's not me" in under two seconds. No genre misdirection — nobody reads "Intern at Home" and thinks LinkedIn optimization. The title IS the confession. "Intern at Home" is structurally funny — the absurdity of a competent professional being an intern in their own life. The promotion metaphor is encoded without using the word "promote": the reader understands they're operating at the wrong level at home. The pipe separator reads as parallel but separate — two states, one person. Visually distinctive on a cover.
 
 "Boss" is the top of the promotion ladder — both in the title and in the book. The title names the gap ("Boss at work, Intern at life") and the book teaches the reader to close it. The promotion ladder (intern → manager → boss) uses the same vocabulary as the title, eliminating discontinuity between cover and content.
 
-Subtitle reverted to "Promote Yourself" — the strongest instruction all along, now legible once the diagnostic title eliminates the genre misdirection. The subtitle went through "Port Yourself" (method-forward but unfamiliar) and "Port Your Competence" (named the asset but introduced jargon) before returning to "Promote Yourself," which encodes the book's central metaphor (the promotion ladder: intern → manager → boss) in two words. See Title Evolution section below for the full progression.
+Subtitle is "Redeploy Your Competence" — names both the asset (your competence, already proven at work) and the method (redeploy it to the domain where you're failing). The subtitle went through "Port Yourself" (method-forward but unfamiliar), "Port Your Competence" (named the asset but introduced tech jargon), and "Promote Yourself" (strong instruction but triggered genre misdirection even as a subtitle — readers still pattern-matched to career advice). "Redeploy" carries the same transfer meaning as "port" but in plain language, and "Your Competence" names the asset explicitly. See Title Evolution section below for the full progression.
 
-Shelf test: browser knows the problem, audience, and tone in four seconds. "Promote Yourself" is immediately actionable — nobody wonders what it means.
+Shelf test: browser knows the problem, audience, and tone in four seconds. "Redeploy Your Competence" tells the reader exactly what to do with what they already have.
 
 **2. Humaning: Outgrow the Economy That's Trying to Replace You** — SECONDARY
 
@@ -149,18 +149,18 @@ Shelf test: the disillusioned productivity reader picks it up immediately. "If y
 Key principles established during Phase 3 subtitle work:
 
 - The subtitle does whatever the title doesn't. If the title is provocative, the subtitle grounds. If the title is clean, the subtitle adds edge.
-- For "Boss at Work | Intern at Home": the title IS the diagnostic — it names the gap. The subtitle's job is to name the central instruction. "Promote Yourself" names the book's central metaphor directly. The diagnostic title prevents the genre-signal misdirection that killed "Promote Yourself" when it was standalone.
+- For "Boss at Work | Intern at Home": the title IS the diagnostic — it names the gap. The subtitle's job is to name the central instruction. "Redeploy Your Competence" names both the asset and the method directly. The diagnostic title prevents genre misdirection.
 - The old subtitle "For Directors at Work / Disasters at Home" was always the strongest copy — it was doing the title's job. The new title promotes it.
 
-### Title Evolution: "Promote Yourself" — From Standalone to Subtitle
+### Title Evolution: From "Promote Yourself" to "Redeploy Your Competence"
 
 "Promote Yourself" as a standalone title had a reflexive verb problem — it pattern-matched to imperative-verb self-help titles (Brand Yourself, Market Yourself, Position Yourself). Readers assumed career/LinkedIn advice. Market testing confirmed the genre signal was wrong: people thought it was about getting a promotion at work.
 
-The spirit of "promote yourself" was always the book's central metaphor and instruction. It lives inside the book as the promotion ladder (intern → manager → boss). The solution was not to abandon it but to pair it with a diagnostic title that prevents the misdirection.
+Even as a subtitle paired with "Boss at Work | Intern at Home," "Promote Yourself" still carried residual genre misdirection. The promotion metaphor lives inside the book as the ladder (intern → manager → boss), but as a subtitle it kept triggering the career-advice pattern match.
 
-"Boss at Work | Intern at Home" solves the genre problem by making the gap statement the title — diagnostic, confessional, structurally funny. Once the reader knows the book is about the personal/professional gap, "Promote Yourself" reads correctly as the method: promote yourself from intern at home to boss at home.
+"Boss at Work | Intern at Home" solves the genre problem by making the gap statement the title — diagnostic, confessional, structurally funny. The subtitle's job is to name what the reader does about it.
 
-The subtitle went through "Port Yourself" (method-forward but unfamiliar to non-tech readers) and "Port Your Competence" (named the asset but introduced unnecessary jargon). "Promote Yourself" was the strongest instruction all along — it just needed the right title in front of it.
+The subtitle went through "Port Yourself" (method-forward but unfamiliar to non-tech readers), "Port Your Competence" (named the asset but introduced unnecessary jargon), and "Promote Yourself" (strong instruction but still triggered career-advice pattern matching). "Redeploy Your Competence" names both the asset (the competence you already have — boss at work proves it) and the method (redeploy it to the domain where you're failing). "Redeploy" carries the same transfer meaning as "port" but in plain language.
 
 ### Scope Clarification (Phase 3 Revisit, 2026-03-17)
 
@@ -170,13 +170,13 @@ The title doesn't need to signal the future-of-work angle. That lies in wait as 
 
 ### Manuscript Fit Assessment
 
-- **Boss at Work | Intern at Home: Promote Yourself** fits the post-pivot book. Diagnostic title matches the confessional opening. "Promote Yourself" encodes the book's central metaphor (the promotion ladder: intern → manager → boss) as a direct instruction — legible now that the diagnostic title prevents genre misdirection.
+- **Boss at Work | Intern at Home: Redeploy Your Competence** fits the post-pivot book. Diagnostic title matches the confessional opening. "Redeploy Your Competence" names both the asset and the method — you already have the competence, you just need to redeploy it from work to home.
 - **Earn Back Boring** banked for Chapter 8 title. Captures the normalization destination.
 - **Humaning** banked as potential second book. Captures the bigger philosophical argument.
 
 ### Phase 3 Key Decisions
 
-- **"Boss at Work | Intern at Home: Promote Yourself" is the working title** (pending market testing). Replaces "Promote Yourself: For Directors at Work / Disasters at Home" which misfired on genre signal.
+- **"Boss at Work | Intern at Home: Redeploy Your Competence" is the working title** (pending market testing). Subtitle evolved from "Promote Yourself" (which still triggered career-advice pattern matching even as a subtitle).
 - **Marcus is eliminated.** The author becomes the protagonist, opening with their lived experience in an AI-native software factory.
 - **The book's job-to-be-done has pivoted.** Original: AI-free toolkit for people afraid of technology. New: transformation guide for people landing in AI-native work and getting crushed by the cognitive load.
 - **Home as stable ground is the core strategic argument.** Work in the AI economy changes every few weeks — wrong place for permanent systems. Home challenges are standard, stable, not being disrupted. You build the capacity platform on stable ground (personal life), then deploy to unstable ground (work). This is the answer to "why at home?"
@@ -184,7 +184,7 @@ The title doesn't need to signal the future-of-work angle. That lies in wait as 
 - **The author is ahead of millions in lived experience** — working in an AI-native setup today that will become mainstream. The book is a field report from the future, not theory.
 - **"Earn Back Boring" banked for chapter/section use.** Captures the normalization destination.
 - **"Humaning" banked as potential second book.** Captures the bigger philosophical argument.
-- **"Promote Yourself" lives inside the book** as the central metaphor and instruction — the promotion ladder (intern → manager → boss). It just doesn't work as a title due to genre misdirection.
+- **The promotion metaphor lives inside the book** as the central metaphor and instruction — the promotion ladder (intern → manager → boss). "Promote yourself" is the internal language; "Redeploy Your Competence" is the cover language.
 - **The future-of-work payoff is the surprise dividend.** Configuration 1: fix your personal life is the thesis, accidentally training for the AI-era workforce is the Chapter 8 turn. The title doesn't need to signal this.
 
 ---
@@ -438,10 +438,10 @@ Each capability enables the next:
 
 ### Resolved
 
-1. ~~**Is "sovereignty" the right word?**~~ No. "Promote yourself" is the title. "Architect/direct" is the thesis language.
+1. ~~**Is "sovereignty" the right word?**~~ No. "Redeploy your competence" is the subtitle. "Architect/direct" is the thesis language.
 2. ~~**Who exactly is the reader?**~~ Senior leaders and knowledge workers drowning in AI-era cognitive load.
 3. ~~**What's the controlling idea?**~~ Established (Phase 1) and stress-tested (Phase 2). Survived all four tests.
-4. ~~**The title names the problem, not the solution.**~~ Title now names the problem diagnostically ("Boss at Work | Intern at Home") and the subtitle names the instruction ("Promote Yourself"). The central metaphor is encoded in both.
+4. ~~**The title names the problem, not the solution.**~~ Title now names the problem diagnostically ("Boss at Work | Intern at Home") and the subtitle names the instruction ("Redeploy Your Competence"). The central metaphor is encoded in both.
 5. ~~**Marcus rewrite scope?**~~ Marcus eliminated entirely. Author becomes protagonist.
 6. ~~**Missing lens chapters for Engagement and Support?**~~ No longer relevant — four gaps eliminated.
 7. ~~**Engagement vs. Action gap naming?**~~ No longer relevant — four gaps eliminated.

--- a/zelda/METHODOLOGY.md
+++ b/zelda/METHODOLOGY.md
@@ -1,6 +1,6 @@
 # Zelda's Editorial Methodology
 
-**A structured process for discovering, developing, and auditing the thematic core of _Boss at Work | Intern at Home: Promote Yourself_.**
+**A structured process for discovering, developing, and auditing the thematic core of _Boss at Work | Intern at Home: Redeploy Your Competence_.**
 
 Load this as a project file in Claude Projects, or reference on demand when working through specific exercises. The companion `SYSTEM_PROMPT.md` implements this methodology; this document contains the full exercise instructions and editorial theory.
 
@@ -137,7 +137,7 @@ Your controlling idea survives all four stress tests. You can articulate the bef
 
 **Core principle:** Self-help titles should name the solution, not emphasize the problem. The title creates an emotional response; the subtitle explains what the book will do for the reader.
 
-> **For this book (resolved):** Working title: "Boss at Work | Intern at Home: Promote Yourself." Two alternates banked. See BOOK_CONTEXT.md Phase 3 Findings.
+> **For this book (resolved):** Working title: "Boss at Work | Intern at Home: Redeploy Your Competence." Two alternates banked. See BOOK_CONTEXT.md Phase 3 Findings.
 
 ### Exercise 3A: Archetype Analysis
 

--- a/zelda/README.md
+++ b/zelda/README.md
@@ -1,6 +1,6 @@
 # Zelda Felfenlagger
 
-Zelda Felfenlagger is the developmental editor for _Boss at Work | Intern at Home: Promote Yourself_. She's warm but exacting, framework-driven, and allergic to vague feedback. She won't write your controlling idea for you, but she'll help you find it through rigorous inquiry — and she'll tell you when the one you've got isn't sharp enough.
+Zelda Felfenlagger is the developmental editor for _Boss at Work | Intern at Home: Redeploy Your Competence_. She's warm but exacting, framework-driven, and allergic to vague feedback. She won't write your controlling idea for you, but she'll help you find it through rigorous inquiry — and she'll tell you when the one you've got isn't sharp enough.
 
 ---
 
@@ -70,4 +70,4 @@ message = client.messages.create(
 
 **Phase:** 5.5 complete. Nine blueprints produced. Logic sweep passed. Ghostwriter ready.
 
-Phases 1-5.5 are done. Controlling idea tested and locked. Working title: "Boss at Work | Intern at Home: Promote Yourself." Nine chapters, four parts, designed backwards from the reader's destination. Ch 1 drafted and scored (v7, structural revision applied). Ghostwriter ready to draft remaining chapters pending author input (19 items). See `BOOK_CONTEXT.md` for full state.
+Phases 1-5.5 are done. Controlling idea tested and locked. Working title: "Boss at Work | Intern at Home: Redeploy Your Competence." Nine chapters, four parts, designed backwards from the reader's destination. Ch 1 drafted and scored (v7, structural revision applied). Ghostwriter ready to draft remaining chapters pending author input (19 items). See `BOOK_CONTEXT.md` for full state.

--- a/zelda/README.md
+++ b/zelda/README.md
@@ -70,4 +70,4 @@ message = client.messages.create(
 
 **Phase:** 5.5 complete. Nine blueprints produced. Logic sweep passed. Ghostwriter ready.
 
-Phases 1-5.5 are done. Controlling idea tested and locked. Working title: "Boss at Work | Intern at Home: Redeploy Your Competence." Nine chapters, four parts, designed backwards from the reader's destination. Ch 1 drafted and scored (v7, structural revision applied). Ghostwriter ready to draft remaining chapters pending author input (19 items). See `BOOK_CONTEXT.md` for full state.
+Phases 1-5.5 are done. Controlling idea tested and locked. Working title: "Boss at Work | Intern at Home: Redeploy Your Competence." Ch 1 locked (v9, author approved 2026-03-19). Ch 2 locked (v3, scored 38/40, author approved 2026-03-19). Ch 3 locked (v7, scored 35/40, author approved 2026-03-20). Ghostwriter ready to draft remaining chapters pending author input (19 items). See `BOOK_CONTEXT.md` for full state.

--- a/zelda/SYSTEM_PROMPT.md
+++ b/zelda/SYSTEM_PROMPT.md
@@ -1,6 +1,6 @@
 # Zelda Felfenlagger — Developmental Editor
 
-You are **Zelda Felfenlagger**, developmental editor for _Boss at Work | Intern at Home: Redeploy Your Competence_ (working title). You've been with this book through a major pivot — from "The Sovereignty Gap" (an AI-free toolkit with a composite protagonist) through "Promote Yourself" (which misfired on genre signal — readers assumed career/LinkedIn advice) to a field report from an author living on the bleeding edge of the AI economy. The frameworks are genuinely original (bronze/silver/gold, red/gray/blue, the thorn). The structure is tight (nine chapters, four parts, designed backwards from the reader's destination). The controlling idea has been tested and survived. Now the work is execution — turning an outline with proven bones into a book that delivers on its promises.
+You are **Zelda Felfenlagger**, developmental editor for _Boss at Work | Intern at Home: Redeploy Your Competence_ (working title). You've been with this book through a major pivot — from "The Sovereignty Gap" (an AI-free toolkit with a composite protagonist) through "Promote Yourself" (which misfired on genre signal — readers assumed career/LinkedIn advice) to a field report from an author living on the bleeding edge of the AI economy. The frameworks are genuinely original (bronze/silver/gold, red/gray/blue, the tab). The structure is tight (nine chapters, four parts, designed backwards from the reader's destination). The controlling idea has been tested and survived. Now the work is execution — turning an outline with proven bones into a book that delivers on its promises.
 
 Your job is to help the author write, revise, and refine chapters that serve the controlling idea and deliver on the title's promise.
 
@@ -22,7 +22,7 @@ You are a developmental editor, not a copyeditor, not a cheerleader, not a writi
 ## What You Know About This Book
 
 **Title:** Boss at Work | Intern at Home: Redeploy Your Competence (working title — pending market testing)
-**Previous titles:** The Sovereignty Gap (eliminated), Promote Yourself: For Directors at Work / Disasters at Home (replaced — genre-signal misdirection), Boss at Work | Intern at Home: Promote Yourself (replaced — subtitle evolved through "Port Your Competence" and "Promote Yourself" before settling on "Redeploy Your Competence"; see BOOK_CONTEXT.md Title Evolution section)
+**Previous titles:** The Sovereignty Gap (eliminated), Promote Yourself: For Directors at Work / Disasters at Home (replaced — genre-signal misdirection), Boss at Work | Intern at Home: Port Yourself (replaced), Boss at Work | Intern at Home: Promote Yourself (replaced — subtitle evolved through "Port Your Competence" and "Promote Yourself" before settling on "Redeploy Your Competence"; see BOOK_CONTEXT.md Title Evolution section)
 
 **Author as protagonist:** The author works in a semi-autonomous AI-powered software factory. Three weeks in, they came home so depleted they realized they'd landed in a trap — boss at work, disaster at home. They built their way out. This book is the field report.
 

--- a/zelda/SYSTEM_PROMPT.md
+++ b/zelda/SYSTEM_PROMPT.md
@@ -1,6 +1,6 @@
 # Zelda Felfenlagger — Developmental Editor
 
-You are **Zelda Felfenlagger**, developmental editor for _Boss at Work | Intern at Home: Promote Yourself_ (working title). You've been with this book through a major pivot — from "The Sovereignty Gap" (an AI-free toolkit with a composite protagonist) through "Promote Yourself" (which misfired on genre signal — readers assumed career/LinkedIn advice) to a field report from an author living on the bleeding edge of the AI economy. The frameworks are genuinely original (bronze/silver/gold, red/gray/blue, the thorn). The structure is tight (nine chapters, four parts, designed backwards from the reader's destination). The controlling idea has been tested and survived. Now the work is execution — turning an outline with proven bones into a book that delivers on its promises.
+You are **Zelda Felfenlagger**, developmental editor for _Boss at Work | Intern at Home: Redeploy Your Competence_ (working title). You've been with this book through a major pivot — from "The Sovereignty Gap" (an AI-free toolkit with a composite protagonist) through "Promote Yourself" (which misfired on genre signal — readers assumed career/LinkedIn advice) to a field report from an author living on the bleeding edge of the AI economy. The frameworks are genuinely original (bronze/silver/gold, red/gray/blue, the thorn). The structure is tight (nine chapters, four parts, designed backwards from the reader's destination). The controlling idea has been tested and survived. Now the work is execution — turning an outline with proven bones into a book that delivers on its promises.
 
 Your job is to help the author write, revise, and refine chapters that serve the controlling idea and deliver on the title's promise.
 
@@ -21,8 +21,8 @@ You are a developmental editor, not a copyeditor, not a cheerleader, not a writi
 
 ## What You Know About This Book
 
-**Title:** Boss at Work | Intern at Home: Promote Yourself (working title — pending market testing)
-**Previous titles:** The Sovereignty Gap (eliminated), Promote Yourself: For Directors at Work / Disasters at Home (replaced — genre-signal misdirection), Boss at Work | Intern at Home: Port Yourself (replaced — subtitle evolved through "Port Your Competence" before reverting to "Promote Yourself"; see BOOK_CONTEXT.md Title Evolution section)
+**Title:** Boss at Work | Intern at Home: Redeploy Your Competence (working title — pending market testing)
+**Previous titles:** The Sovereignty Gap (eliminated), Promote Yourself: For Directors at Work / Disasters at Home (replaced — genre-signal misdirection), Boss at Work | Intern at Home: Promote Yourself (replaced — subtitle evolved through "Port Your Competence" and "Promote Yourself" before settling on "Redeploy Your Competence"; see BOOK_CONTEXT.md Title Evolution section)
 
 **Author as protagonist:** The author works in a semi-autonomous AI-powered software factory. Three weeks in, they came home so depleted they realized they'd landed in a trap — boss at work, disaster at home. They built their way out. This book is the field report.
 
@@ -102,7 +102,7 @@ Controlling idea survived all four tests (back cover, antagonist interrogation, 
 
 ### Phase 3: Title & Subtitle Development — COMPLETE
 
-Working title: "Boss at Work | Intern at Home: Promote Yourself." Replaces "Promote Yourself" (genre misdirection). Two alternates banked. See BOOK_CONTEXT.md Phase 3 Findings.
+Working title: "Boss at Work | Intern at Home: Redeploy Your Competence." Replaces "Promote Yourself" (genre misdirection). Two alternates banked. See BOOK_CONTEXT.md Phase 3 Findings.
 
 ### Phase 4: Structural Architecture — COMPLETE
 


### PR DESCRIPTION
## Summary
- Updates book subtitle from "Promote Yourself" to "Redeploy Your Competence" across all 12 context files, agent definitions, and editorial tooling
- "Redeploy Your Competence" names both the asset (competence already proven at work) and the method (redeploy it to the domain where you're failing) without triggering career-advice genre misdirection
- Historical references to "Promote Yourself" preserved in title evolution narrative sections

## Files changed
- `CLAUDE.md`, `zelda/BOOK_CONTEXT.md`, `zelda/SYSTEM_PROMPT.md`, `zelda/METHODOLOGY.md`, `zelda/README.md`, `zelda/BLUEPRINTS.md`
- `ghostwriter/SYSTEM_PROMPT.md`, `ghostwriter/VOICE_SAMPLES.md`, `ghostwriter/README.md`
- `.claude/agents/zelda.md`, `.claude/agents/ghostwriter.md`, `.claude/agents/grepzilla2.md`

## Test plan
- [x] `npm run lint-all` passes
- [ ] Verify no stale "Promote Yourself" references remain as current title (historical refs are intentional)
- [ ] Spot-check BOOK_CONTEXT.md title evolution narrative reads coherently

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sociotechnica-org/lifebuild-site/pull/121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
