### PR TITLE
Add cognitive-lab/SESSION_PROMPTS.md

### DIFF
--- a/.claude/agents/quenton-quince.md
+++ b/.claude/agents/quenton-quince.md
@@ -6,7 +6,7 @@ model: claude-opus-4-7
 color: orange
 ---
 
-You are **Quenton Quince**, design collaborator for the cognitive lab and the framework underlying *The 7 Turn Work Week*.
+You are **Quenton Quince**, design collaborator for the cognitive lab and the framework underlying _The 7 Turn Work Week_.
 
 ## Step 1: Load your brain
 

--- a/cognitive-lab/SESSION_PROMPTS.md
+++ b/cognitive-lab/SESSION_PROMPTS.md
@@ -22,7 +22,7 @@ The 7 Turn Work Week framework. Pick up where we left off.
 Today: [WHAT YOU WANT TO DO]
 ```
 
-Quenton's load-brain procedure runs automatically: he reads `quenton-quince/SYSTEM_PROMPT.md`, `METHODOLOGY.md`, `LAB_CONTEXT.md`, `PLAYS.md`, and `PRINCIPLES.md`. He'll orient on the lab state himself.
+Quenton's load-brain procedure (defined in `.claude/agents/quenton-quince.md`) instructs him to read `quenton-quince/SYSTEM_PROMPT.md`, `METHODOLOGY.md`, `LAB_CONTEXT.md`, `PLAYS.md`, and `PRINCIPLES.md` on launch. The short form relies on this — use the long form below if returning after a gap, switching branches, or any time you want the lab state explicitly re-oriented.
 
 ---
 
@@ -43,14 +43,19 @@ Orient by reading:
   cognitive-lab/cognitive-lab-v0.1.html
 
 State of play (update this section as the framework evolves):
-- Frame Workshop is shipped (v0.2 four-batch form: Scope / Outcome /
-  Approach / Safety; lived-tested 2026-05-01).
-- Pilot Check Station is shipped (three-dimension rule-out:
-  cognitive king / emotional / physical, threshold ≤3 = grounded).
+- Frame Workshop: prototype shipped, v0.2 four-batch form (Scope /
+  Outcome / Approach / Safety) lived-tested 2026-05-01. LAB-001 marked
+  live; LAB-002 (chapter outline) still in-progress.
+- Pilot Check Station: workshop and prototype shipped (three-dimension
+  rule-out: cognitive king / emotional / physical, threshold ≤3 =
+  grounded). LAB-007 (form refinement) and LAB-008 (chapter) still
+  in-progress.
 - Two central images: cache-game (Frame's organizing metaphor) and
   heartbeat (Gauge↔Recovery rhythm).
 - Capacity check-in PoC and Pilot Check converge into a unified Gauge
-  instrument (LAB-025, queued).
+  instrument. Two related backlog items: LAB-025 (Make the Gauge a
+  workshop, embed capacity check-in) and LAB-021 (Capacity check-in
+  v0.2, turn-aware data model). Both P1.
 - Quenton (you) and Larry Moleman are project-resident agents (PR #123).
 - grepzilla2 covers cognitive-lab/ now (PR #126); use for markdown-heavy
   PRs that Devin skips.
@@ -143,7 +148,7 @@ End the session by running Larry's Session-Integration play.
 
 ## What's automatic — don't bother specifying
 
-Quenton on launch:
+### Quenton on launch
 
 - Reads SYSTEM_PROMPT, METHODOLOGY, LAB_CONTEXT, PLAYS, PRINCIPLES
 - Reads the relevant area's recent Log entries before proposing
@@ -154,7 +159,7 @@ Quenton on launch:
 - Hands operational follow-up to Larry without being asked
 - Closes sessions with what was decided / what's queued / next step
 
-Larry on launch:
+### Larry on launch
 
 - Reads SYSTEM_PROMPT, JOB_CATALOG, PLAYS, LAB_CONTEXT
 - Returns receipts in the standard format (Did / Noticed / Queued)

--- a/cognitive-lab/SESSION_PROMPTS.md
+++ b/cognitive-lab/SESSION_PROMPTS.md
@@ -1,0 +1,184 @@
+# Cognitive Lab — Session Prompts
+
+How to start (and close) a session in the cognitive lab. Sibling to `PROCESS.md` (how the lab works) and `DECISIONS.md` (what's been decided).
+
+Last meaningful update: 2026-05-02. Update this file when:
+
+- The state-of-play summary in the long form goes stale
+- The current "urgent priority" example shifts
+- A new agent joins the system
+- The session-close prompt becomes optional (after Debrief Workshop ships, integration moves into Debrief itself)
+
+---
+
+## Standing invocation (any session, short)
+
+The default. Use this once you've oriented Quenton at least once on the current state of the lab.
+
+```
+Launch Quenton Quince. We're working in the cognitive lab on
+The 7 Turn Work Week framework. Pick up where we left off.
+
+Today: [WHAT YOU WANT TO DO]
+```
+
+Quenton's load-brain procedure runs automatically: he reads `quenton-quince/SYSTEM_PROMPT.md`, `METHODOLOGY.md`, `LAB_CONTEXT.md`, `PLAYS.md`, and `PRINCIPLES.md`. He'll orient on the lab state himself.
+
+---
+
+## Pick-up-where-we-left-off (longer, first session on a new branch)
+
+Use this when starting fresh on a new branch (or returning after a gap), so Quenton picks up the right state-of-play without you having to re-explain.
+
+```
+Launch Quenton Quince to pick up cognitive-lab work.
+
+Orient by reading:
+- cognitive-lab/DECISIONS.md (decisions log)
+- cognitive-lab/PROCESS.md (agent composition, two central images,
+  daily/weekly rhythm)
+- quenton-quince/PLAYS.md and PRINCIPLES.md (your playbook + heuristics)
+- The Log tile (experiments array) of frame-workshop, pilot-check-station,
+  debrief-booth, the-gauge, transition-hallway in
+  cognitive-lab/cognitive-lab-v0.1.html
+
+State of play (update this section as the framework evolves):
+- Frame Workshop is shipped (v0.2 four-batch form: Scope / Outcome /
+  Approach / Safety; lived-tested 2026-05-01).
+- Pilot Check Station is shipped (three-dimension rule-out:
+  cognitive king / emotional / physical, threshold ≤3 = grounded).
+- Two central images: cache-game (Frame's organizing metaphor) and
+  heartbeat (Gauge↔Recovery rhythm).
+- Capacity check-in PoC and Pilot Check converge into a unified Gauge
+  instrument (LAB-025, queued).
+- Quenton (you) and Larry Moleman are project-resident agents (PR #123).
+- grepzilla2 covers cognitive-lab/ now (PR #126); use for markdown-heavy
+  PRs that Devin skips.
+
+Urgent priority (update as priorities shift):
+- LAB-032 (P0): Bootstrap Debrief Workshop. Its absence creates
+  session-end integration debt. Until it ships, Larry's
+  Session-Integration play substitutes.
+
+Today: [WHAT YOU WANT TO DO]
+```
+
+After Quenton orients in that first session, drop back to the standing short form for subsequent ones.
+
+---
+
+## Session-close (Larry's Session-Integration play)
+
+Important. Run at the end of every session **until the Debrief Workshop is shipped (LAB-032)**. After that, Debrief invokes integration as part of its closing procedure, and this standalone call becomes optional.
+
+```
+Larry, run the Session-Integration play.
+
+Audit today's session outputs against the lab state. Add missing Log
+entries on the affected areas. Draft any chunks or To-Do items that
+should be added. Run a cross-reference check for drift between
+DECISIONS.md / PROCESS.md and the lab data. Write a master Log entry
+on director-desk capturing what was integrated and what's queued.
+```
+
+Larry's Session-Integration play (in `larry-moleman/PLAYS.md`) walks through the procedure step-by-step. He'll return a receipt of what he touched.
+
+---
+
+## Larry-only operational asks
+
+Smaller asks that don't need a full Quenton design session. Examples:
+
+```
+Launch Larry Moleman. Daily summary of lab state.
+```
+
+```
+Launch Larry Moleman. Capture this observation as a Log entry on
+[area]: [text]. Title it briefly.
+```
+
+```
+Launch Larry Moleman. Audit DECISIONS.md against the lab data.
+Flag any LAB-XXX, area, or chunk references that don't resolve.
+```
+
+Larry returns a receipt: what he touched, what he flagged, what's queued.
+
+---
+
+## Concrete example (current top priority — keep this current)
+
+For the very next session, the natural move is bootstrapping the Debrief Workshop. Update this example as priorities shift.
+
+```
+Launch Quenton Quince to pick up cognitive-lab work.
+
+Orient by reading cognitive-lab/DECISIONS.md, cognitive-lab/PROCESS.md,
+quenton-quince/PLAYS.md, and the Log tiles of frame-workshop,
+pilot-check-station, and debrief-booth in
+cognitive-lab/cognitive-lab-v0.1.html.
+
+Today: bootstrap the Debrief Workshop (LAB-032). This is the URGENT
+priority — Debrief's absence creates the session-end integration debt
+Larry's Session-Integration play has been substituting for. Apply the
+Bootstrap-a-Workshop play:
+
+1. Wildcat the Debrief on a recent turn (5 min, no template, just
+   talk it through).
+2. Design the form from the lived data — same four-batch chunking
+   thinking we used for Frame.
+3. Build the workshop prototype: mark debrief-booth area
+   workshop:true; build the form as the resting/editing/viewing
+   mode-state machine; wire save handler to auto-Log each Debrief.
+4. Seed Chapter chunks from After-Action Review (US Army),
+   reflection theory (Kolb, Schön), and surgical post-op debriefs.
+5. Update LAB-003 (Debrief form) and LAB-004 (Debrief chapter)
+   status as you go.
+
+End the session by running Larry's Session-Integration play.
+```
+
+---
+
+## What's automatic — don't bother specifying
+
+Quenton on launch:
+
+- Reads SYSTEM_PROMPT, METHODOLOGY, LAB_CONTEXT, PLAYS, PRINCIPLES
+- Reads the relevant area's recent Log entries before proposing
+- Won't relitigate decisions in DECISIONS.md
+- Leads with opinionated proposals + tradeoff tables
+- Cites specific research (Sweller, Hobfoll, Sonnentag, Hockey, Leroy, Klein, Wickens, Risko & Gilbert)
+- Pushes back on weak ideas (acronym-driven structure, forced metaphors, duplicate tools)
+- Hands operational follow-up to Larry without being asked
+- Closes sessions with what was decided / what's queued / next step
+
+Larry on launch:
+
+- Reads SYSTEM_PROMPT, JOB_CATALOG, PLAYS, LAB_CONTEXT
+- Returns receipts in the standard format (Did / Noticed / Queued)
+- Routes work that exceeds his role to the right agent
+- Won't fabricate state — surfaces "Couldn't do" with what would unblock
+
+---
+
+## When to use which form
+
+| Situation | Form |
+|---|---|
+| First session on a new branch, or returning after a gap | Pick-up-where-we-left-off (long) |
+| Subsequent sessions on the same branch | Standing invocation (short) |
+| Quick operational ask (no design work) | Larry-only |
+| End of any design session | Session-close (Larry) |
+| Fresh start on a specific high-priority workshop | Concrete example (current top priority) |
+
+---
+
+## Notes on evolution
+
+This file is meant to stay current. Edit it when the state-of-play summary goes stale or the urgent-priority example shifts. The framework is being built while being used; the prompts that kick off sessions need to keep up.
+
+When the Debrief Workshop ships, the session-close section becomes optional — Debrief itself invokes the integration as part of its closing procedure. Update the section header at that point.
+
+When new agents join the system (e.g., a "Cookie" agent for some specialized role), add their invocation patterns here.

--- a/larry-moleman/JOB_CATALOG.md
+++ b/larry-moleman/JOB_CATALOG.md
@@ -33,6 +33,7 @@ Every operational observation becomes a Log entry on the relevant area.
 7. Update the floor's experiments count for that area.
 
 **When to title:**
+
 - If the author dictated the entry, ask whether they want to title it or accept your draft.
 - If auto-generating from a status transition, use the canonical form: `Shipped: LAB-XXX — [item title]`.
 
@@ -57,6 +58,7 @@ The Debrief Booth's prototype is still being designed. Until it's built, capture
 The status cycle is: **backlog → in-progress → drafted → live → archived**.
 
 Hygiene tasks:
+
 - When the author says an item shipped, cycle it to `live` (which auto-Logs the transition).
 - When the author retires an item, cycle it to `archived`.
 - Surface items that have been `in-progress` or `drafted` for an unusually long time as candidates for review.
@@ -90,6 +92,7 @@ Chunks are markdown-ish (whitespace and line breaks preserved). Don't try to mak
 ### 2.4 Cross-reference checks
 
 When the framework changes, check that:
+
 - The deck slides (`cognitive-lab/turn-v0.1-map.html`) still match the framework's current state.
 - The phases-and-leverage doc still describes phases the same way the lab represents them.
 - LAB item briefs still match the actual scope of the work.
@@ -107,6 +110,7 @@ Your editing scope is **clarity**, not voice.
 - Standardize formatting (Markdown bullets, headings).
 
 What to NOT do:
+
 - Don't rewrite for the author's voice. That's ghostwriter's job.
 - Don't restructure the chunk unless asked.
 - Don't change the meaning while tightening; if a sentence is unclear, surface it for the author rather than guess.
@@ -164,23 +168,23 @@ You flag; the author re-assigns.
 
 When the work exceeds your role, name the next agent and the specific job.
 
-| Trigger | Route to | What to ask them |
-|---|---|---|
-| Architectural / design call | **Quenton Quince** | "Quenton, the author is asking [question]. Could you take this?" |
-| Book editorial / chapter analysis | **Zelda** | "This is chapter-structural work — Zelda's territory." |
-| Voice-matched chapter prose | **ghostwriter** | "Chunk is ready for prose; ghostwriter, please draft in the labnotes register." |
-| Code review on the Astro site | **grepzilla2** | "Site changes need a review; grepzilla2, please run the standard checks." |
+| Trigger                           | Route to           | What to ask them                                                                |
+| --------------------------------- | ------------------ | ------------------------------------------------------------------------------- |
+| Architectural / design call       | **Quenton Quince** | "Quenton, the author is asking [question]. Could you take this?"                |
+| Book editorial / chapter analysis | **Zelda**          | "This is chapter-structural work — Zelda's territory."                          |
+| Voice-matched chapter prose       | **ghostwriter**    | "Chunk is ready for prose; ghostwriter, please draft in the labnotes register." |
+| Code review on the Astro site     | **grepzilla2**     | "Site changes need a review; grepzilla2, please run the standard checks."       |
 
 Don't try to do their work. Hand off cleanly with the specific ask.
 
 ## Common operations — quick reference
 
-| Operation | Files touched |
-|---|---|
-| Auto-Log on status → live | `cognitive-lab/cognitive-lab-v0.1.html` (the experiments array of the item's area) |
-| Add a Source | `cognitive-lab/cognitive-lab-v0.1.html` (the area's `sources` array) |
-| Add a Chunk | `cognitive-lab/cognitive-lab-v0.1.html` (the area's `chunks` array) |
-| Add a To-Do | `cognitive-lab/cognitive-lab-v0.1.html` (items dictionary + the area's items array + Backlog Wall items) |
-| Update LAB-XXX brief | `cognitive-lab/cognitive-lab-v0.1.html` (items dictionary entry) |
+| Operation                 | Files touched                                                                                            |
+| ------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Auto-Log on status → live | `cognitive-lab/cognitive-lab-v0.1.html` (the experiments array of the item's area)                       |
+| Add a Source              | `cognitive-lab/cognitive-lab-v0.1.html` (the area's `sources` array)                                     |
+| Add a Chunk               | `cognitive-lab/cognitive-lab-v0.1.html` (the area's `chunks` array)                                      |
+| Add a To-Do               | `cognitive-lab/cognitive-lab-v0.1.html` (items dictionary + the area's items array + Backlog Wall items) |
+| Update LAB-XXX brief      | `cognitive-lab/cognitive-lab-v0.1.html` (items dictionary entry)                                         |
 
 For workspace-local development before the merge, paths may live under `.context/` instead of `cognitive-lab/`. Check both.

--- a/larry-moleman/LAB_CONTEXT.md
+++ b/larry-moleman/LAB_CONTEXT.md
@@ -100,23 +100,23 @@ Find the area's `"chunks": [` and prepend the new chunk, or update an existing o
 
 ## Areas in the lab (for routing)
 
-| Area ID | Name | Workshop? |
-|---|---|---|
-| `frame-workshop` | Frame Workshop | yes |
-| `comprehend-station` | Comprehend Station | no |
-| `sync-floor` | Sync Floor | no |
-| `push-bay` | Produce Bay | no |
-| `debrief-booth` | Debrief Booth | no |
-| `recovery-room` | Recovery Room | no |
-| `the-gauge` | The Gauge | no |
-| `pilot-check-station` | Pilot Check Station | yes |
-| `transition-hallway` | Transition Hallway | no |
-| `trim-bench` | Trim Bench | no |
-| `library` | The Library | no |
-| `archive` | The Archive | no |
-| `backlog-wall` | Backlog Wall | no |
-| `deck-theater` | Deck Theater | no |
-| `director-desk` | Director's Desk | no |
+| Area ID               | Name                | Workshop? |
+| --------------------- | ------------------- | --------- |
+| `frame-workshop`      | Frame Workshop      | yes       |
+| `comprehend-station`  | Comprehend Station  | no        |
+| `sync-floor`          | Sync Floor          | no        |
+| `push-bay`            | Produce Bay         | no        |
+| `debrief-booth`       | Debrief Booth       | no        |
+| `recovery-room`       | Recovery Room       | no        |
+| `the-gauge`           | The Gauge           | no        |
+| `pilot-check-station` | Pilot Check Station | yes       |
+| `transition-hallway`  | Transition Hallway  | no        |
+| `trim-bench`          | Trim Bench          | no        |
+| `library`             | The Library         | no        |
+| `archive`             | The Archive         | no        |
+| `backlog-wall`        | Backlog Wall        | no        |
+| `deck-theater`        | Deck Theater        | no        |
+| `director-desk`       | Director's Desk     | no        |
 
 This list will grow as more areas become workshops and as new areas are added.
 

--- a/quenton-quince/LAB_CONTEXT.md
+++ b/quenton-quince/LAB_CONTEXT.md
@@ -37,33 +37,38 @@ Then open `http://localhost:8765/cognitive-lab-v0.1.html`.
 The lab is a top-down, click-to-explore floor plan with four bands:
 
 **Band 1 — Reference / aux** (gestalt visuals, hover for label):
+
 - The Library (research)
 - The Archive (lab notes, decisions, shipped)
 - Deck Theater (the v0.2 presentation)
 - Backlog Wall (priority list)
 
 **Band 2 — Phase cycle** (six rooms left-to-right):
+
 - Frame · Comprehend · Sync · Produce (formerly Push) · Debrief · Recover
 
 **Band 3 — Meta-disciplines:**
+
 - Transition Hallway · Trim Bench
 
 **Band 4 — Bottom (instruments + Director):**
+
 - The Gauge · Pilot Check Station · Director's Desk
 
 Click any area opens a side drawer (drawer expands to 66vw if the area has `workshop: true`). Drawers contain:
+
 - A description (shown via the (i) tooltip in the header)
 - Top half: the prototype (forms, sliders) — workshop areas only
 - Bottom half: the four-tile floor shelf — **To Do · Log · Chapter · Sources**
 
 ## The four-tile shelf (every area)
 
-| Tile | What lives here |
-|---|---|
-| **✓ To Do** | Forward-looking work — items to build, run, or write |
-| **📓 Log** | Backward-looking observations — what happened during runs, what was noticed, what changed |
-| **📚 Chapter** | Book material as chunks (title → summary → longform body). Chunks are editable. |
-| **📎 Sources** | Inputs — research references, past versions, related files |
+| Tile           | What lives here                                                                           |
+| -------------- | ----------------------------------------------------------------------------------------- |
+| **✓ To Do**    | Forward-looking work — items to build, run, or write                                      |
+| **📓 Log**     | Backward-looking observations — what happened during runs, what was noticed, what changed |
+| **📚 Chapter** | Book material as chunks (title → summary → longform body). Chunks are editable.           |
+| **📎 Sources** | Inputs — research references, past versions, related files                                |
 
 Items have stable IDs (LAB-001, LAB-002, etc.). Status cycles: backlog → in-progress → drafted → live → archived. When an item moves to live or archived, an auto-Log entry captures the transition.
 

--- a/quenton-quince/METHODOLOGY.md
+++ b/quenton-quince/METHODOLOGY.md
@@ -57,12 +57,12 @@ After building:
 
 You don't do everything. Recognize when work belongs elsewhere:
 
-| Agent | Their domain |
-|---|---|
-| **Larry Moleman** | Operational tasks, capture, status hygiene, daily summaries, light prose polish |
-| **Zelda** | Book editorial — chapter analysis, controlling-idea work, structural diagnosis |
-| **ghostwriter** | Voice-matched chapter prose in the labnotes register |
-| **grepzilla2** | Code/content review for the broader Astro site (book chapters, changelog, frontmatter) |
+| Agent             | Their domain                                                                           |
+| ----------------- | -------------------------------------------------------------------------------------- |
+| **Larry Moleman** | Operational tasks, capture, status hygiene, daily summaries, light prose polish        |
+| **Zelda**         | Book editorial — chapter analysis, controlling-idea work, structural diagnosis         |
+| **ghostwriter**   | Voice-matched chapter prose in the labnotes register                                   |
+| **grepzilla2**    | Code/content review for the broader Astro site (book chapters, changelog, frontmatter) |
 
 Hand-offs should name the agent and the specific job. "Larry, please log this change and update LAB-007 status" is good. "Someone should follow up" is bad.
 

--- a/quenton-quince/README.md
+++ b/quenton-quince/README.md
@@ -1,6 +1,6 @@
 # Quenton Quince
 
-Design collaborator for the cognitive lab and the framework underlying *The 7 Turn Work Week*. Co-architects with the author. Pushes back. Names tradeoffs. Defers judgment calls.
+Design collaborator for the cognitive lab and the framework underlying _The 7 Turn Work Week_. Co-architects with the author. Pushes back. Names tradeoffs. Defers judgment calls.
 
 ## Files
 

--- a/quenton-quince/SYSTEM_PROMPT.md
+++ b/quenton-quince/SYSTEM_PROMPT.md
@@ -1,6 +1,6 @@
 # Quenton Quince — System Prompt
 
-You are **Quenton Quince**, design collaborator for the cognitive lab and the framework underlying *The 7 Turn Work Week*. Your job is to think through design problems with the author — propose, push back, name tradeoffs, and build artifacts together when green-lit.
+You are **Quenton Quince**, design collaborator for the cognitive lab and the framework underlying _The 7 Turn Work Week_. Your job is to think through design problems with the author — propose, push back, name tradeoffs, and build artifacts together when green-lit.
 
 ## What you are
 
@@ -10,7 +10,7 @@ You hold three things in your head simultaneously:
 
 1. **The framework.** The phase structure (Frame · Comprehend · Sync · Push · Debrief · Recover), meta-disciplines (Transition · Trim), the Gauge as continuous capacity instrument, and the central images (the cache-game, the heartbeat).
 2. **The lab.** The interactive workshop where the framework is being built. Areas, items, chunks, experiments, sources. Live state.
-3. **The book.** *The 7 Turn Work Week* in progress, with the chapter material accumulating in the lab's Chapter chunks. Eventually flowing to ghostwriter and Zelda.
+3. **The book.** _The 7 Turn Work Week_ in progress, with the chapter material accumulating in the lab's Chapter chunks. Eventually flowing to ghostwriter and Zelda.
 
 You design across all three. You don't write final book voice. You don't operate the lab. You don't do deep editorial. Those have other agents.
 


### PR DESCRIPTION
## Summary

Durable home for session-start and session-close prompts in the cognitive lab. Sibling to `PROCESS.md` (how the lab works) and `DECISIONS.md` (what's been decided).

Until now the prompts that kick off sessions have lived only in conversation transcripts. This PR captures them as a maintained reference so future sessions can copy-paste the right block, and so the framework's evolution stays current with the prompts.

## What's in the PR

One file: `cognitive-lab/SESSION_PROMPTS.md`. Five sections:

1. **Standing invocation (short)** — for any session after the first on a branch
2. **Pick-up-where-we-left-off (long)** — for the first session on a new branch; includes current state-of-play and urgent priority (LAB-032 Debrief Workshop bootstrap)
3. **Session-close** — Larry's Session-Integration play; runs at end of every session until Debrief Workshop ships
4. **Larry-only operational asks** — smaller calls that don't need Quenton's design judgment
5. **Concrete example for current top priority** — Debrief Workshop bootstrap walked through

Plus reference sections: what's automatic (don't bother specifying), when to use which form, notes on evolution.

## Why now

The user just closed a long design session and asked where the session-startup prompt should live. Previously I'd recommended saving it 'somewhere durable' — this PR makes the lab itself the durable home, alongside the other meta-process docs.

## Maintenance

The file is meant to stay current. Update when:
- State-of-play summary goes stale
- Urgent-priority example shifts (currently Debrief Workshop)
- New agents join the system
- Session-close prompt becomes optional (after Debrief Workshop ships, integration moves into Debrief itself)

## Test plan

- [ ] Verify prettier passes (already verified locally)
- [ ] Verify the long-form prompt's state-of-play matches actual lab state at PR open
- [ ] Verify all referenced files exist (`cognitive-lab/DECISIONS.md`, `cognitive-lab/PROCESS.md`, `quenton-quince/PLAYS.md` etc.)
- [ ] Smoke test in next session: copy the pick-up-where-we-left-off block; confirm Quenton orients correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)