### PR TITLE
Course tier + Build canvas + Comprehend Station (v0.1→v0.4 arc)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"dbc93a0c-d15a-493e-ae9d-2bcd6e6880c8","pid":4760,"procStart":"Mon May  4 17:36:00 2026","acquiredAt":1777927124884}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"dbc93a0c-d15a-493e-ae9d-2bcd6e6880c8","pid":4760,"procStart":"Mon May  4 17:36:00 2026","acquiredAt":1777927124884}

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ pnpm-debug.log*
 # package-lock.json
 yarn.lock
 pnpm-lock.yaml
+.claude/

--- a/cognitive-lab/DECISIONS.md
+++ b/cognitive-lab/DECISIONS.md
@@ -6,6 +6,18 @@ Entries are reverse-chronological (newest first). Each has: date, decision, reas
 
 ---
 
+## 2026-05-04 (evening) · Hex Map v0.3 — concentric rings + map-legend palette
+
+**Decision.** Hex Map v0.3 drops the red P0 stroke and replaces stroke-as-priority with spatial position: concentric rings carry priority (P0 center → P1 → P2). The palette moves to Okabe-Ito (color-blind safe). An explicit map legend names each area → color, the way a geographic map names blue = water. Hover reveals genus:species identity (area name + item name); per-hex LAB-### labels are dropped.
+
+**Reasoning.** The author dogfooded v0.2 and found the red borders distracting — the stroke was competing with biome color in the same visual layer, creating the same channel-collision problem v0.2 was designed to fix. Concentric rings resolve this by encoding priority through position (a distinct channel from color and stroke). The Okabe-Ito palette with an explicit legend makes the map readable as a map — the reader doesn't infer color meaning from context; the legend states it. Genus:species hover frees the hex face to carry only its color signal; identity is revealed on demand rather than baked into the face as text clutter.
+
+**Status.** Active. Shipped on branch `danversfleury/lab-course-tier` (commits `6c40ddb` and `664e479`).
+
+**References.** Commits `6c40ddb` (concentric rings + palette + legend + hover) and `664e479` (fixes: drop dead .pulse-once.p0 rule, escape priority/status, document palette collision), `cognitive-lab/cognitive-lab-v0.1.html` (chunk-hex-map-v03).
+
+---
+
 ## 2026-05-04 (evening) · Frontier-first Frame picker with expand
 
 **Decision.** The per-leg Frame picker defaults to the active Course's frontier. Expand to Full lab is the deliberate emergence valve. Off-frontier picks are tagged with `ref.off_frontier=true` and shown with a chip badge. The strict-only and glow-only alternatives were rejected.

--- a/cognitive-lab/DECISIONS.md
+++ b/cognitive-lab/DECISIONS.md
@@ -6,6 +6,30 @@ Entries are reverse-chronological (newest first). Each has: date, decision, reas
 
 ---
 
+## 2026-05-04 (late) · Build canvas v0.1 — snap-circuit grid, lens architecture, HTML tooltip; LAB-043/044/046 reclassified
+
+**Decision.** Four framework-level calls shipped in the v0.4 arc (branch `danversfleury/lab-course-tier`, 14 commits since `7437bc4`):
+
+1. **Build canvas v0.1 ships (click-to-place; not drag-and-drop).** The Course view gains a user-authored snap-circuit grid (7×10 cells, ARIA grid). The author places items from the tool drawer onto the grid; positions persist in `course.build_positions`. Template apply and Clear board are first-class actions. Drag-and-drop was explicitly deferred per Quenton's design call — ship click-to-place first, then let dogfood surface whether DnD is worth the cost (LAB-049).
+
+2. **Lens architecture (one canvas, three lenses).** The Course view now has three tabs: Build (default, author-owned canvas) / By function (v0.2 biome Hex Map, restored as a reference lens) / By priority (v0.3 concentric-rings Hex Map). The active lens persists in localStorage. The two Hex Map lenses are read-only re-projections of the underlying lab data; the Build lens is the only authoring surface. `wireHexSVGListeners` was consolidated to fix double-registration on lens switch.
+
+3. **Snap-circuits-with-build-book reframe.** The architectural pivot driving v0.4: snap circuits ship with a build book — a catalog of circuits you can build. The lab should give the user a board, a parts bin, and a builds book (templates = release plans in planning status) rather than generating maps for them. Kay's principle redirected at the user: *"It's easier to build a diagram than read a diagram."* The user building their own placement learns the structure; reading an auto-generated map consumes it.
+
+4. **HTML tooltip pattern (instant hex hover).** SVG `<title>` has a 1-second browser delay. Replaced with an HTML tooltip layer (z-index 450, above toolbar), driven by `mousemove`. `aria-label` replaces `<title>` on each polygon to suppress the duplicate native browser tooltip while preserving accessibility. Pattern is reusable for any future SVG with polygons needing instant hover identity.
+
+**Data hygiene.** LAB-043, LAB-044, and LAB-046 carried invalid `"P3"` priority values in their `priority` fields (the schema enum is P0/P1/P2). All three were promoted to `"P2 (later)"` to match the v0.2 priority spec enum. This was caught during the cumulative sweep and fixed before the session-close commit.
+
+**Reasoning.** The build-canvas pivot resolves the passive/active tension in the prior Hex Map: the map was *generated* from lab data, positioning the author as a reader of a system-produced artifact. The snap-circuit analogy (from Bruner/WS004, already embedded in the Leg view's circuit board) applied at the Course/week scale: give the author components and let them compose. The three-lens architecture preserves the Hex Map's value (it's a good reference view) without making it the default. Build is the primary surface because it's the one the author authors.
+
+Click-to-place over drag-and-drop is a deliberate scope constraint, not a compromise. Quenton's call: dogfood the simpler interaction first. DnD tracked as LAB-049.
+
+**Status.** Active. All four shipped on branch `danversfleury/lab-course-tier`. New deferred items: LAB-047 (Release as 4th tier), LAB-048 (Comprehend boot gate), LAB-049 (DnD v0.5+), LAB-050 (chain edges on Build canvas), LAB-051 (map world long-vision).
+
+**References.** Commits `a5de21f` (HTML tooltip), `d0171b9` (lens dispatcher, Move 3a), `43b1add` (empty snap-circuit grid, Move 3b), plus Move 3c–3e + cumulative sweep commits on branch `danversfleury/lab-course-tier`. `cognitive-lab/cognitive-lab-v0.1.html` (chunks: chunk-build-canvas-v0.1, chunk-snap-circuit-builds-book, chunk-lens-architecture, chunk-instant-hex-tooltip; items LAB-047–LAB-051).
+
+---
+
 ## 2026-05-04 (evening) · Hex Map v0.3 — concentric rings + map-legend palette
 
 **Decision.** Hex Map v0.3 drops the red P0 stroke and replaces stroke-as-priority with spatial position: concentric rings carry priority (P0 center → P1 → P2). The palette moves to Okabe-Ito (color-blind safe). An explicit map legend names each area → color, the way a geographic map names blue = water. Hover reveals genus:species identity (area name + item name); per-hex LAB-### labels are dropped.

--- a/cognitive-lab/DECISIONS.md
+++ b/cognitive-lab/DECISIONS.md
@@ -6,6 +6,78 @@ Entries are reverse-chronological (newest first). Each has: date, decision, reas
 
 ---
 
+## 2026-05-04 (evening) · Frontier-first Frame picker with expand
+
+**Decision.** The per-leg Frame picker defaults to the active Course's frontier. Expand to Full lab is the deliberate emergence valve. Off-frontier picks are tagged with `ref.off_frontier=true` and shown with a chip badge. The strict-only and glow-only alternatives were rejected.
+
+**Reasoning.** Morning dogfood surfaced the seam bug: the picker was showing the entire lab instead of the Course frontier, defeating the rogaine metaphor at the per-leg level. The expand toggle was chosen over a strict frontier-only picker because emergence is a legitimate reason to go off-frontier — something surfaces mid-leg that wasn't visible at Course-planning time. Strict-only would suppress that. Glow-only (highlight off-frontier picks without tagging) would surface the data visually but lose it for Debrief writeback. The tag + chip badge preserves both: visible to the author in the Frame, queryable by the Debrief save handler (LAB-042, deferred).
+
+**Status.** Active. Tag in place; Debrief pre-fill queued as LAB-042 (P2).
+
+**References.** Commits on branch `danversfleury/lab-course-tier` (v0.2 arc), `cognitive-lab/cognitive-lab-v0.1.html` (chunk-frontier-first-picker, LAB-042).
+
+---
+
+## 2026-05-04 (evening) · Comprehend Signals: deck-open + status-cycle auto-log; conservative surveillance line
+
+**Decision.** Comprehend auto-logs three kinds of intentional acts: `note` (manual), `synthesis` (status cycle to live/archived), `deck` (deck-open matched by DECK_FILE_RE). Frame card field activity is explicitly excluded for now.
+
+**Reasoning.** The seam bug the author caught in morning dogfood: the Comprehend zone was showing "idle" while real comprehension activity was happening elsewhere (deck walks, status cycles). The fix required a surveillance line — a principle for which acts merit a log entry. The line drawn: only acts the user *intentionally took* and *would expect to leave a record*. Status cycles and deck-opens clear this bar. Field edits in Frame (Doing / Not Doing / Approach) do not — they're exploratory; the user may type and delete without committing. Logging them would capture intent-noise. One Course of dogfood will reveal whether the signal is sparse enough to warrant expansion (LAB-044, P3).
+
+**Status.** Active. Surveillance line is a first-class constraint, not a footnote. Expansion criteria deferred to LAB-044.
+
+**References.** Branch `danversfleury/lab-course-tier` (v0.2 arc), `cognitive-lab/cognitive-lab-v0.1.html` (chunk-comprehend-signals, LAB-044, LAB-046).
+
+---
+
+## 2026-05-04 (evening) · Four-channel Hex Map encoding (hue / luminosity / stroke / motion)
+
+**Decision.** Hex Map v0.2 encodes four cognitive jobs across four independent visual channels: hue=biome (stable identity), luminosity=relevance (4-state ramp), stroke=priority (P0 → 2px ring), motion=attention (pulse on select + breath on active-leg working set). Replaces the v0.1 fill-vs-outline approach and the purple "both" override ring.
+
+**Reasoning.** Morning dogfood surfaced the misread: P0 red was winning the visual fight against biome hue, making it impossible to read frontier state independently of priority state. The v0.1 fill-vs-outline encoding was trying to carry multiple states through a single channel, which collapsed when states co-occurred. Four independent channels solve this: each type of information has its own visual grammar; they compose without ambiguity. The design follows the Bruner/Snap Circuits principle already adopted for the lab: each cognitive job gets its own representation primitive rather than overloading a single channel.
+
+**Status.** Active. All four channels shipped in the v0.2 arc.
+
+**References.** Branch `danversfleury/lab-course-tier` (v0.2 arc), `cognitive-lab/cognitive-lab-v0.1.html` (chunk-four-channel-hex-encoding).
+
+---
+
+## 2026-05-04 (evening) · Luminosity ramp (4-state: archived / available / in-frontier / active)
+
+**Decision.** The luminosity channel uses four states: 18% (archived — terrain), 50% (available — items exist but not on frontier), 100% (in-frontier — reachable this week), 100% + saturation boost (active — in current leg's working set). Steps are logarithmic-ish for perceptual evenness.
+
+**Reasoning.** Linear steps (0-25-50-100) would make the archived→available step perceptually large and the available→frontier step small — the wrong distribution for the cognitive jobs each state does. Logarithmic-ish distribution (18-50-100) makes archived recede into background (terrain), available readable but muted, frontier fully lit. The 18% floor keeps archived hexes visible as terrain context rather than invisible — the map is a map, not a spotlight. The saturation boost for active-leg distinguishes "on course frontier" from "actually in this leg's working set" without adding a fifth luminosity state.
+
+**Status.** Active.
+
+**References.** `cognitive-lab/cognitive-lab-v0.1.html` (chunk-luminosity-ramp).
+
+---
+
+## 2026-05-04 (evening) · Motion budget: pulse + breath only; prefers-reduced-motion honored
+
+**Decision.** The Hex Map uses exactly two motion behaviors: a single 600ms pulse on select, and a slow 6s ±5% ambient breath on the active-leg working set. No additional motion states. Both suppressed when prefers-reduced-motion is set.
+
+**Reasoning.** Motion is a preattentive feature — it pulls attention before the user consciously decides to look. Uncontrolled motion would pull attention out of the author's current task continuously. The cap is cognitive-load-driven: the same principle (extraneous load reduction is the highest-ROI cognitive intervention) that drives the P0 hard cap at 3 applies to motion in the UI. The pulse confirms selection without persisting; the breath signals "live right now" from the periphery without demanding focus. prefers-reduced-motion compliance is a hard constraint, not optional.
+
+**Status.** Active.
+
+**References.** `cognitive-lab/cognitive-lab-v0.1.html` (chunk-motion-budget).
+
+---
+
+## 2026-05-04 (evening) · Biome regions replace the random Hex Map grid
+
+**Decision.** Hex Map v0.2 clusters hexes into labeled, biome-tinted regions rather than a flat grid. Regions are the legend; the separate swatch row is dropped. Regions sort biggest-first. Semantic adjacency within biomes is deferred (LAB-043, P3).
+
+**Reasoning.** Morning dogfood surfaced the misread: the v0.1 grid layout looked random — spatial proximity implied relationship, but the grid had no relationship logic. This imposed extraneous load (inferring meaning from position that had none). Biome regions give the map a spatial grammar: you navigate to the turn-phases cluster or the capacity-instruments cluster, not to cell (3,2). Regions-as-legend drops the redundant swatch row — the map tells its own story. Sorting biggest-first makes the dominant cognitive territory (turn phases, 5–6 hexes) visually anchor the layout.
+
+**Status.** Active. Within-biome semantic adjacency deferred per Quenton's call — revisit after one Course of lived use shows whether it matters.
+
+**References.** `cognitive-lab/cognitive-lab-v0.1.html` (chunk-biome-regions, LAB-043).
+
+---
+
 ## 2026-05-04 · Phase 5 click-throughs and Sync form deferred to backlog
 
 **Decision.** Phase 5 of the rogaine-spine arc ships the Snap Circuit Leg view in read-only form. Click-through wiring (zone → form/drawer) and the Sync station form are explicitly deferred.

--- a/cognitive-lab/DECISIONS.md
+++ b/cognitive-lab/DECISIONS.md
@@ -6,6 +6,90 @@ Entries are reverse-chronological (newest first). Each has: date, decision, reas
 
 ---
 
+## 2026-05-04 · Phase 5 click-throughs and Sync form deferred to backlog
+
+**Decision.** Phase 5 of the rogaine-spine arc ships the Snap Circuit Leg view in read-only form. Click-through wiring (zone → form/drawer) and the Sync station form are explicitly deferred.
+
+**Reasoning.** The read-only board delivers the cognitive job (orientation at the leg scale) without requiring fully-built forms for every phase. Wiring click-throughs before all target forms exist would create dead-end interactions. The deferred items are scoped as LAB-037 (click-throughs) and LAB-035 (Sync form) — both P2, both unblocked by the current phase shipping cleanly.
+
+**Status.** Active. LAB-037 and LAB-035 in backlog.
+
+**References.** Commit `11c6cd1` (Phase 5 fixes), `cognitive-lab/cognitive-lab-v0.1.html` (LAB-035, LAB-037).
+
+---
+
+## 2026-05-04 · Course Coach named as future agent role
+
+**Decision.** A future agent role — Course Coach — is named and scoped. It reads the current Course's `legs[]` array like poker hand histories and suggests better moves for the next leg's Frame.
+
+**Reasoning.** Once 4–5 legs have completed Frame and Debrief sub-records, patterns become detectable: consistent over-scoping, frontier items that keep getting skipped, capacity mis-reads recurring on the same day-of-week. A poker-coach framing (reading hand histories, surfacing patterns, suggesting adjustments) is the right shape. Whether it's a sub-agent or top-level agent is a design call for Quenton — deferred until leg-history depth accumulates.
+
+**Status.** Active (spec only). Implementation queued as LAB-034, P2.
+
+**References.** `cognitive-lab/cognitive-lab-v0.1.html` (LAB-034, chunk-course-tier-spec).
+
+---
+
+## 2026-05-04 · Bruner / Snap Circuits design language adopted
+
+**Decision.** The lab's design language is explicitly Bruner-grounded: push every representation from symbolic toward iconic and enactive. Hex Map (Course/week scale) and Snap Circuit board (Leg/turn scale) are the first two implementations. All subsequent visual decisions are evaluated against this standard.
+
+**Reasoning.** The lab as built is heavily symbolic — text fields, JSON, written labels. Bruner's three modes (enactive / iconic / symbolic) name the gap. Alan Kay: "constructing a diagram is much less difficult than reading one." WS004 ("Beyond the Symbolic") established the Snap Circuits analogy for AI agent composition — a child snapping components is performing the architecture, not reading about it. The rogaine-spine arc brought that analogy into the lab's own UI: the five-zone circuit board makes the turn structure tactile. Every new view now starts with the question: what is the iconic/enactive equivalent of what we're expressing symbolically?
+
+**Status.** Active. Applies to all future lab UI work.
+
+**References.** `cognitive-lab/cognitive-lab-v0.1.html` (chunk-bruner-snap-design-language), WS004, commits `c554317` (Hex Map), `21f4cdc` (Snap Circuit board).
+
+---
+
+## 2026-05-04 · Two-tier visualization split (Hex Map for Course/Map, Snap Circuits for Leg)
+
+**Decision.** The lab uses two distinct visualizations that do different cognitive jobs and don't overlap: Hex Map for the Course/week scale; Snap Circuit board for the Leg/turn scale.
+
+**Reasoning.** A single visualization trying to show both week-level terrain and leg-level wiring would either be too dense or too abstract. The split lets each metaphor do its native job cleanly: the Hex Map gives bird's-eye terrain orientation (where is the work, what's in fog, what's glowing P0); the Snap Circuit board gives signal-flow orientation (how does this leg wire together, which zones are live). The two compose — you consult the map to know the week, you consult the circuit to run the leg.
+
+**Status.** Active. Hex Map v0.1 (read-only) and Snap Circuit board v0.1 (read-only) shipped. v0.2 interaction queued as LAB-041 and LAB-037.
+
+**References.** Commits `c554317` (Hex Map), `21f4cdc` (Snap Circuit board), `cognitive-lab/cognitive-lab-v0.1.html` (chunk-hex-map-course-view-v01, chunk-snap-circuit-leg-view).
+
+---
+
+## 2026-05-04 · Frontier-not-itinerary as the Course planning call
+
+**Decision.** A Course names what is *reachable* this week — items on `course.frontier[]` — not which leg hits which item. Per-leg Frame picks from the frontier at turn-start. Debrief feeds back via `changes_to_course`.
+
+**Reasoning.** The itinerary version (leg 1 = items A+B, leg 2 = C+D) violates the rogaine condition: the racer doesn't plan checkpoints in order; they choose dynamically based on terrain and capacity. An itinerary creates guilt debt and stale plans. A frontier creates feedback loops — each leg's Frame is a real-time route decision against current conditions. Quenton's formulation: "The Course names the terrain. The racer picks the route." The design also solves the self-imposed-constraint problem: a well-set frontier is genuinely larger than any seven legs can reach, preserving real selectivity at planning time.
+
+**Status.** Active. Implemented in the Course data model.
+
+**References.** `cognitive-lab/cognitive-lab-v0.1.html` (chunk-frontier-vs-itinerary, chunk-course-tier-spec, chunk-course-setter-problem-self-set).
+
+---
+
+## 2026-05-04 · "7 leg courses" naming locked to book title
+
+**Decision.** The canonical week-scale unit is a **7 leg course**. One Full Turn = one leg. One ISO week = one Course (7 legs). The naming is locked to the book title *The 7 Turn Work Week*.
+
+**Reasoning.** The three-tier model (Course → Leg → Phase) embeds the book's central claim in the data architecture. "Turn" and "leg" are synonyms at the turn scale — "leg" is the rogaine vocabulary for a segment of a larger course, making the metaphor structurally consistent. The ISO-week Course ID convention (`YYYY-WNN`) is unambiguous and human-readable. Locking the naming to the book title makes every Course in the lab a lived proof point of the book's argument.
+
+**Status.** Active. Locked 2026-05-04.
+
+**References.** `cognitive-lab/cognitive-lab-v0.1.html` (chunk-7-leg-courses-naming), branch `danversfleury/lab-course-tier`.
+
+---
+
+## 2026-05-04 · Course tier added (three-tier data model: Map → Course → Leg)
+
+**Decision.** The lab's data model gains a third tier above the existing phase-level records: Map (the lab itself) → Course (one ISO week, 7-leg arc) → Leg (one Full Turn, wrapping Frame · Comprehend · Sync · Produce · Debrief sub-records).
+
+**Reasoning.** The structural realization: each lab station (Frame, Comprehend, Sync, Produce, Debrief) isn't a separate form/function — there's a **unit of work** flowing through every phase. Danvers brought a deep research brief on rogaining (the Australian orienteering sport) and proposed that knowledge work is best modeled as a turn-based rogaine. A turn = a "leg" (one Full Turn). A week = a "7 leg course" — locked to the book title. The three-tier model resolves a prior architecture mismatch: the Frame card was being treated as a filing artifact (save and archive), when its real job is to *start a leg*. Every later station is a different lens on the same underlying unit of work. The Leg record wraps all five sub-records and stays open until Debrief closes it.
+
+**Status.** Active. Phase 1–5 of the rogaine-spine arc implemented and merged on branch `danversfleury/lab-course-tier` (11 commits beyond main as of 2026-05-04).
+
+**References.** Commits `a377f9b` through `11c6cd1`, `cognitive-lab/cognitive-lab-v0.1.html` (chunk-course-tier-spec, chunk-7-leg-courses-naming, chunk-course-as-spine-station-as-lens).
+
+---
+
 ## 2026-05-02 · Two-role agent split — Quenton (design) / Larry (operations)
 
 **Decision.** Two distinct AI agents for working in the lab, each with its own companion folder following the Zelda/ghostwriter pattern.

--- a/cognitive-lab/DECISIONS.md
+++ b/cognitive-lab/DECISIONS.md
@@ -6,6 +6,28 @@ Entries are reverse-chronological (newest first). Each has: date, decision, reas
 
 ---
 
+## 2026-05-04 (later) · Move 2 (Comprehension Station arc) — orientation workshop, Walk Studio, C-before-F, iframe pattern, LAB-009 status
+
+**Decision.** Five sub-phases shipped in the Move 2 arc (branch `danversfleury/lab-course-tier`, 11 commits since the v0.4 session-close):
+
+1. **Comprehend Station ships as a workshop (Move 2a–2e).** Comprehend Station promoted to `workshop: true`. "Where you are" orientation snapshot at top of the drawer: active leg + Course, last 3 comprehend acts, time since last touch, last debrief if present. Collapsible via sessionStorage; click a recent entry to expand inline. Walk Studio sidebar + main split: sidebar lists available walks; main pane renders a presentation deck or a product walk (step renderer + iframe of the live lab). Walk start and completion log to `leg.comprehend[]` as `kind:'walk'`. cc-kind-walk chip color (reddish-purple). Leg view zone subtitle counts walks alongside notes/synthesis/decks.
+
+2. **Walk Studio meta-loop: the lab teaches itself.** The realization driving Move 2: when Claude ships a feature and asks for a test, instructions live in chat. That's friction. The fix: instructions live inside the lab as structured product walks. The full loop — Claude ships a feature, authors a walk, author opens Comprehend Station, walks through the live lab in an iframe, completion logs to the leg — is now real. First authored walk: 'Walk: Build canvas v0.1' (8 steps), replacing the chat-instructed test of the v0.4 build canvas.
+
+3. **C-before-F floor reorder.** Band 2 reorders to Comprehend → Frame. The principle: orientation precedes scoping. You can't pick what to do this turn until you've loaded what just happened. The C-before-F principle stands in layout; the boot-strip gate (hard Comprehend checkpoint before Frame) is explicitly deferred to LAB-048 (P2).
+
+4. **Walk-mode iframe pattern + localStorage isolation.** Walk Studio loads the lab inside an iframe with `?walk=1`. Lab init applies `body.walk-mode`, hides Comprehend Station from the floor (opacity 0.3 + pointer-events none + aria-hidden — recursion defense), and suppresses localStorage writes for view+lens so iframe navigation doesn't bleed to the parent lab's own state. This is now a documented convention for any future feature that embeds the lab in an iframe.
+
+5. **LAB-009 (Comprehend form) — call: drafted.** Comprehend Station now ships as an orientation workshop with Walk Studio. The structured re-immersion form (agent-context picker, 'context loaded' gate before Produce) isn't yet built — that's the chapter material. Status is drafted: the workshop form is live; the chapter material isn't.
+
+**Reasoning.** The test-in-chat loop was friction that compounded with each shipped feature. Authoring the test as a walk inside the lab transforms every feature shipping into a self-documenting artifact. The Walk Studio embeds the lab's own surfaces inside the lab — the metaphor holds: Comprehend Station orients you to the lab, and the lab teaches you how to use it. The C-before-F reorder makes the principle structural rather than incidental. The iframe + localStorage isolation pattern resolves a real engineering risk (iframe navigation bleeding to parent state) in a reusable, named way.
+
+**Status.** Active. All five sub-phases shipped on branch `danversfleury/lab-course-tier`. New deferred items: LAB-052 (interactive walks), LAB-053 (persistent walk progress), LAB-054 (JSON-loaded WALKS), LAB-055 (in-lab authoring UI), LAB-056 (sandbox-Course mode), LAB-057 (multi-walk sequences).
+
+**References.** Branch `danversfleury/lab-course-tier` (11 commits since `fbcd25e`). `cognitive-lab/cognitive-lab-v0.1.html` (chunks: chunk-comprehend-station-v0.1, chunk-walk-studio-meta-loop, chunk-c-before-f-floor-reorder, chunk-walk-mode-iframe-recursion-defense; items LAB-009 [drafted], LAB-052–LAB-057).
+
+---
+
 ## 2026-05-04 (late) · Build canvas v0.1 — snap-circuit grid, lens architecture, HTML tooltip; LAB-043/044/046 reclassified
 
 **Decision.** Four framework-level calls shipped in the v0.4 arc (branch `danversfleury/lab-course-tier`, 14 commits since `7437bc4`):

--- a/cognitive-lab/DECISIONS.md
+++ b/cognitive-lab/DECISIONS.md
@@ -80,7 +80,7 @@ Click-to-place over drag-and-drop is a deliberate scope constraint, not a compro
 
 **Decision.** Comprehend auto-logs three kinds of intentional acts: `note` (manual), `synthesis` (status cycle to live/archived), `deck` (deck-open matched by DECK_FILE_RE). Frame card field activity is explicitly excluded for now.
 
-**Reasoning.** The seam bug the author caught in morning dogfood: the Comprehend zone was showing "idle" while real comprehension activity was happening elsewhere (deck walks, status cycles). The fix required a surveillance line — a principle for which acts merit a log entry. The line drawn: only acts the user *intentionally took* and *would expect to leave a record*. Status cycles and deck-opens clear this bar. Field edits in Frame (Doing / Not Doing / Approach) do not — they're exploratory; the user may type and delete without committing. Logging them would capture intent-noise. One Course of dogfood will reveal whether the signal is sparse enough to warrant expansion (LAB-044, P3).
+**Reasoning.** The seam bug the author caught in morning dogfood: the Comprehend zone was showing "idle" while real comprehension activity was happening elsewhere (deck walks, status cycles). The fix required a surveillance line — a principle for which acts merit a log entry. The line drawn: only acts the user *intentionally took* and *would expect to leave a record*. Status cycles and deck-opens clear this bar. Field edits in Frame (Doing / Not Doing / Approach) do not — they're exploratory; the user may type and delete without committing. Logging them would capture intent-noise. One Course of dogfood will reveal whether the signal is sparse enough to warrant expansion (LAB-044, P2).
 
 **Status.** Active. Surveillance line is a first-class constraint, not a footnote. Expansion criteria deferred to LAB-044.
 
@@ -126,7 +126,7 @@ Click-to-place over drag-and-drop is a deliberate scope constraint, not a compro
 
 ## 2026-05-04 (evening) · Biome regions replace the random Hex Map grid
 
-**Decision.** Hex Map v0.2 clusters hexes into labeled, biome-tinted regions rather than a flat grid. Regions are the legend; the separate swatch row is dropped. Regions sort biggest-first. Semantic adjacency within biomes is deferred (LAB-043, P3).
+**Decision.** Hex Map v0.2 clusters hexes into labeled, biome-tinted regions rather than a flat grid. Regions are the legend; the separate swatch row is dropped. Regions sort biggest-first. Semantic adjacency within biomes is deferred (LAB-043, P2).
 
 **Reasoning.** Morning dogfood surfaced the misread: the v0.1 grid layout looked random — spatial proximity implied relationship, but the grid had no relationship logic. This imposed extraneous load (inferring meaning from position that had none). Biome regions give the map a spatial grammar: you navigate to the turn-phases cluster or the capacity-instruments cluster, not to cell (3,2). Regions-as-legend drops the redundant swatch row — the map tells its own story. Sorting biggest-first makes the dominant cognitive territory (turn phases, 5–6 hexes) visually anchor the layout.
 

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -657,6 +657,33 @@
     margin-bottom: 3px;
   }
 
+  /* Phase 1.5: kind labels for mixed-kind comprehend timelines (note ·
+     synthesis · deck). Three colors so the user can scan kinds without
+     reading the label. The label itself is the type word; the color is
+     the iconic channel (per the Bruner / four-channel design language). */
+  .cc-kind {
+    display: inline-block;
+    font-family: var(--font-px);
+    font-size: 9px;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    padding: 1px 5px;
+    border-radius: 2px;
+    margin-right: 6px;
+    vertical-align: baseline;
+  }
+  .cc-kind-note      { color: #d4a030; background: rgba(212,160,48,0.10); border: 1px solid rgba(212,160,48,0.35); }
+  .cc-kind-synthesis { color: #5cb09a; background: rgba(92,176,154,0.10); border: 1px solid rgba(92,176,154,0.35); }
+  .cc-kind-deck      { color: #6f9ee0; background: rgba(74,123,212,0.10); border: 1px solid rgba(74,123,212,0.35); }
+  /* Tighten the cc-when line in mixed-kind mode so the kind chip sits on
+     the same row as the timestamp + body for scannability. */
+  .course-comprehend-entry .cc-when { display: inline-block; margin-right: 8px; margin-bottom: 0; }
+  .course-comprehend-entry .cc-body { color: var(--fg); }
+  /* Synthesis entries: emphasize the item id with the px font */
+  .course-comprehend-entry.cc-synthesis .cc-body,
+  .leg-comprehend-list li.cc-synthesis,
+  .leg-comprehend-list li.cc-deck { font-family: var(--font-px); font-size: 11.5px; }
+
   /* ── Lab tile (shared across alt views) ──
      Each tile pulls its area icon + accent color from the floor,
      so an item visually carries the room it lives in. */
@@ -5083,6 +5110,13 @@
     const idx = STATUS_CYCLE.indexOf(cur);
     const next = STATUS_CYCLE[(idx + 1) % STATUS_CYCLE.length];
     setItemStatus(id, next);
+    // Phase 1.5: cycling to live or archived is the synthesis act
+    // ("I now consider this done"). Auto-log to the active leg's
+    // comprehend[]. Cycles to in-progress / drafted / backlog are
+    // workflow noise — not logged.
+    if (next === 'live' || next === 'archived') {
+      logComprehendSynthesis(id, cur, next);
+    }
     return next;
   }
 
@@ -8142,19 +8176,32 @@
       inHTML + mustChips + bonusChips);
   }
   function renderLegZoneComprehend(leg) {
-    const notes = Array.isArray(leg.comprehend) ? leg.comprehend : [];
-    if (notes.length === 0) {
+    const entries = Array.isArray(leg.comprehend) ? leg.comprehend : [];
+    if (entries.length === 0) {
       return legZoneShell('comprehend', '⚡', 'amplifier', 'Comprehend', '', 'idle',
-        '<div class="leg-zone-empty">No notes yet. Capture re-immersion notes from the Course view to amplify what you\'re holding in mind.</div>');
+        '<div class="leg-zone-empty">No comprehension activity yet. Capture a note from the Course view, walk a deck, or cycle an item to live/archived — they all land here.</div>');
     }
-    const recent = notes.slice(-3).reverse();
-    const items = recent.map(n =>
-      `<li><span class="lcl-when">${escapeHTML(fmtComprehendWhen(n && n.at))}</span>${escapeHTML((n && n.text) || '').replace(/\n/g, '<br>')}</li>`
-    ).join('');
-    const more = notes.length > 3
-      ? `<div class="leg-zone-line"><span class="lzl-label">+${notes.length - 3} earlier</span></div>`
+    // Phase 1.5: aggregate counts across kinds for the lit-state subtitle.
+    const kindCounts = entries.reduce((acc, e) => {
+      const k = (e && e.kind) || 'note';
+      acc[k] = (acc[k] || 0) + 1;
+      return acc;
+    }, {});
+    const subtitleParts = [];
+    if (kindCounts.note)      subtitleParts.push(kindCounts.note + ' note' + (kindCounts.note === 1 ? '' : 's'));
+    if (kindCounts.synthesis) subtitleParts.push(kindCounts.synthesis + ' synthesis');
+    if (kindCounts.deck)      subtitleParts.push(kindCounts.deck + ' deck' + (kindCounts.deck === 1 ? '' : 's'));
+    const subtitle = subtitleParts.join(' · ');
+
+    const recent = entries.slice(-3).reverse();
+    const items = recent.map(e => {
+      const p = comprehendEntryParts(e);
+      return `<li class="cc-${p.kind}"><span class="lcl-when">${escapeHTML(fmtComprehendWhen(e && e.at))}</span><span class="cc-kind cc-kind-${p.kind}">${escapeHTML(p.label)}</span> ${p.bodyHTML}</li>`;
+    }).join('');
+    const more = entries.length > 3
+      ? `<div class="leg-zone-line"><span class="lzl-label">+${entries.length - 3} earlier</span></div>`
       : '';
-    return legZoneShell('comprehend', '⚡', 'amplifier', 'Comprehend', 'lit', notes.length + ' note' + (notes.length === 1 ? '' : 's'),
+    return legZoneShell('comprehend', '⚡', 'amplifier', 'Comprehend', 'lit', subtitle,
       '<ul class="leg-comprehend-list">' + items + '</ul>' + more);
   }
   function renderLegZoneSync(leg) {
@@ -8220,10 +8267,99 @@
     }
   });
 
-  /* ── On-demand Comprehend (Phase 3) ──
+  /* ── Comprehend Signals (Phase 1.5) ──
+     The Comprehend zone aggregates three kinds of activity, all written to
+     leg.comprehend[]:
+       kind: 'note'       → manual capture from the textarea (Phase 3)
+       kind: 'synthesis'  → status cycle to live/archived ("I now consider
+                            this done") — auto-logged from cycleStatus
+       kind: 'deck'       → opening a known deck file (recap-play act) —
+                            auto-logged from artifact-link clicks
+     Surveillance line: only acts the user *intentionally took* and
+     *would expect to leave a record*. No mouse-tracking, no search-
+     query logging, no item-hover. Director-of-the-lab tone.
+
+     Entry shape (back-compat: missing `kind` → 'note'):
+       { at, kind, text?, source?, item_id?, transition? } */
+
+  // Deck-file matcher. Catches the existing two decks plus future
+  // arc-comprehension decks following the *-deck-vN.M.html convention.
+  const DECK_FILE_RE = /(?:^|\/)(turn-v[\d.]+-map|.*-deck-v[\d.]+|comprehension-deck-v[\d.]+)\.html$/i;
+
+  function appendComprehendEntry(entry) {
+    // Adds a comprehend entry to the active leg. No-op if no active leg
+    // (orphan signals are dropped silently — by design; the leg is the
+    // unit of comprehension and we don't try to back-fill).
+    const leg = findActiveLeg();
+    if (!leg) return null;
+    leg.comprehend = Array.isArray(leg.comprehend) ? leg.comprehend.slice() : [];
+    leg.comprehend.push(Object.assign({ at: new Date().toISOString() }, entry));
+    return upsertLeg(leg);
+  }
+  function logComprehendSynthesis(itemId, prevStatus, nextStatus) {
+    // Called from cycleStatus on transitions to live/archived only.
+    appendComprehendEntry({
+      kind: 'synthesis',
+      item_id: itemId,
+      transition: (prevStatus || '?') + ' → ' + nextStatus
+    });
+    // If the user is on the Course or Leg view when this fires, surface
+    // the new entry immediately. Best-effort: render functions guard.
+    if (typeof activeView !== 'undefined') {
+      if (activeView === 'course' && typeof renderCourseComprehend === 'function') renderCourseComprehend();
+      if (activeView === 'leg'    && typeof renderLegView          === 'function') renderLegView();
+    }
+  }
+  function logComprehendDeckOpen(href) {
+    // Called when the user clicks an artifact-link whose href matches a
+    // known deck file. Strips any query string / fragment for cleanliness.
+    const clean = (href || '').split('?')[0].split('#')[0];
+    appendComprehendEntry({
+      kind: 'deck',
+      source: clean
+    });
+    if (typeof activeView !== 'undefined') {
+      if (activeView === 'course' && typeof renderCourseComprehend === 'function') renderCourseComprehend();
+      if (activeView === 'leg'    && typeof renderLegView          === 'function') renderLegView();
+    }
+  }
+  // Delegated click handler for any artifact-link in the lab. Fires the
+  // deck-open log only when the href matches the deck file pattern. Does
+  // not preventDefault — the link still opens normally in a new tab.
+  document.addEventListener('click', (e) => {
+    const a = e.target && e.target.closest ? e.target.closest('a.artifact-link') : null;
+    if (!a) return;
+    const href = a.getAttribute('href') || '';
+    if (DECK_FILE_RE.test(href)) {
+      logComprehendDeckOpen(href);
+    }
+  });
+
+  // Shared helper for rendering a single comprehend entry's payload (the
+  // kind label + the body). Used by both the Course view's log and the
+  // Leg view's Comprehend zone. Back-compat: an entry with no `kind` (the
+  // pre-Phase-1.5 shape) renders as a 'note' with just the text body.
+  function comprehendEntryParts(entry) {
+    if (!entry) return { kind: 'note', label: 'note', bodyHTML: '' };
+    const k = entry.kind || 'note';
+    if (k === 'synthesis') {
+      const id = escapeHTML(entry.item_id || '?');
+      const tr = escapeHTML(entry.transition || '');
+      return { kind: 'synthesis', label: 'synthesis', bodyHTML: id + (tr ? '  ' + tr : '') };
+    }
+    if (k === 'deck') {
+      const src = escapeHTML(entry.source || '?');
+      return { kind: 'deck', label: 'deck', bodyHTML: src };
+    }
+    // 'note' (default) — text body, newlines preserved
+    const txt = escapeHTML(entry.text || '').replace(/\n/g, '<br>');
+    return { kind: 'note', label: 'note', bodyHTML: txt };
+  }
+
+  /* ── On-demand Comprehend (Phase 3, extended in Phase 1.5) ──
      Single textarea + Capture button. Appends a timestamped note to the
      active leg's comprehend[]. Renders the most-recent-first log below.
-     If no active leg exists yet, prompts the user to start one via Frame.
+     The log now also surfaces auto-logged synthesis + deck entries.
      fmtComprehendWhen is defined above (shared with the Leg view). */
   function renderCourseComprehend() {
     const wrap = document.getElementById('course-comprehend');
@@ -8239,15 +8375,18 @@
     }
     const entries = (leg.comprehend || []).slice().reverse(); // newest first
     const logHTML = entries.length === 0
-      ? '<p class="course-comprehend-empty">No notes yet for ' + escapeHTML(leg.id) + '.</p>'
-      : entries.map(e => `<div class="course-comprehend-entry">
-          <span class="cc-when">${escapeHTML(fmtComprehendWhen(e && e.at))}</span>
-          ${escapeHTML((e && e.text) || '').replace(/\n/g, '<br>')}
-        </div>`).join('');
+      ? '<p class="course-comprehend-empty">No comprehension activity yet for ' + escapeHTML(leg.id) + '. Capture a note above, walk a deck, or cycle an item to live/archived.</p>'
+      : entries.map(e => {
+          const p = comprehendEntryParts(e);
+          return `<div class="course-comprehend-entry cc-${p.kind}">
+            <span class="cc-when">${escapeHTML(fmtComprehendWhen(e && e.at))}</span>
+            <span class="cc-kind cc-kind-${p.kind}">${escapeHTML(p.label)}</span>
+            <span class="cc-body">${p.bodyHTML}</span>
+          </div>`;
+        }).join('');
     wrap.innerHTML =
       '<p class="course-comprehend-title">Comprehend · ' + escapeHTML(leg.id) + '</p>' +
-      '<p class="course-comprehend-sub">Re-immersion notes for the active leg. ' +
-      'Capture what just changed, what to load before continuing, what surprised you.</p>' +
+      '<p class="course-comprehend-sub">Activity for the active leg. Notes you write, decks you walk, items you cycle to live/archived all land here.</p>' +
       '<textarea id="course-comprehend-input" placeholder="What just changed? What do I need to load? What surprised me?"></textarea>' +
       '<div class="course-comprehend-actions">' +
         '<button type="button" id="course-comprehend-capture" class="ff-btn primary">Capture note</button>' +

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -4695,6 +4695,7 @@
      leg hits which item. Frame at each leg picks from the frontier. */
   const COURSE_KEY = 'cognitive-lab-v0.1::courses';
   const COURSE_LEG_COUNT = 7; // matches book title (The 7 Turn Work Week)
+  const LEG_KEY = 'cognitive-lab-v0.1::legs';
 
   function isoWeekId(date) {
     // ISO-8601 week-numbering: weeks start Monday; week 1 contains the first Thursday.
@@ -4759,20 +4760,30 @@
        changes_to_course   → 0..1 delta written back to the Course frontier on debrief
      ID convention: LEG-YYYY-MM-DD-A (date + letter for multi-leg days).
      The leg references the Course it belongs to via course_ref. */
-  const LEG_KEY = 'cognitive-lab-v0.1::legs';
 
   function todayDateOnly(date) {
     const d = date ? new Date(date.getTime()) : new Date();
     return d.toISOString().slice(0, 10);
   }
   function nextLegLetter(courseId, dateStr) {
-    // Returns 'A'/'B'/'C'/... for the next leg created on the given day in the given course.
+    // Returns 'A'/'B'/'C'/... for the next leg created on the given day in the
+    // given course. Reads the dedicated `letter` field rather than parsing it
+    // out of the ID, so the function stays correct if the ID format changes.
     const existing = loadLegs().filter(l =>
       l && l.course_ref === courseId && l.date === dateStr
     );
-    const letters = existing.map(l => (l.id || '').slice(-1));
+    const letters = existing.map(l => l && l.letter).filter(Boolean);
+    const Z = 'Z'.charCodeAt(0);
     let code = 'A'.charCodeAt(0);
-    while (letters.includes(String.fromCharCode(code))) code++;
+    while (letters.includes(String.fromCharCode(code))) {
+      code++;
+      if (code > Z) {
+        // 26 legs on a single day in one course should never happen (cap is 7
+        // per course total). If it does, the data is corrupt; surface it loudly
+        // rather than returning a non-alpha character that breaks downstream IDs.
+        throw new Error('nextLegLetter: more than 26 legs on ' + dateStr + ' in ' + courseId);
+      }
+    }
     return String.fromCharCode(code);
   }
   function legId(courseId, dateStr, letter) {
@@ -4823,6 +4834,7 @@
       leg_number: legNumber,            // 1..COURSE_LEG_COUNT
       status: 'planning',               // planning · in-progress · debriefed · archived
       date: dateStr,
+      letter: letter,                   // dedicated field; nextLegLetter reads it
       frame_card_id: null,
       comprehend: [],                   // [{at: ISO, text: string}]
       sync: null,                       // {at, ...} once captured

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -2373,6 +2373,75 @@
   #pc-recent-list .ws-recent-card.cleared { border-left-color: var(--success); }
   #pc-recent-list .ws-recent-card.grounded { border-left-color: var(--danger); }
 
+  /* ── Course Header bar (renders active leg + course at the top of every workshop drawer) ──
+     Single-line glanceable strip. Quenton's "iconic skin" call: leg-number is a
+     7-segment LED bar (book title: The 7 Turn Work Week) — current leg lit,
+     prior dimmed, future ghosted. */
+  .course-header-bar {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 14px;
+    padding: 8px 12px;
+    margin-bottom: 12px;
+    background: rgba(0,0,0,0.22);
+    border: 1px solid var(--panel-bd);
+    border-radius: 6px;
+    font-family: var(--font-px);
+    font-size: 10.5px;
+    color: var(--accent-dim);
+  }
+  .course-header-bar.empty { font-style: italic; color: #6f7a90; }
+  .course-header-bar .ch-leg-id {
+    color: var(--accent);
+    font-weight: bold;
+    letter-spacing: 1px;
+  }
+  .course-header-bar .ch-segments {
+    display: inline-flex;
+    gap: 3px;
+    align-items: center;
+  }
+  .course-header-bar .ch-seg {
+    width: 14px;
+    height: 6px;
+    border-radius: 1px;
+    background: rgba(255,255,255,0.08);
+    border: 1px solid rgba(255,255,255,0.15);
+    box-sizing: border-box;
+  }
+  .course-header-bar .ch-seg.done    { background: rgba(74,138,90,0.55); border-color: rgba(74,138,90,0.7); }
+  .course-header-bar .ch-seg.current { background: var(--accent); border-color: var(--accent); box-shadow: 0 0 4px rgba(226,160,74,0.6); }
+  .course-header-bar .ch-seg.future  { background: rgba(255,255,255,0.04); border-color: rgba(255,255,255,0.10); }
+  .course-header-bar .ch-counter {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 4px;
+  }
+  .course-header-bar .ch-counter .ch-label { letter-spacing: 1px; }
+  .course-header-bar .ch-counter .ch-value { color: var(--fg); font-weight: bold; }
+  .course-header-bar .ch-counter.over .ch-value { color: #c25450; }
+  .course-header-bar .ch-status {
+    margin-left: auto;
+    padding: 2px 6px;
+    border: 1px solid var(--panel-bd);
+    border-radius: 3px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    font-size: 9.5px;
+  }
+  .course-header-bar .ch-link {
+    color: var(--accent);
+    text-decoration: underline dotted;
+    cursor: pointer;
+    background: none;
+    border: none;
+    font-family: inherit;
+    font-size: inherit;
+    padding: 0;
+  }
+  .course-header-bar .ch-link:hover { color: var(--fg); }
+
   /* ── Workshop modes ── */
   .ws-mode { display: none; flex-direction: column; gap: 12px; }
   .ws-mode.active { display: flex; }
@@ -3365,6 +3434,9 @@
   <div id="drawer-body">
     <!-- Workshop view (three modes: resting / editing / viewing) -->
     <div id="workshop-view">
+
+      <!-- Course Header bar — renders the active leg (if any) at the top of every workshop drawer. -->
+      <div id="course-header" class="course-header-bar"></div>
 
       <!-- RESTING — default. Calm, inviting, one CTA + collapsed recent. -->
       <div class="ws-mode active" id="ws-resting">
@@ -4573,6 +4645,7 @@
       drawer.classList.add('workshop');
       wsView.classList.add('visible');
       if (floorHeading) floorHeading.style.display = '';
+      renderCourseHeader();
 
       if (areaId === 'pilot-check-station') {
         frameModes.forEach(el => el.style.display = 'none');
@@ -4854,6 +4927,94 @@
     saveLegs(arr);
     return leg;
   }
+
+  /* ── Frame ↔ Leg bridge ──
+     Frame cards are currently identified by their ISO `savedAt` timestamp
+     (no explicit id field). The Leg uses that timestamp as `frame_card_id`.
+     `findFrameCardForLeg` resolves it; `attachFrameToLeg` is called from the
+     Frame save handler to ensure a leg exists and links the card to it. */
+  function findFrameCardForLeg(leg) {
+    if (!leg || !leg.frame_card_id) return null;
+    return loadFrameCards().find(c => c && c.savedAt === leg.frame_card_id) || null;
+  }
+  function attachFrameToLeg(card) {
+    // Called after a Frame card is saved. Ensures a leg exists for today, in
+    // the current ISO-week's course, and links the card to it. Bumps the
+    // leg from `planning` → `in-progress` if applicable. Returns the leg.
+    if (!card || !card.savedAt) return null;
+    let leg = findActiveLeg();
+    const todayStr = todayDateOnly();
+    // If active leg is from a different day, start a fresh leg for today.
+    if (leg && leg.date !== todayStr) leg = null;
+    if (!leg) leg = newLegDraft({ date: todayStr });
+    leg.frame_card_id = card.savedAt;
+    if (leg.status === 'planning') leg.status = 'in-progress';
+    return upsertLeg(leg);
+  }
+
+  /* ── Course Header (top strip rendered in every workshop drawer) ──
+     Compact line: leg id · 7-segment LED bar · MUSTS x/3 · BONUS x · MAP n/m
+     · status badge. Reads the active leg + linked Frame card + active Course. */
+  function renderCourseHeader() {
+    const el = document.getElementById('course-header');
+    if (!el) return;
+    const leg = findActiveLeg();
+    const courseId = isoWeekId();
+    const course = findCourseById(courseId);
+
+    if (!leg && !course) {
+      el.className = 'course-header-bar empty';
+      el.innerHTML = 'No course or leg yet — open the <button type="button" class="ch-link" data-act="goto-course">Course view</button> to plan the week.';
+      return;
+    }
+
+    // Header chunks. Order: leg id · LED segments · MUSTS · BONUS · MAP · status.
+    const legId    = leg ? leg.id : 'No leg yet';
+    const legNum   = leg ? leg.leg_number : 0;
+    const status   = leg ? leg.status : 'planning';
+    const card     = leg ? findFrameCardForLeg(leg) : null;
+    const mustArr  = card && Array.isArray(card.must) ? card.must
+                   : (card && typeof card.must === 'string' && card.must.trim() ? [{ id: 'free' }] : []);
+    const bonusArr = card && Array.isArray(card.stretch) ? card.stretch
+                   : (card && typeof card.stretch === 'string' && card.stretch.trim() ? [{ id: 'free' }] : []);
+    const mustsCount = mustArr.length;
+    const bonusCount = bonusArr.length;
+    const frontierCount = course && Array.isArray(course.frontier) ? course.frontier.length : 0;
+    const mapTotal = (typeof allItemsArray === 'function') ? allItemsArray().length : 0;
+
+    // 7-segment LED bar. Done = legs strictly before legNum. Current = legNum. Future = the rest.
+    const segments = [];
+    for (let i = 1; i <= COURSE_LEG_COUNT; i++) {
+      let cls = 'ch-seg';
+      if (legNum && i < legNum) cls += ' done';
+      else if (legNum && i === legNum) cls += ' current';
+      else cls += ' future';
+      segments.push('<span class="' + cls + '" title="leg ' + i + ' of ' + COURSE_LEG_COUNT + '"></span>');
+    }
+
+    const mustsClass = mustsCount > 3 ? 'ch-counter over' : 'ch-counter';
+    const parts = [];
+    parts.push('<span class="ch-leg-id">' + escapeHTML(legId) + '</span>');
+    parts.push('<span class="ch-segments" aria-label="leg ' + legNum + ' of ' + COURSE_LEG_COUNT + '">' + segments.join('') + '</span>');
+    parts.push('<span class="' + mustsClass + '"><span class="ch-label">MUSTS</span><span class="ch-value">' + mustsCount + '/3</span></span>');
+    parts.push('<span class="ch-counter"><span class="ch-label">BONUS</span><span class="ch-value">' + bonusCount + '</span></span>');
+    if (course) {
+      parts.push('<span class="ch-counter"><span class="ch-label">MAP</span><span class="ch-value">' + frontierCount + '/' + mapTotal + ' in scope</span></span>');
+    } else {
+      parts.push('<span class="ch-counter"><span class="ch-label">MAP</span><span class="ch-value">no course set</span></span>');
+    }
+    parts.push('<span class="ch-status">' + escapeHTML(status) + '</span>');
+
+    el.className = 'course-header-bar';
+    el.innerHTML = parts.join('');
+  }
+
+  // Course Header click handler (only the goto-course link is clickable today).
+  document.addEventListener('click', (e) => {
+    if (e.target && e.target.classList && e.target.classList.contains('ch-link') && e.target.dataset.act === 'goto-course') {
+      if (typeof setView === 'function') setView('course');
+    }
+  });
 
   /* ── Frame Workshop: storage helpers ── */
   const FRAME_KEY = 'cognitive-lab-v0.1::frame-cards';
@@ -6006,14 +6167,24 @@
     const filled = FF_FIELDS.filter(f => fieldIsFilled(card[f])).length;
     if (filled === 0) return;
     const cards = loadFrameCards();
+    let savedCard = card;
     if (editingOriginalIdx >= 0 && cards[editingOriginalIdx]) {
-      // preserve original date if user is editing an existing card
-      card.date = cards[editingOriginalIdx].date || card.date;
+      // preserve original date + savedAt if user is editing an existing card,
+      // so the leg-attach link by savedAt stays stable across edits
+      const orig = cards[editingOriginalIdx];
+      card.date = orig.date || card.date;
+      card.savedAt = orig.savedAt || card.savedAt;
       cards[editingOriginalIdx] = card;
+      savedCard = card;
     } else {
       cards.push(card);
     }
     saveFrameCards(cards);
+    // Phase 2: ensure today's leg exists in the active week's course and link
+    // the just-saved Frame card to it. New cards bump the leg into in-progress;
+    // edits to an already-attached card leave the link unchanged.
+    attachFrameToLeg(savedCard);
+    renderCourseHeader();
     flashSaved();
     setTimeout(() => enterResting(), 600);
   });

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -8540,6 +8540,10 @@
   function renderCourseHexMap() {
     const wrap = document.getElementById('course-hexmap');
     if (!wrap) return;
+    // Hide any visible hex tooltip — lens switches replace the SVG so no
+    // mouseout fires on the detached node, leaving a stale tooltip.
+    const staleTooltip = document.getElementById('hex-tooltip');
+    if (staleTooltip) staleTooltip.hidden = true;
     const c = getOrInitCourseDraft();
     const frontierSet = new Set(c.frontier || []);
     const workingSet = getActiveLegWorkingSet();

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -469,6 +469,55 @@
     line-height: 1.6;
   }
   .course-build-placeholder strong { color: var(--accent); }
+  /* Build canvas (Move 3b): snap-circuit-style grid. Empty cells with a
+     center "snap point" dot, labeled rows (A–G) and columns (1–10). */
+  .bc-canvas-wrap {
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-bd);
+    border-radius: 8px;
+    padding: 14px;
+    margin-top: 4px;
+  }
+  .bc-canvas {
+    width: 100%;
+    height: auto;
+    display: block;
+  }
+  .bc-cell-bg {
+    fill: rgba(255,255,255,0.02);
+    stroke: rgba(255,255,255,0.10);
+    stroke-width: 0.6;
+    transition: fill 120ms ease, stroke 120ms ease;
+  }
+  .bc-cell:hover .bc-cell-bg {
+    fill: rgba(226,160,74,0.08);
+    stroke: var(--accent-dim);
+    stroke-width: 1.2;
+    cursor: pointer;
+  }
+  .bc-cell-snap {
+    fill: rgba(255,255,255,0.16);
+    pointer-events: none;
+  }
+  .bc-cell:hover .bc-cell-snap {
+    fill: var(--accent);
+  }
+  .bc-grid-label {
+    font-family: var(--font-px);
+    font-size: 10px;
+    font-weight: bold;
+    fill: var(--accent-dim);
+    letter-spacing: 0.5px;
+    pointer-events: none;
+  }
+  .bc-canvas-hint {
+    font-family: var(--font-px);
+    font-size: 10px;
+    color: #6f7a90;
+    margin-top: 8px;
+    text-align: center;
+  }
+  .bc-canvas-hint strong { color: var(--accent); }
   /* By-function lens (restored from v0.2): clustered biome regions. */
   .hex-region-bg {
     fill-opacity: 0.06;
@@ -8640,18 +8689,85 @@
     });
   }
 
-  /* Build lens (Move 3a stub).
-     Fills out in Move 3b (empty canvas with grid), 3c (tool drawer),
-     3d (click-to-place + persistence), 3e (template apply). */
+  /* Build lens (Moves 3b → 3e).
+     3b ships the empty snap-circuit grid (rows A–G × cols 1–10 = 70
+     cells). Cells are clickable but inert until the tool drawer (3c)
+     and click-to-place mechanic (3d) land. */
+  const BC_ROWS    = 7;
+  const BC_COLS    = 10;
+  const BC_CELL    = 52;       // pixel size of each grid cell
+  const BC_LABEL_PAD = 24;     // edge padding for row/col labels
+  const BC_ROW_LETTERS = ['A','B','C','D','E','F','G'];
+  function bcCellId(row, col) {
+    // "A1", "B7", etc — snap-circuit board convention.
+    return BC_ROW_LETTERS[row] + (col + 1);
+  }
   function renderCourseLensBuild(slot /*, items, frontierSet, workingSet */) {
+    const w = BC_LABEL_PAD * 2 + BC_COLS * BC_CELL;
+    const h = BC_LABEL_PAD + BC_ROWS * BC_CELL + 8;
+
+    // Column labels across the top
+    const colLabels = [];
+    for (let c = 0; c < BC_COLS; c++) {
+      const x = BC_LABEL_PAD + c * BC_CELL + BC_CELL / 2;
+      const y = BC_LABEL_PAD - 6;
+      colLabels.push(`<text class="bc-grid-label" x="${x}" y="${y}" text-anchor="middle">${c + 1}</text>`);
+    }
+
+    // Row labels down the left
+    const rowLabels = [];
+    for (let r = 0; r < BC_ROWS; r++) {
+      const x = BC_LABEL_PAD - 8;
+      const y = BC_LABEL_PAD + r * BC_CELL + BC_CELL / 2 + 4;
+      rowLabels.push(`<text class="bc-grid-label" x="${x}" y="${y}" text-anchor="end">${BC_ROW_LETTERS[r]}</text>`);
+    }
+
+    // Grid cells (each is a clickable group with bg rect + center snap dot)
+    const cells = [];
+    for (let r = 0; r < BC_ROWS; r++) {
+      for (let c = 0; c < BC_COLS; c++) {
+        const x = BC_LABEL_PAD + c * BC_CELL;
+        const y = BC_LABEL_PAD + r * BC_CELL;
+        const cellId = bcCellId(r, c);
+        cells.push(`<g class="bc-cell" data-row="${r}" data-col="${c}" data-cell="${cellId}" role="gridcell" aria-label="cell ${cellId}, empty">
+          <rect class="bc-cell-bg" x="${x}" y="${y}" width="${BC_CELL}" height="${BC_CELL}" rx="3" ry="3"/>
+          <circle class="bc-cell-snap" cx="${x + BC_CELL / 2}" cy="${y + BC_CELL / 2}" r="3"/>
+        </g>`);
+      }
+    }
+
     slot.innerHTML = `
-      <div class="course-build-placeholder">
-        <p>The <strong>Build canvas</strong> ships across Moves 3b–3e:</p>
-        <p>3b · empty grid (snap-circuit board) → 3c · tool drawer (item palette)<br>
-           3d · click-to-place + persistence → 3e · template apply (current frontier as starting position)</p>
-        <p style="margin-top: 14px;">For now, switch to <strong>By priority</strong> or <strong>By function</strong>.</p>
+      <p class="course-hexmap-sub">Build · empty canvas (snap-circuit board, ${BC_ROWS}×${BC_COLS} = ${BC_ROWS * BC_COLS} cells). Cells are clickable but inert until the tool drawer + click-to-place mechanic land in Moves 3c–3d.</p>
+      <div class="bc-canvas-wrap">
+        <svg class="bc-canvas" viewBox="0 0 ${w} ${h}" preserveAspectRatio="xMidYMid meet" role="grid" aria-label="Build canvas: ${BC_ROWS}×${BC_COLS} grid, currently empty.">
+          ${colLabels.join('')}
+          ${rowLabels.join('')}
+          ${cells.join('')}
+        </svg>
       </div>
+      <p class="bc-canvas-hint">Coming in 3c–3e: <strong>tool drawer</strong> (item palette) · <strong>click-to-place</strong> · <strong>template apply</strong> (frontier as starting position).</p>
     `;
+
+    // Inert click handler — acknowledges interactions until 3d wires the
+    // real placement mechanic. Click any cell to confirm grid is alive.
+    const svg = slot.querySelector('svg.bc-canvas');
+    if (svg) {
+      svg.addEventListener('click', (e) => {
+        const cell = e.target && e.target.closest ? e.target.closest('.bc-cell') : null;
+        if (!cell) return;
+        // Visual ping: flash the cell border briefly.
+        const bg = cell.querySelector('.bc-cell-bg');
+        if (!bg) return;
+        bg.style.transition = 'none';
+        bg.style.fill   = 'rgba(226,160,74,0.22)';
+        bg.style.stroke = 'var(--accent)';
+        setTimeout(() => {
+          bg.style.transition = '';
+          bg.style.fill   = '';
+          bg.style.stroke = '';
+        }, 180);
+      });
+    }
   }
 
   /* By-function lens — restored from v0.2.

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -4379,6 +4379,12 @@
       ],
       "chunks": [
         {
+          "id": "chunk-frontier-first-picker",
+          "title": "Frontier-first Frame picker with expand",
+          "summary": "The per-leg Frame picker scopes to the active Course's frontier by default. Expand to Full lab is the deliberate emergence valve. Off-frontier picks get tagged so Debrief can surface them.",
+          "body": "Phase 2 of the rogaine-spine arc resolves the seam bug the author caught in morning dogfood: the Frame picker was showing the entire lab instead of scoping to the current Course's frontier.\n\n**The decision (Quenton design dialog):** The picker defaults to the Course frontier — items the author already committed as reachable this week. This is the right default because the rogaine metaphor holds at the per-leg level: the racer chooses from the terrain they've already entered, not from the full map.\n\n**Expand = deliberate emergence valve.** The author can toggle to Full lab view. This is not a shortcut — it's a named design move. Emergence is the only good reason to pick off-frontier: something surfaces mid-leg that wasn't visible at Course-planning time. The toggle requires a deliberate act so that off-frontier picks are never accidental.\n\n**Off-frontier tagging.** When the author picks an item outside the frontier, the pick is saved with `ref.off_frontier = true` and displayed with a chip badge in the Frame. This makes the off-frontier pick visible at a glance — no inference required.\n\n**Debrief pre-fill (deferred, LAB-042).** The tag is designed to feed Debrief's `changes_to_course.frontier_added` field. At Debrief time, the system can pre-fill: 'You picked [item] off-frontier this leg — add to Course frontier?' The author confirms or dismisses. This wires the Course-planning feedback loop without requiring manual cross-referencing. Deferred to LAB-042.\n\n**Alternatives considered and rejected:**\n- Strict picker (frontier-only, no expand): prevents emergence; wrong tradeoff.\n- Glow/badge on off-frontier picks without a tag: visually informative but loses the data for Debrief writeback."
+        },
+        {
           "id": "chunk-course-as-spine-station-as-lens",
           "title": "Course as spine — each station as a different lens",
           "summary": "Architectural shift: Frame doesn't file a card, it sets the course. Every later station (Comprehend, Sync, Produce, Debrief) is a different lens on the same course.",
@@ -4446,11 +4452,17 @@
       "type": "phase / conditional",
       "accent": "amber",
       "description": "Where Comprehend practice and chapter live. The phase that loads remaining state from agents and prior work.",
-      "items": ["LAB-009","LAB-010"],
+      "items": ["LAB-009","LAB-010","LAB-044","LAB-046"],
       "artifacts": [
         { "label": "turn-v0.1-phases-and-leverage.md (Comprehend section)", "href": "turn-v0.1-phases-and-leverage.md" }
       ],
       "chunks": [
+        {
+          "id": "chunk-comprehend-signals",
+          "title": "Comprehend Signals — what the station captures and why",
+          "summary": "Comprehend auto-logs three kinds of intentional acts: notes (manual), synthesis (status cycle to live/archived), deck-open. The surveillance line: only acts the user intentionally took and would expect to leave a record.",
+          "body": "Phase 1.5 of the rogaine-spine arc formalizes what Comprehend captures and draws the surveillance line.\n\n**Three capture kinds:**\n- `note` — manual note entry by the user. Explicit; no ambiguity.\n- `synthesis` — auto-logged when a leg's status cycles to `live` or `archived`. The status cycle is an intentional act with a durable consequence; logging it is reasonable.\n- `deck` — auto-logged when the user opens a deck file (matched by DECK_FILE_RE). Deck-opens are deliberate re-immersion acts; they would naturally leave a record if the system were a notebook.\n\n**The shape:**\n```\nleg.comprehend[]: [\n  { at: ISO-timestamp, kind: 'note' | 'synthesis' | 'deck', ... }\n]\n```\n\n**The surveillance line.** Comprehend only captures acts the user *intentionally took* and *would expect to leave a record*. This excludes: passive file reads, hover events, search queries, time-on-zone, and Frame card field activity. Quenton's formulation in the design dialog: 'if the user would be surprised to see it in a log, don't log it.'\n\nExplicitly deferred: auto-logging Frame card field activity (Doing / Not Doing / Approach). Phase 1.5 deferred this because field edits are exploratory — the user may type and delete without committing. Wait one Course of dogfood before expanding. See LAB-044.\n\nThe surveillance line is a first-class design constraint, not a footnote. Every future Comprehend expansion should be evaluated against it."
+        },
         {
           "id": "chunk-missing-comprehend",
           "title": "Re-immersion has been doing work without a home",
@@ -4492,7 +4504,7 @@
       "accent": "blue",
       "workshop": true,
       "description": "Where Debrief practice and chapter live. Closes the cycle, captures, sets up the next gauge read. Currently the urgent priority — its absence is the gap that creates session-end integration debt.",
-      "items": ["LAB-003","LAB-004","LAB-032","LAB-038"],
+      "items": ["LAB-003","LAB-004","LAB-032","LAB-038","LAB-042"],
       "sources": [
         { "label": "turn-v0.1-phases-and-leverage.md (Debrief section)", "href": "turn-v0.1-phases-and-leverage.md" }
       ],
@@ -4594,7 +4606,7 @@
       "type": "aux / persistent",
       "accent": "dark",
       "description": "Your seat. Where the Frame card sits today, where lab notes get written. Also the home for cross-cutting lab work — agent composition, process docs, session integration.",
-      "items": ["LAB-022","LAB-023","LAB-024","LAB-029","LAB-034","LAB-035","LAB-037","LAB-039","LAB-040","LAB-041"],
+      "items": ["LAB-022","LAB-023","LAB-024","LAB-029","LAB-034","LAB-035","LAB-037","LAB-039","LAB-040","LAB-041","LAB-043","LAB-045"],
       "sources": [
         { "label": "PROCESS.md (how the agents compose, lab-to-book flow)", "href": "PROCESS.md" },
         { "label": "DECISIONS.md (synthesized decisions log)", "href": "DECISIONS.md" }
@@ -4623,6 +4635,30 @@
         }
       ],
       "chunks": [
+        {
+          "id": "chunk-four-channel-hex-encoding",
+          "title": "Four-channel Hex Map encoding — hue, luminosity, stroke, motion",
+          "summary": "Hex Map v0.2 assigns each cognitive job its own visual primitive: hue=biome, luminosity=relevance, stroke=priority, motion=attention. Stops overloading hue.",
+          "body": "Hex Map v0.1 used hue (biome color) and fog-of-war as its only encoding channels, with a priority glow ring that visually competed with the biome color. Morning dogfood surfaced the problem: P0 red was winning the visual fight against biome hue, making frontier state hard to read independently of priority state.\n\nv0.2 resolves this by giving each cognitive job its own independent channel:\n\n- **Hue** → biome (stable area identity; doesn't change within a Course).\n- **Luminosity** → relevance (4-state ramp; see chunk-luminosity-ramp).\n- **Stroke** → priority (P0 items in the area → 2px ring; no P0 → 1px or none).\n- **Motion** → attention (single pulse on select; ambient breath on active-leg working set; see chunk-motion-budget).\n\nEach channel is orthogonal. You can read P0 state without interpreting biome color. You can read relevance without reading priority. The four channels compose: the map becomes readable at a glance because each type of information has its own visual grammar.\n\n**What this replaces:** the v0.1 fill-vs-outline approach and the purple 'both' override ring. Both tried to encode multiple states through a single channel (fill pattern), which created ambiguity when states co-occurred."
+        },
+        {
+          "id": "chunk-luminosity-ramp",
+          "title": "Luminosity ramp — four-state relevance encoding",
+          "summary": "Four-state luminosity ramp: 18% archived (terrain), 50% available, 100% in-frontier, 100%+sat active in current leg. Logarithmic-ish steps for perceptual evenness.",
+          "body": "The luminosity channel encodes how relevant a hex is to the current leg's work:\n\n| State | Luminosity | Meaning |\n|---|---|---|\n| archived | 18% | terrain; context only; no active items |\n| available | 50% | items exist but not on current frontier |\n| in-frontier | 100% | reachable this week; on course.frontier[] |\n| active (current leg) | 100% + saturation boost | in working set for this leg |\n\nThe steps are logarithmic-ish rather than linear. Linear 0-25-50-100 would produce a ramp where the archived→available step is perceptually large and the available→frontier step is small. The logarithmic distribution (18-50-100) gives perceptually even steps — archived recedes into the background (terrain), available is readable but muted, frontier is fully lit.\n\nThe active-leg saturation boost distinguishes 'on course frontier' from 'actually in this leg's working set' without introducing a fifth luminosity state. Saturation is a distinct channel from luminosity; the combination is unambiguous.\n\nThe 18% floor for archived hexes is intentional: they stay visible as terrain context, not invisible. The map is a map — terrain below the fog line is still visible, just dark."
+        },
+        {
+          "id": "chunk-motion-budget",
+          "title": "Motion budget — pulse + breath, nothing more",
+          "summary": "Two motion behaviors only: single 600ms pulse on select, slow 6s ±5% ambient breath on active-leg working set. Cap prevents Vegas-slot-machine overload. Honors prefers-reduced-motion.",
+          "body": "Motion is the most attention-grabbing encoding channel available. The motion budget for the Hex Map is deliberately minimal:\n\n**Pulse (select):** a single 600ms opacity pulse when the user clicks a hex. One pulse, then stops. Confirms the selection landed without persisting the animation.\n\n**Breath (active-leg working set):** a slow ambient breathing animation (±5% opacity, 6s cycle) on hexes that are in the active leg's working set. The breath is slow enough to be peripheral — you notice it when you look, not from across the room. It signals 'this is live right now' without demanding focus.\n\n**The cap:** two behaviors only. No additional motion states, no layered animations, no staggered pulses. The cap is cognitive-load-driven — motion is a preattentive feature; uncontrolled motion pulls attention out of the author's current task.\n\n**prefers-reduced-motion:** both animations are suppressed when the OS reduced-motion preference is set. This is not optional — it's a hard constraint."
+        },
+        {
+          "id": "chunk-biome-regions",
+          "title": "Biome regions — clusters replace the random grid",
+          "summary": "Hex Map clusters areas into labeled, biome-tinted regions. Regions are the legend; the swatch row is gone. Sorted biggest-first so dominant biomes anchor the layout.",
+          "body": "Hex Map v0.1 laid out hexes in a simple grid. The layout looked random — there was no spatial grammar telling the author why Frame was next to the Gauge or why the Backlog Wall was adjacent to Director's Desk. Morning dogfood surfaced the misread: spatial proximity implied relationship, but the grid had no relationship logic.\n\nv0.2 clusters hexes into biome regions — groups of related areas that share an accent color and a conceptual cluster:\n\n- **Turn phases** (blue + amber): Frame · Comprehend · Sync · Produce · Debrief — the five-phase arc in one cluster.\n- **Capacity instruments** (amber + green): Gauge · Pilot Check · Recovery — the capacity regulation group.\n- **Lab infrastructure** (dark): Director's Desk · Library · Archive · Backlog Wall.\n- **Presentation** (teal): Deck Theater.\n\nEach region is labeled with the cluster name and biome-tinted (a faint background wash). The regions ARE the legend — there is no separate swatch row.\n\nSorting: regions render biggest-first. The largest biome (turn phases, with 5–6 hexes) anchors the layout; smaller clusters fill around it. This makes the dominant cognitive territory visually dominant, which is the right default.\n\n**Semantic adjacency within biomes** (deferred, LAB-043): Phase 1 packs hexes within a biome in a simple 3-column grid. Whether related items within a biome should cluster (chapter chunks near their sources) is deferred until lived use shows it matters."
+        },
         {
           "id": "chunk-snap-circuit-leg-view",
           "title": "Snap Circuit board — Leg view (v0.1)",
@@ -4825,7 +4861,8 @@
         "LAB-017","LAB-018","LAB-019","LAB-020","LAB-021","LAB-022","LAB-023","LAB-024",
         "LAB-025","LAB-026","LAB-027","LAB-028","LAB-029",
         "LAB-030","LAB-031","LAB-032","LAB-033",
-        "LAB-034","LAB-035","LAB-036","LAB-037","LAB-038","LAB-039","LAB-040","LAB-041"
+        "LAB-034","LAB-035","LAB-036","LAB-037","LAB-038","LAB-039","LAB-040","LAB-041",
+        "LAB-042","LAB-043","LAB-044","LAB-045","LAB-046"
       ],
       "artifacts": [],
       "notes": []
@@ -5222,6 +5259,51 @@
       "area": "director-desk",
       "brief": "Hex Map v0.1 is read-only. v0.2: click-to-add-to-frontier, hover details panel, semantic adjacency.",
       "full": "Hex Map v0.1 (commit c554317, Step 0b of the rogaine-spine arc) is read-only — biome/fog/glow/halo are rendered but not interactive. v0.2 targets: (1) click-to-add-to-frontier — clicking a hex opens a picker of that area's items to add to course.frontier[]; (2) hover details panel — hovering a hex shows item count, P0 count, active leg count, most recent Log entry title; (3) semantic adjacency — items from related areas are placed near each other on the map, not just grouped by area. Adjacency is a design call for Quenton (what makes two areas semantically adjacent in this lab?). P2 — the read-only map is valuable; interaction is quality-of-life."
+    },
+    "LAB-042": {
+      "id": "LAB-042",
+      "title": "Off-frontier picks → Debrief frontier-added pre-fill",
+      "status": "backlog",
+      "priority": "P2",
+      "area": "debrief-booth",
+      "brief": "Phase 2 captures ref.off_frontier=true on off-frontier picks. Debrief save handler should pre-fill changes_to_course.frontier_added from those flags so the user just confirms.",
+      "full": "Phase 2 of the rogaine-spine arc wires the Frame picker to default to the Course frontier and tags any off-frontier pick with ref.off_frontier=true plus a chip badge. The next step in the feedback loop: at Debrief time, the save handler reads the current leg's Frame picks, finds any flagged off_frontier=true, and pre-fills changes_to_course.frontier_added with those items. The user sees: 'You picked [item] off-frontier this leg — add to Course frontier?' and confirms or dismisses. This closes the Course-planning feedback loop without requiring manual cross-referencing between Frame and Debrief. P2 — the tag is in place; the pre-fill is a quality-of-life step after Debrief workshop ships (LAB-032)."
+    },
+    "LAB-043": {
+      "id": "LAB-043",
+      "title": "Hex Map adjacency v0.2 — semantic clusters within biomes",
+      "status": "backlog",
+      "priority": "P3",
+      "area": "director-desk",
+      "brief": "Phase 1 packs hexes per area in a 3-col grid within biomes. Open question: should items near related items within a biome cluster? Deferred until lived use shows it matters.",
+      "full": "Hex Map v0.2 (Phase 1) groups hexes into biome regions with a simple 3-column packing. Per Quenton's design dialog (turn 3), semantic adjacency within a biome — e.g., chapter chunks near their source documents, Frame near Pilot Check in the capacity cluster — was explicitly deferred. Rationale: the biome regions already provide 80% of the spatial grammar; adding within-biome adjacency logic before seeing how the map is actually used risks premature optimization. Revisit after one Course of dogfood. If the author navigates the map by looking for known relationships, semantic adjacency is worth the complexity. If they navigate by biome + label, it isn't. P3."
+    },
+    "LAB-044": {
+      "id": "LAB-044",
+      "title": "Comprehend Signals expansion (Frame field activity)",
+      "status": "backlog",
+      "priority": "P3",
+      "area": "comprehend-station",
+      "brief": "Phase 1.5 explicitly deferred auto-logging Frame card field activity (Doing/Not Doing/Approach). Wait one Course of dogfood; if the Comprehend zone stays sparse, expand.",
+      "full": "Phase 1.5 drew the Comprehend surveillance line at intentional acts the user would expect to leave a record: notes (manual), synthesis (status cycle), deck-opens. Frame card field activity — typing in Doing, Not Doing, or Approach — was explicitly excluded. Rationale: field edits are exploratory; the user may type and delete without committing. Logging field edits would capture intent-noise rather than intent-signal. However, if one Course of lived use shows the Comprehend zone staying sparse (few captures, thin record), expansion to field activity may be warranted. The question to answer at that point: what's the right commit event? (Save button? Field blur? Word count threshold?) Deferred to Quenton and the author after dogfood. P3."
+    },
+    "LAB-045": {
+      "id": "LAB-045",
+      "title": "prereqs[] data model + chain edges on Hex Map",
+      "status": "backlog",
+      "priority": "P2",
+      "area": "director-desk",
+      "brief": "Add prereqs[] field to items, back-fill known chains with the author, render arrows on the Hex Map as chain edges.",
+      "full": "Per Quenton's Phase 1 spec, 'chain rendering as drawn edges' was deferred because item.prereqs[] doesn't exist in the data model. The full build: (1) add prereqs: string[] to the item shape in the baseline JSON; (2) work with the author to back-fill known dependency chains (e.g., LAB-042 depends on LAB-032; LAB-037 depends on LAB-035); (3) render directed edges (arrows) between hex tiles on the Hex Map where a prereqs relationship exists. Arrows are lightweight — the map should remain readable; edges are secondary information. P2 — the prereqs data is the blocking artifact; the rendering follows once the data exists."
+    },
+    "LAB-046": {
+      "id": "LAB-046",
+      "title": "Comprehend sufficient threshold (Course Coach territory)",
+      "status": "backlog",
+      "priority": "P3",
+      "area": "comprehend-station",
+      "brief": "Phase 1.5 deferred: at what density/count does Comprehend register as sufficient? Don't pre-design — that's the Course Coach's job (LAB-034). Captured so it's not forgotten.",
+      "full": "Phase 1.5 deliberately deferred the question of sufficiency: when has a leg's Comprehend phase loaded enough context to proceed to Produce? This is not a question Larry or the lab UI should answer alone — it's Course Coach territory (LAB-034). The Course Coach reads leg histories and can detect patterns like 'legs where Comprehend had < 2 entries correlated with mid-leg re-immersion interruptions.' Pre-designing a sufficiency threshold now would be premature — it would encode a guess before the data exists to inform it. Capture the question here so it's not forgotten when LAB-034 becomes active. P3."
     }
   }
 }

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -422,6 +422,13 @@
   .hex-cell.breathing {
     animation: hex-breath 6s ease-in-out infinite;
   }
+  /* When a breathing hex is clicked, the pulse needs to win the cascade.
+     Same specificity as .breathing alone, so we promote with a 3-class
+     selector. Without this, the pulse-once animation is silently shadowed
+     and active-leg hexes eat clicks (caught by grepzilla phase 1 review). */
+  .hex-cell.pulse-once.breathing {
+    animation: hex-pulse-once 600ms ease-out;
+  }
   /* Motion-sensitivity guardrail — disable ambient breath but keep the
      single-pulse acknowledgment (it's a discrete event, not ambient). */
   @media (prefers-reduced-motion: reduce) {
@@ -8404,7 +8411,9 @@
       }).join('\n');
 
       // Region background + label (region-local coordinates 0..r.w, 0..r.h).
-      const bg = `<rect class="hex-region-bg" x="0" y="0" width="${r.w}" height="${r.h}" fill="${tint}" stroke="${tint}" />`;
+      // rx/ry as SVG presentation attributes serve as a fallback for browsers
+      // that don't support rx/ry as CSS properties (Firefox <122, Safari <17).
+      const bg = `<rect class="hex-region-bg" x="0" y="0" width="${r.w}" height="${r.h}" rx="8" ry="8" fill="${tint}" stroke="${tint}" />`;
       const labelY = HEX_PAD - 2;
       const label = `<text class="hex-region-label" x="${HEX_PAD}" y="${labelY}">${escapeHTML(r.areaName)}</text>` +
                     `<text class="hex-region-count" x="${(r.w - HEX_PAD).toFixed(2)}" y="${labelY}" text-anchor="end">${r.items.length}</text>`;

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -2524,6 +2524,16 @@
   }
   .course-header-bar .ch-link:hover { color: var(--fg); }
 
+  /* Scope .ff-hint inside the view-mode label so the "legacy" tag renders
+     dimmed/normal-case rather than inheriting the label's bold accent style. */
+  .ws-vb-row .lbl .ff-hint {
+    color: #6f7a90;
+    font-weight: normal;
+    text-transform: none;
+    letter-spacing: 0;
+    font-size: 9px;
+  }
+
   /* ── Debrief Workshop: rogaine-shape extras (Phase 4) ──
      Score display is auto-computed read-only summary. Radio group is
      the "Course held?" three-state pick that surfaces the framed-but-
@@ -6448,7 +6458,11 @@
   function dbCardHasContent(card) {
     if (!card) return false;
     if (card.course_held) return true;
-    return DB_FIELDS.some(f => (card[f] || '').toString().trim().length > 0);
+    if (DB_FIELDS.some(f => (card[f] || '').toString().trim().length > 0)) return true;
+    // Also surface legacy data so a user editing an old card and hitting
+    // Cancel without typing still gets the discard prompt — the card has
+    // *content* even if the new form doesn't expose those fields.
+    return DB_FIELDS_LEGACY.some(f => (card[f] || '').toString().trim().length > 0);
   }
   /* Score auto-derive from active leg's Frame card.
      Phase 4 only counts plan-side: Musts (from frame.must) and Bonus (from
@@ -6494,7 +6508,13 @@
   function attachDebriefToLeg(card) {
     if (!card || !card.savedAt) return null;
     const leg = findActiveLeg();
-    if (!leg) return null;
+    if (!leg) {
+      // Orphan Debrief: card is saved (above) but has no leg to write back
+      // to. Acceptable for now; surface a console warning so phase 5+ debug
+      // sessions can spot unexpected orphans without re-tracing the save path.
+      console.warn('[Debrief] No active leg — card saved as orphan:', card.savedAt);
+      return null;
+    }
     leg.debrief_card_id = card.savedAt;
     leg.changes_to_course = {
       at: new Date().toISOString(),
@@ -6514,6 +6534,7 @@
 
   let dbMode = 'resting';
   let dbEditingOriginalIdx = -1;
+  let dbEditingOriginalCard = null; // snapshot of the card at edit-open, for dirty/cancel checks
 
   function setDbMode(mode) {
     dbMode = mode;
@@ -6532,6 +6553,7 @@
 
   function dbEnterEditing(card, idx) {
     dbEditingOriginalIdx = (typeof idx === 'number') ? idx : -1;
+    dbEditingOriginalCard = card ? JSON.parse(JSON.stringify(card)) : null;
     const dateEl = document.getElementById('db-date');
     if (dateEl) dateEl.textContent = todayDateString();
     document.getElementById('db-editing-title').innerHTML =
@@ -6648,7 +6670,11 @@
     const cancelBtn = document.getElementById('db-cancel-btn');
     if (cancelBtn) cancelBtn.addEventListener('click', () => {
       const draft = readDebriefForm();
-      if (dbCardHasContent(draft) && !confirm('Discard this card? Unsaved changes will be lost.')) return;
+      // Treat as "has content" if the live draft has anything OR the original
+      // card had legacy data the form doesn't expose (so an edit-from-legacy
+      // still gets the discard prompt).
+      const hasContent = dbCardHasContent(draft) || dbCardHasContent(dbEditingOriginalCard);
+      if (hasContent && !confirm('Discard this card? Unsaved changes will be lost.')) return;
       dbEnterResting();
     });
 

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -5732,6 +5732,7 @@
     if (notesEl) notesEl.value = '';
     framePickerPanelOpen = { must: false, stretch: false };
     framePickerExpandTier = { must: 'P0', stretch: 'P0' };
+    framePickerScope = { must: 'frontier', stretch: 'frontier' };
     frameSlotExpanded = { must: new Set() };
     Object.keys(FF_PICKER_FIELDS).forEach(f => renderFramePicker(f));
   }
@@ -5740,9 +5741,14 @@
   // For LAB-027 v3, ref objects may carry optional approach fields
   // (mode / leaning_on / ai_people / done_this_turn). Pass them through
   // when present; absent on legacy v2.5 cards (back-compat).
+  // Phase 2: also pass through `off_frontier` so the flag survives a
+  // save/reload cycle. Without this, the chip's off-frontier badge
+  // disappears after every save and Debrief loses the candidate signal
+  // for changes_to_course.frontier_added.
   function coerceFieldValue(field, value) {
     if (Array.isArray(value)) return value.filter(r => r && r.id).map(r => {
       const out = { id: r.id, title: r.title || '' };
+      if (r.off_frontier === true) out.off_frontier = true;
       FF_SLOT_FIELDS.forEach(k => {
         if (typeof r[k] === 'string' && r[k].length > 0) out[k] = r[k];
       });
@@ -5776,6 +5782,13 @@
     if (notesEl) notesEl.value = card.must_notes || '';
     framePickerPanelOpen = { must: false, stretch: false };
     framePickerExpandTier = { must: 'P0', stretch: 'P0' };
+    // Phase 2: also reset scope to 'frontier' on card load. If the previous
+    // session ended with the user toggled to 'all' (e.g., because the prior
+    // card had no course frontier), defaulting back to 'frontier' surfaces
+    // the new card's frontier scope correctly. The auto-flip in
+    // renderFramePicker still kicks in if this card's course also lacks a
+    // frontier — so 'frontier' is the safe default in both cases.
+    framePickerScope = { must: 'frontier', stretch: 'frontier' };
     // Auto-expand any must slot whose ref carries approach data. Empty slots stay collapsed
     // so a fresh card doesn't open four panels at once. Keeps lived data visible after reload.
     frameSlotExpanded = { must: new Set() };

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -5379,9 +5379,11 @@
     el.innerHTML = parts.join('');
   }
 
-  // Course Header click handler (only the goto-course link is clickable today).
+  // Course Header click handler. Use closest() so a future inner-element
+  // wrap (e.g., <strong> inside the link) doesn't break the dispatch.
   document.addEventListener('click', (e) => {
-    if (e.target && e.target.classList && e.target.classList.contains('ch-link') && e.target.dataset.act === 'goto-course') {
+    const tgt = e.target && e.target.closest ? e.target.closest('[data-act="goto-course"]') : null;
+    if (tgt && tgt.classList && tgt.classList.contains('ch-link')) {
       if (typeof setView === 'function') setView('course');
     }
   });
@@ -7898,6 +7900,20 @@
     `;
   }
 
+  /* Format helper used by both the Comprehend section and the Leg view's
+     Comprehend zone. Defined up here so both call sites pre-date the
+     definition is impossible (function-declaration hoisting works either
+     way; the explicit ordering also documents intent). */
+  function fmtComprehendWhen(iso) {
+    if (!iso) return '·';
+    try {
+      const d = new Date(iso);
+      const date = d.toISOString().slice(0, 10);
+      const time = d.toTimeString().slice(0, 5);
+      return date + ' · ' + time;
+    } catch { return iso; }
+  }
+
   /* ── Leg view: Snap Circuit board (Phase 5) ──
      Renders the active leg as a five-zone circuit board. Each zone reads
      from the corresponding leg sub-record and the linked Frame/Debrief
@@ -7991,12 +8007,15 @@
       '<ul class="leg-comprehend-list">' + items + '</ul>' + more);
   }
   function renderLegZoneSync(leg) {
+    // ≈ (U+2248) renders consistently across platforms — engineering-symbol
+    // glyphs like ⏚ tofu out on Windows. Filter / capacitor evokes the same
+    // signal-shaping role.
     if (!leg.sync) {
-      return legZoneShell('sync', '⏚', 'filter', 'Sync', '', 'deferred',
+      return legZoneShell('sync', '≈', 'filter', 'Sync', '', 'deferred',
         '<div class="leg-zone-empty">Sync station deferred to a later phase. The slot exists; the form does not yet.</div>');
     }
-    const summary = (leg.sync && leg.sync.summary) || JSON.stringify(leg.sync).slice(0, 200);
-    return legZoneShell('sync', '⏚', 'filter', 'Sync', 'lit', 'captured',
+    const summary = (leg.sync && leg.sync.summary) || '(sync data present — no summary)';
+    return legZoneShell('sync', '≈', 'filter', 'Sync', 'lit', 'captured',
       `<div class="leg-zone-line"><span class="lzl-value">${escapeHTML(summary)}</span></div>`);
   }
   function renderLegZoneProduce(leg) {
@@ -8040,8 +8059,11 @@
   }
 
   // Leg-view click handler (jump to Frame Workshop from the empty-state).
+  // Use closest() so wrapping the link's text in a child element later
+  // (e.g., <strong>) doesn't silently break the dispatch.
   document.addEventListener('click', (e) => {
-    if (e.target && e.target.dataset && e.target.dataset.act === 'goto-frame') {
+    const tgt = e.target && e.target.closest ? e.target.closest('[data-act="goto-frame"]') : null;
+    if (tgt) {
       if (typeof setView === 'function') setView('floor');
       if (typeof openDrawer === 'function') openDrawer('frame-workshop');
     }
@@ -8050,16 +8072,8 @@
   /* ── On-demand Comprehend (Phase 3) ──
      Single textarea + Capture button. Appends a timestamped note to the
      active leg's comprehend[]. Renders the most-recent-first log below.
-     If no active leg exists yet, prompts the user to start one via Frame. */
-  function fmtComprehendWhen(iso) {
-    if (!iso) return '·';
-    try {
-      const d = new Date(iso);
-      const date = d.toISOString().slice(0, 10);
-      const time = d.toTimeString().slice(0, 5);
-      return date + ' · ' + time;
-    } catch { return iso; }
-  }
+     If no active leg exists yet, prompts the user to start one via Frame.
+     fmtComprehendWhen is defined above (shared with the Leg view). */
   function renderCourseComprehend() {
     const wrap = document.getElementById('course-comprehend');
     if (!wrap) return;

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -926,7 +926,10 @@
     background: var(--panel-bg);
     border: 1px solid var(--panel-bd);
     border-radius: 6px;
-    overflow: hidden;
+    /* overflow: visible so the sidebar item hover-preview tooltip can
+       escape into the main pane area without being clipped. Scoped
+       clipping happens on the inner sidebar/main panes individually. */
+    overflow: visible;
   }
   .comp-studio-header {
     padding: 8px 14px;
@@ -1037,6 +1040,19 @@
     overflow: hidden;
     display: flex;
     flex-direction: column;
+    /* Border-radius lives on the parent .comp-studio. Round just the
+       right corners on the main pane so the visual remains crisp now
+       that the parent uses overflow: visible. */
+    border-top-right-radius: 6px;
+    border-bottom-right-radius: 6px;
+  }
+  /* Scoped empty-state styling for the studio sidebar (the global
+     .comp-snap-val .comp-snap-empty selector doesn't match here). */
+  .comp-studio-sidebar .comp-snap-empty {
+    color: #6f7a90;
+    font-style: italic;
+    font-size: 11px;
+    padding: 6px 8px;
   }
   .comp-studio-main-empty {
     padding: 40px 24px;
@@ -8205,7 +8221,12 @@
        kind         'deck' or 'product' (Move 2d adds product walks)
        subtitle?    short blurb under the title
        preview?     hover-tooltip text (Move 2e polish fold)
-       deck_href?   for kind:'deck' — iframe src (relative path)
+       deck_href?   for kind:'deck' — iframe src (relative path).
+                    MUST be a trusted local path. The iframe loads
+                    same-origin without `sandbox`, so an external or
+                    untrusted URL would run with full lab privileges.
+                    If a future workflow ingests external decks, gate
+                    them through a sandbox allowlist before adding here.
        target_route? for kind:'product' — hash route to boot the lab
                      iframe into for the walk's first step
        steps?       for kind:'product' — array of {narrative, target_selector?}

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -1608,13 +1608,16 @@
   .cc-kind-note      { color: #d4a030; background: rgba(212,160,48,0.10); border: 1px solid rgba(212,160,48,0.35); }
   .cc-kind-synthesis { color: #5cb09a; background: rgba(92,176,154,0.10); border: 1px solid rgba(92,176,154,0.35); }
   .cc-kind-deck      { color: #6f9ee0; background: rgba(74,123,212,0.10); border: 1px solid rgba(74,123,212,0.35); }
+  .cc-kind-walk      { color: #c897cf; background: rgba(204,121,167,0.10); border: 1px solid rgba(204,121,167,0.35); }
   .course-comprehend-entry .cc-body { color: var(--fg); }
   /* Synthesis + deck entries: px-font emphasis on the body since they're
      ID-shaped or path-shaped, not prose. */
   .course-comprehend-entry.cc-synthesis .cc-body,
   .course-comprehend-entry.cc-deck .cc-body,
+  .course-comprehend-entry.cc-walk .cc-body,
   .leg-comprehend-list li.cc-synthesis,
-  .leg-comprehend-list li.cc-deck { font-family: var(--font-px); font-size: 11.5px; }
+  .leg-comprehend-list li.cc-deck,
+  .leg-comprehend-list li.cc-walk { font-family: var(--font-px); font-size: 11.5px; }
 
   /* ── Lab tile (shared across alt views) ──
      Each tile pulls its area icon + accent color from the floor,
@@ -8729,8 +8732,12 @@
           setWalkStep(0); // start fresh
           if (walk.kind === 'deck' && walk.deck_href && typeof logComprehendDeckOpen === 'function') {
             logComprehendDeckOpen(walk.deck_href);
+          } else if (walk.kind === 'product') {
+            // Move 2e: log walk-start so abandoned walks register as
+            // intent. Completion is logged separately via the Done
+            // button (see doneBtn handler below).
+            logComprehendWalkStart(walk.id);
           }
-          // Move 2e will log walk-start here for product walks.
         }
         renderComprehendStudio(studio);
       });
@@ -8758,10 +8765,41 @@
     });
     const doneBtn = studio.querySelector('[data-act="walk-done"]');
     if (doneBtn) doneBtn.addEventListener('click', () => {
-      // Move 2e will log walk-completion here. For 2d, just close.
+      // Move 2e: log walk completion to leg.comprehend[]. The walk's
+      // active-id state clears after; the entry is durable.
+      const id = getActiveWalkId();
+      const walk = id ? WALKS.find(w => w.id === id) : null;
+      if (walk) {
+        const stepsCompleted = (walk.steps || []).length;
+        logComprehendWalkComplete(walk.id, stepsCompleted);
+      }
       setActiveWalkId(null);
       setWalkStep(0);
       renderComprehendStudio(studio);
+    });
+  }
+
+  /* Walk start + completion logging (Move 2e). Both append to the
+     active leg's comprehend[] as kind:'walk' with a status discriminator
+     ('started' or 'completed'). Per Quenton: progress is session,
+     completion is durable on the leg. Logging the *start* captures
+     intent — abandoned walks show up as evidence the user tried, even
+     if they never reached Done. */
+  function logComprehendWalkStart(walkId) {
+    if (typeof appendComprehendEntry !== 'function') return;
+    appendComprehendEntry({
+      kind: 'walk',
+      walk_id: walkId,
+      status: 'started'
+    });
+  }
+  function logComprehendWalkComplete(walkId, stepsCompleted) {
+    if (typeof appendComprehendEntry !== 'function') return;
+    appendComprehendEntry({
+      kind: 'walk',
+      walk_id: walkId,
+      status: 'completed',
+      steps_completed: typeof stepsCompleted === 'number' ? stepsCompleted : 0
     });
   }
 
@@ -10773,6 +10811,7 @@
     if (kindCounts.note)      subtitleParts.push(kindCounts.note + ' note' + (kindCounts.note === 1 ? '' : 's'));
     if (kindCounts.synthesis) subtitleParts.push(kindCounts.synthesis + ' synthesis');
     if (kindCounts.deck)      subtitleParts.push(kindCounts.deck + ' deck' + (kindCounts.deck === 1 ? '' : 's'));
+    if (kindCounts.walk)      subtitleParts.push(kindCounts.walk + ' walk' + (kindCounts.walk === 1 ? '' : 's'));
     const subtitle = subtitleParts.join(' · ');
 
     const recent = entries.slice(-3).reverse();
@@ -10931,6 +10970,16 @@
     if (k === 'deck') {
       const src = escapeHTML(entry.source || '?');
       return { kind: 'deck', label: 'deck', bodyHTML: src };
+    }
+    if (k === 'walk') {
+      // Move 2e: walk entries carry walk_id + status (started/completed)
+      // and steps_completed when the user reached the Done button.
+      const wid = escapeHTML(entry.walk_id || '?');
+      const status = escapeHTML(entry.status || 'started');
+      const stepsTxt = (typeof entry.steps_completed === 'number')
+        ? '  ' + entry.steps_completed + ' steps'
+        : '';
+      return { kind: 'walk', label: 'walk', bodyHTML: wid + '  ' + status + stepsTxt };
     }
     // 'note' (default) — text body, newlines preserved
     const txt = escapeHTML(entry.text || '').replace(/\n/g, '<br>');

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -8838,6 +8838,12 @@
     // mouseout fires on the detached node, leaving a stale tooltip.
     const staleTooltip = document.getElementById('hex-tooltip');
     if (staleTooltip) staleTooltip.hidden = true;
+    // Clear stale chip state. The action chip's DOM is destroyed by any
+    // full re-render; the in-memory ID should follow. (bcInHand is *not*
+    // cleared — it's intentional state that should survive lens switches
+    // so the user can pivot between Build and another lens with their
+    // held piece intact.)
+    bcActionItemId = null;
     const c = getOrInitCourseDraft();
     const frontierSet = new Set(c.frontier || []);
     const workingSet = getActiveLegWorkingSet();
@@ -9339,11 +9345,17 @@
     }
     // Outside-click closer. Closes over the chip element directly so that
     // chip-button clicks (which bubble to document) are correctly identified
-    // as inside the chip — avoids both the never-registered bug and the
-    // double-render-on-button-click bug grepzilla flagged.
+    // as inside the chip. Bail early if some other render path already
+    // cleared bcActionItemId (e.g., a lens switch); avoids the double-render
+    // on lens-switch-while-chip-open that grepzilla's cumulative sweep
+    // caught.
     setTimeout(() => {
       const closer = (e) => {
         if (chip.contains(e.target)) return;
+        if (bcActionItemId === null) {
+          document.removeEventListener('click', closer);
+          return;
+        }
         bcActionItemId = null;
         document.removeEventListener('click', closer);
         renderCourseHexMap();

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -1054,6 +1054,141 @@
     font-size: 11px;
     padding: 6px 8px;
   }
+
+  /* Product walk — step renderer (Move 2d). When the active walk is
+     kind:'product', the main pane splits internally: narrative panel
+     (top, left-aligned) above the iframe of the lab in ?walk=1 mode. */
+  .comp-walk-step {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    height: 100%;
+  }
+  .comp-walk-narrative {
+    background: var(--panel-bg);
+    border-bottom: 1px solid var(--panel-bd);
+    padding: 12px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    max-height: 240px;
+    overflow-y: auto;
+  }
+  .comp-walk-step-header {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    font-family: var(--font-px);
+    font-size: 10px;
+    color: var(--accent-dim);
+    letter-spacing: 1px;
+    text-transform: uppercase;
+  }
+  .comp-walk-step-header .comp-walk-step-counter { color: var(--accent); font-weight: bold; }
+  .comp-walk-step-title {
+    font-family: inherit;
+    font-size: 14px;
+    color: var(--fg);
+    margin: 0;
+    line-height: 1.4;
+    text-transform: none;
+    letter-spacing: 0;
+  }
+  .comp-walk-step-body {
+    font-size: 12.5px;
+    color: var(--fg);
+    line-height: 1.55;
+    white-space: pre-wrap;
+  }
+  .comp-walk-step-body strong { color: var(--accent); }
+  .comp-walk-step-body code {
+    font-family: var(--font-px);
+    background: rgba(255,255,255,0.06);
+    padding: 1px 4px;
+    border-radius: 2px;
+    font-size: 11.5px;
+  }
+  .comp-walk-actions {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    margin-top: 4px;
+  }
+  .comp-walk-actions button {
+    background: transparent;
+    border: 1px solid var(--panel-bd);
+    color: var(--fg);
+    padding: 5px 10px;
+    border-radius: 3px;
+    font-family: var(--font-px);
+    font-size: 10.5px;
+    letter-spacing: 0.5px;
+    cursor: pointer;
+  }
+  .comp-walk-actions button:hover {
+    background: rgba(226,160,74,0.10);
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+  .comp-walk-actions button.primary {
+    background: var(--accent);
+    color: #1a1a2e;
+    border-color: var(--accent);
+    font-weight: bold;
+  }
+  .comp-walk-actions button.primary:hover { background: #e6ad55; color: #1a1a2e; }
+  .comp-walk-actions button[disabled] { opacity: 0.4; cursor: not-allowed; pointer-events: none; }
+  .comp-walk-warning {
+    background: rgba(194,84,80,0.14);
+    border: 1px solid rgba(194,84,80,0.55);
+    border-radius: 4px;
+    padding: 6px 10px;
+    color: #ffb0a8;
+    font-size: 11.5px;
+    line-height: 1.5;
+  }
+  .comp-walk-warning strong { color: #ffb0a8; }
+
+  /* Walk-mode banner (Move 2d). When the lab is loaded inside the
+     Walk Studio iframe (?walk=1), this top banner gives the user a
+     wayfinding handle and the Comprehend Station area is hidden from
+     the floor to prevent recursive Walk Studios. */
+  .walk-banner {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 600;
+    background: rgba(226,160,74,0.96);
+    color: #1a1a2e;
+    padding: 5px 14px;
+    font-family: var(--font-px);
+    font-size: 11px;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+    text-align: center;
+    border-bottom: 1px solid #1a1a2e;
+  }
+  body.walk-mode { padding-top: 26px; }
+  body.walk-mode .area[data-area="comprehend-station"] {
+    opacity: 0.3;
+    pointer-events: none;
+    position: relative;
+  }
+  body.walk-mode .area[data-area="comprehend-station"]::after {
+    content: 'inert in walk mode';
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: var(--font-px);
+    font-size: 9px;
+    color: #1a1a2e;
+    background: rgba(226,160,74,0.55);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+  }
   .comp-studio-main-empty {
     padding: 40px 24px;
     text-align: center;
@@ -8234,6 +8369,42 @@
                      (triggers the step-0 mutation warning) */
   const WALKS = [
     {
+      id: 'walk-build-canvas-v0.1',
+      title: 'Build canvas v0.1',
+      kind: 'product',
+      subtitle: '7 steps · click-to-place tour',
+      preview: 'Hands-on tour of the Build canvas (the snap-circuit board) that shipped in the v0.4 arc. Place items from the drawer onto the grid, swap, remove, apply a template.',
+      target_route: 'view=course&lens=build',
+      mutates: true,
+      steps: [
+        {
+          narrative: '**Welcome to the Build canvas walk.**\n\nThis walk replaces my chat-based test instructions for the v0.4 build canvas. You\'ll click through 6 steps inside the live lab on the right.\n\n**Heads-up:** clicking around in this walk will modify your active Course\'s build_positions. That\'s the point — but if you want a sandbox, open a fresh Course before continuing.\n\nClick **Next** when you\'re ready.',
+          warn: true
+        },
+        {
+          narrative: 'You\'re on the **Course view**, with the **Build** sub-tab selected. Three tabs are available: **▦ Build** (you\'re here) · **⛰ By function** (biome regions) · **◎ By priority** (concentric rings).\n\nThe Build tab is the canvas the user designs themselves. The other two are read-only re-projections of the same data.\n\nIn the right pane, take a beat to look at the layout: empty grid (left), tool drawer (right). Then click **Next**.'
+        },
+        {
+          narrative: '**The grid** is 7 rows × 10 cols (cells **A1**–**G10**). Each cell has a center "snap point" — that\'s where pieces land.\n\n**The drawer** lists all your unplaced LAB items, grouped by area. Each area is one biome (Frame Workshop, Pilot Check, Debrief Booth, etc) with its own color from the Okabe-Ito palette.\n\nAbove the drawer items, two buttons: **▦ Apply template** + **✕ Clear board**.\n\nClick **Next** to start placing.'
+        },
+        {
+          narrative: '**Click any item in the drawer.** It enters "in-hand" state — accent border, accent fill, the item is now ready to place.\n\nNotice the canvas: empty cells now show a subtle accent tint (they\'re drop targets), and the cursor turns to a crosshair on hover.\n\nClick the same item again to drop it (or pick a different one to swap what\'s in hand).\n\nThen click **Next**.'
+        },
+        {
+          narrative: '**With an item in hand, click an empty cell.**\n\nThe piece snaps into place. The cell now shows a colored hex (color = area accent) with the LAB-### number label.\n\nThe item disappears from the drawer (the drawer filters by what\'s already placed). The header shows updated counts: "**N placed · M in drawer**".\n\nClick **Next**.'
+        },
+        {
+          narrative: '**Try the template.** Above the drawer items, click **▦ Apply template**.\n\nThis batch-places the active Course\'s frontier items onto the grid in priority + area order, snapped row-major. It **skips items you\'ve already placed** — your earlier placement is preserved.\n\nIf the frontier is empty, the button is disabled. If everything\'s already placed, you get a brief "Nothing new to place" message.\n\nClick **Next** to learn how to edit placements.'
+        },
+        {
+          narrative: '**Click any placed piece.** A small action chip pops up next to the cell with three options: **⇪ Pick up** · **↩ Remove** · **× Cancel**.\n\n- **Pick up** = removes the piece and puts it in hand. Click an empty cell to re-place. (This is the "move" affordance — drag-and-drop is deferred to v0.5+.)\n- **Remove** = pulls the piece back to the drawer.\n- **Cancel** = closes the chip.\n\nClicking outside the chip also closes it.\n\nClick **Next** to wrap up.'
+        },
+        {
+          narrative: '**You\'ve walked the Build canvas.**\n\nThe key moves: drawer-pick → place → click-to-edit. The grid is yours; the template is a starting position, not a constraint.\n\nWhat\'s deferred to v0.5+: drag-and-drop, sandbox-Course mode for state-mutating walks, multi-walk sequences, walk-authoring UI, interactive verification (auto-advance on correct click).\n\nClick **Done** to mark the walk complete and log it to your active leg\'s comprehend timeline. Or close from the Comprehend Station header to exit without logging.'
+        }
+      ]
+    },
+    {
       id: 'deck-rogaine-spine',
       title: 'The Rogaine Spine',
       kind: 'deck',
@@ -8254,6 +8425,7 @@
   // walk's progress (per Quenton: progress is session, completion is
   // durable on the leg's comprehend log).
   const COMP_ACTIVE_WALK_KEY = 'cognitive-lab-v0.1::comp-active-walk';
+  const COMP_WALK_STEP_KEY   = 'cognitive-lab-v0.1::comp-walk-step';
   function getActiveWalkId() {
     try { return sessionStorage.getItem(COMP_ACTIVE_WALK_KEY); }
     catch { return null; }
@@ -8263,6 +8435,35 @@
       if (id) sessionStorage.setItem(COMP_ACTIVE_WALK_KEY, id);
       else sessionStorage.removeItem(COMP_ACTIVE_WALK_KEY);
     } catch {}
+  }
+  function getWalkStep() {
+    try {
+      const v = parseInt(sessionStorage.getItem(COMP_WALK_STEP_KEY), 10);
+      return Number.isFinite(v) && v >= 0 ? v : 0;
+    } catch { return 0; }
+  }
+  function setWalkStep(n) {
+    try { sessionStorage.setItem(COMP_WALK_STEP_KEY, String(Math.max(0, n | 0))); } catch {}
+  }
+  // Render `**bold**` and `code` chunks in walk narrative as HTML. Plain
+  // markdown subset; nothing fancy. escapeHTML runs first so the input
+  // is safe before we apply the inline transforms.
+  function renderWalkMarkdownInline(text) {
+    let s = escapeHTML(text || '');
+    // **bold**
+    s = s.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+    // `code`
+    s = s.replace(/`([^`]+)`/g, '<code>$1</code>');
+    // newlines → <br>
+    s = s.replace(/\n/g, '<br>');
+    return s;
+  }
+  // Build the iframe URL for a product walk. Adds `?walk=1` plus the
+  // walk's target_route (if set).
+  function walkIframeSrc(walk) {
+    let qs = 'walk=1';
+    if (walk.target_route) qs += '&' + walk.target_route;
+    return 'cognitive-lab-v0.1.html?' + qs;
   }
 
   // Snapshot collapse state — sessionStorage so a single dogfood
@@ -8449,8 +8650,42 @@
           '<iframe class="comp-studio-iframe" src="' + escapeHTML(activeWalk.deck_href) + '" title="' + escapeHTML(activeWalk.title) + '"></iframe>' +
         '</div>';
     } else {
-      // Product walk (Move 2d) — placeholder until 2d wires the step renderer.
-      mainHTML = '<div class="comp-studio-main-empty">Product walks land in Move 2d.</div>';
+      // Product walk: split internal pane (narrative + Back/Next on top,
+      // iframe of the lab in walk mode below).
+      const steps = Array.isArray(activeWalk.steps) ? activeWalk.steps : [];
+      const stepCount = steps.length;
+      let stepIdx = Math.min(Math.max(getWalkStep(), 0), Math.max(stepCount - 1, 0));
+      const step = steps[stepIdx] || { narrative: '(walk has no steps)' };
+      const isFirst = stepIdx === 0;
+      const isLast  = stepIdx >= stepCount - 1;
+      const stepCounter = stepCount > 0 ? `Step ${stepIdx + 1} of ${stepCount}` : 'Step';
+      const warningHTML = step.warn
+        ? `<div class="comp-walk-warning"><strong>⚠ Mutation warning:</strong> this walk modifies your active Course\'s state. Open a fresh Course before continuing if you want a sandbox.</div>`
+        : '';
+      const narrativeBody = renderWalkMarkdownInline(step.narrative || '');
+      mainHTML =
+        '<div class="comp-studio-iframe-wrap">' +
+          '<div class="comp-studio-iframe-bar">' +
+            '<span class="comp-studio-bar-title">' + escapeHTML(activeWalk.title) + '</span>' +
+            '<a href="#" data-act="walk-close" title="Close this walk">× close</a>' +
+          '</div>' +
+          '<div class="comp-walk-step">' +
+            '<div class="comp-walk-narrative">' +
+              '<div class="comp-walk-step-header">' +
+                '<span class="comp-walk-step-counter">' + escapeHTML(stepCounter) + '</span>' +
+              '</div>' +
+              warningHTML +
+              '<div class="comp-walk-step-body">' + narrativeBody + '</div>' +
+              '<div class="comp-walk-actions">' +
+                '<button type="button" data-act="walk-prev" ' + (isFirst ? 'disabled' : '') + '>← Back</button>' +
+                (isLast
+                  ? '<button type="button" class="primary" data-act="walk-done">Done</button>'
+                  : '<button type="button" class="primary" data-act="walk-next">Next →</button>') +
+              '</div>' +
+            '</div>' +
+            '<iframe class="comp-studio-iframe" src="' + escapeHTML(walkIframeSrc(activeWalk)) + '" title="' + escapeHTML(activeWalk.title) + ' (walk mode)"></iframe>' +
+          '</div>' +
+        '</div>';
     }
 
     studio.innerHTML =
@@ -8474,11 +8709,14 @@
         if (getActiveWalkId() === id) {
           // Re-clicking the active walk closes it.
           setActiveWalkId(null);
+          setWalkStep(0);
         } else {
           setActiveWalkId(id);
+          setWalkStep(0); // start fresh
           if (walk.kind === 'deck' && walk.deck_href && typeof logComprehendDeckOpen === 'function') {
             logComprehendDeckOpen(walk.deck_href);
           }
+          // Move 2e will log walk-start here for product walks.
         }
         renderComprehendStudio(studio);
       });
@@ -8489,9 +8727,28 @@
       closeLink.addEventListener('click', (e) => {
         e.preventDefault();
         setActiveWalkId(null);
+        setWalkStep(0);
         renderComprehendStudio(studio);
       });
     }
+    // Product walk Back / Next / Done.
+    const backBtn = studio.querySelector('[data-act="walk-prev"]');
+    if (backBtn) backBtn.addEventListener('click', () => {
+      setWalkStep(getWalkStep() - 1);
+      renderComprehendStudio(studio);
+    });
+    const nextBtn = studio.querySelector('[data-act="walk-next"]');
+    if (nextBtn) nextBtn.addEventListener('click', () => {
+      setWalkStep(getWalkStep() + 1);
+      renderComprehendStudio(studio);
+    });
+    const doneBtn = studio.querySelector('[data-act="walk-done"]');
+    if (doneBtn) doneBtn.addEventListener('click', () => {
+      // Move 2e will log walk-completion here. For 2d, just close.
+      setActiveWalkId(null);
+      setWalkStep(0);
+      renderComprehendStudio(studio);
+    });
   }
 
   // Wire debrief controls (bound once at load)
@@ -8833,6 +9090,14 @@
   let activeView = 'floor';
 
   function loadActiveView() {
+    // Move 2d: when the lab loads inside a Walk Studio iframe, the
+    // walk's target_route can override the user's persisted active
+    // view via the `?view=` query param. URL > localStorage > default.
+    try {
+      const params = new URLSearchParams(location.search);
+      const urlView = params.get('view');
+      if (urlView && VIEWS.includes(urlView)) return urlView;
+    } catch {}
     try {
       const v = localStorage.getItem(VIEW_KEY);
       return VIEWS.includes(v) ? v : 'floor';
@@ -9547,6 +9812,13 @@
   const COURSE_HEX_LENS_KEY = 'cognitive-lab-v0.1::course-hex-lens';
   const COURSE_HEX_LENSES = ['build', 'function', 'priority'];
   function loadCourseHexLens() {
+    // Move 2d: walk target_route can override the persisted lens via
+    // `?lens=` query param. URL > localStorage > default.
+    try {
+      const params = new URLSearchParams(location.search);
+      const urlLens = params.get('lens');
+      if (urlLens && COURSE_HEX_LENSES.includes(urlLens)) return urlLens;
+    } catch {}
     try {
       const v = localStorage.getItem(COURSE_HEX_LENS_KEY);
       return COURSE_HEX_LENSES.includes(v) ? v : 'build';
@@ -11405,6 +11677,24 @@
      Hydrate localStorage from the server's canonical files first (if available),
      then bootstrap the UI. On plain `python -m http.server` the fetches 404 and
      we fall through to the existing localStorage-only behavior. */
+
+  // Move 2d: walk-mode detection. When the lab loads inside a Walk
+  // Studio iframe with `?walk=1`, mark the body and inject a banner
+  // so the user has a wayfinding handle. CSS hides the Comprehend
+  // Station from the floor to prevent recursive Walk Studios.
+  (function applyWalkMode() {
+    let walkFlag = false;
+    try {
+      walkFlag = new URLSearchParams(location.search).get('walk') === '1';
+    } catch {}
+    if (!walkFlag) return;
+    document.body.classList.add('walk-mode');
+    const banner = document.createElement('div');
+    banner.className = 'walk-banner';
+    banner.textContent = '⚑ Walk in progress — close from the Comprehend Station to return to the full lab';
+    document.body.insertBefore(banner, document.body.firstChild);
+  })();
+
   hydrateFromServer().then(() => {
     renderFloorBadges();
     buildAreaVisuals();

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -633,6 +633,44 @@
     font-size: 11px;
     padding: 8px 6px;
   }
+  /* Drawer action buttons (Move 3e): Apply template + Clear board.
+     Live in the drawer header below the title. */
+  .bc-drawer-actions {
+    display: flex;
+    gap: 4px;
+    margin-bottom: 8px;
+    flex-wrap: wrap;
+  }
+  .bc-drawer-action {
+    flex: 1;
+    min-width: 92px;
+    background: transparent;
+    color: var(--accent-dim);
+    border: 1px solid var(--panel-bd);
+    border-radius: 3px;
+    padding: 5px 8px;
+    font-family: var(--font-px);
+    font-size: 9.5px;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    cursor: pointer;
+    transition: color 100ms, border-color 100ms, background 100ms;
+  }
+  .bc-drawer-action:hover {
+    color: var(--accent);
+    border-color: var(--accent);
+    background: rgba(226,160,74,0.08);
+  }
+  .bc-drawer-action.danger:hover {
+    color: #ffb0a8;
+    border-color: #c25450;
+    background: rgba(194,84,80,0.10);
+  }
+  .bc-drawer-action[disabled] {
+    opacity: 0.4;
+    cursor: not-allowed;
+    pointer-events: none;
+  }
   /* In-hand state (Move 3d): drawer item that's currently being held,
      ready to snap into a cell. Highlighted with accent border + bg. */
   .bc-drawer-item.bc-in-hand {
@@ -8925,6 +8963,64 @@
       upsertCourse(c);
     }
   }
+  function clearAllBuildPositions() {
+    const c = getOrInitCourseDraft();
+    if (c.build_positions && Object.keys(c.build_positions).length > 0) {
+      c.build_positions = {};
+      upsertCourse(c);
+    }
+  }
+  /* Move 3e template apply: takes the active course's frontier,
+     resolves to actual items, sorts by priority then area, and snaps
+     them into the canvas in row-major order starting at (0,0). Skips
+     items already placed (preserves user's existing layout). Returns
+     the count placed. Per Quenton: starting position, not constraint —
+     every piece is individually editable after via the action chip. */
+  function applyBuildTemplate(items) {
+    const c = getOrInitCourseDraft();
+    const positions = (c.build_positions = c.build_positions || {});
+    const frontier = Array.isArray(c.frontier) ? c.frontier : [];
+    const placedSet = new Set(Object.keys(positions));
+    const itemsById = new Map();
+    (items || []).forEach(it => itemsById.set(it.id, it));
+    // Frontier items in priority+area order. Drops items already placed
+    // and items that don't resolve (frontier id with no matching item).
+    const candidates = frontier
+      .map(id => itemsById.get(id))
+      .filter(it => it && !placedSet.has(it.id))
+      .sort((a, b) => {
+        const pa = priorityRank(a.priority) - priorityRank(b.priority);
+        if (pa !== 0) return pa;
+        const ax = (a.areaName || '').localeCompare(b.areaName || '');
+        if (ax !== 0) return ax;
+        return (a.id || '').localeCompare(b.id || '');
+      });
+    // Find the first empty cell in row-major order; place each candidate
+    // there. If the canvas fills (>= BC_ROWS * BC_COLS placements), stop.
+    const occupiedCells = new Set();
+    Object.values(positions).forEach(p => {
+      if (p && typeof p.row === 'number') occupiedCells.add(p.row + ',' + p.col);
+    });
+    let placedCount = 0;
+    let cursor = 0;
+    for (const it of candidates) {
+      // Walk row-major from `cursor` until we find an empty cell.
+      while (cursor < BC_ROWS * BC_COLS) {
+        const row = Math.floor(cursor / BC_COLS);
+        const col = cursor % BC_COLS;
+        cursor++;
+        if (!occupiedCells.has(row + ',' + col)) {
+          positions[it.id] = { row, col };
+          occupiedCells.add(row + ',' + col);
+          placedCount++;
+          break;
+        }
+      }
+      if (cursor >= BC_ROWS * BC_COLS) break;
+    }
+    if (placedCount > 0) upsertCourse(c);
+    return placedCount;
+  }
   function renderCourseLensBuild(slot, items /*, frontierSet, workingSet */) {
     const course = getOrInitCourseDraft();
     const positions = getBuildPositions(course);
@@ -9058,10 +9154,14 @@
         <div class="bc-drawer" aria-label="Item drawer">
           <p class="bc-drawer-title">Tool drawer · ${drawerItems.length} items</p>
           <p class="bc-drawer-sub">Pieces grouped by area. Click to take in hand; click again to drop. With one in hand, click a cell to snap it.</p>
+          <div class="bc-drawer-actions">
+            <button type="button" class="bc-drawer-action" data-act="apply-template" ${(course.frontier || []).length === 0 ? 'disabled' : ''} title="Snap this Course's frontier items to the board in priority + area order. Skips items already placed.">▦ Apply template</button>
+            <button type="button" class="bc-drawer-action danger" data-act="clear-board" ${placedCount === 0 ? 'disabled' : ''} title="Remove all placements from the board.">✕ Clear board</button>
+          </div>
           ${drawerInner}
         </div>
       </div>
-      <p class="bc-canvas-hint">Coming in 3e: <strong>template apply</strong> (frontier as starting position).</p>
+      <p class="bc-canvas-hint">Apply template = frontier in priority order, snapped row-major. Clear board = remove all placements. Per-piece edits via the action chip on a placed cell.</p>
     `;
 
     // Re-apply in-hand visual on the drawer item (rendered after the
@@ -9119,10 +9219,40 @@
         renderCourseHexMap();
       });
     }
-    // ── Drawer click handler: take / drop in hand ──
+    // ── Drawer click handler: take/drop in hand + template actions ──
     const drawer = slot.querySelector('.bc-drawer');
     if (drawer) {
       drawer.addEventListener('click', (e) => {
+        // Template actions take precedence over item picks (their selectors
+        // don't overlap, but checking the action button first is clearer).
+        const actBtn = e.target && e.target.closest ? e.target.closest('.bc-drawer-action') : null;
+        if (actBtn) {
+          const act = actBtn.dataset.act;
+          if (act === 'apply-template') {
+            const placed = applyBuildTemplate(items);
+            if (placed === 0) {
+              // Either frontier is empty, every frontier item is already
+              // placed, or the canvas is full. The button's disabled state
+              // catches empty-frontier; the others fall through silently.
+              return;
+            }
+            bcInHand = null;
+            bcActionItemId = null;
+            renderCourseHexMap();
+            return;
+          }
+          if (act === 'clear-board') {
+            const placedCountNow = Object.keys(getBuildPositions(getOrInitCourseDraft())).length;
+            if (placedCountNow === 0) return;
+            if (!confirm('Remove all ' + placedCountNow + ' placements from the board?')) return;
+            clearAllBuildPositions();
+            bcInHand = null;
+            bcActionItemId = null;
+            renderCourseHexMap();
+            return;
+          }
+          return;
+        }
         const btn = e.target && e.target.closest ? e.target.closest('.bc-drawer-item') : null;
         if (!btn) return;
         const id = btn.dataset.item;

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -5209,10 +5209,10 @@
       "id": "LAB-040",
       "title": "Course planning surface on Director's Desk drawer",
       "status": "backlog",
-      "priority": "P3",
+      "priority": "P2",
       "area": "director-desk",
       "brief": "Course planning form lives as a top-level toolbar tab. Consider also surfacing course state inside Director's Desk's drawer as a cross-cutting strategic surface.",
-      "full": "The Course planning form and Hex Map currently live as a separate toolbar tab (Course / Map). Director's Desk is the strategic home — where cross-cutting work lives. An open design question: should a condensed version of the current Course state (frontier items, active leg, P0s) also appear in the Director's Desk drawer, so the author doesn't need to switch tabs to orient before a Frame? This would make the Desk a true strategic anchor. Open design call — flag for Quenton. P3 (low urgency; the toolbar tab is working)."
+      "full": "The Course planning form and Hex Map currently live as a separate toolbar tab (Course / Map). Director's Desk is the strategic home — where cross-cutting work lives. An open design question: should a condensed version of the current Course state (frontier items, active leg, P0s) also appear in the Director's Desk drawer, so the author doesn't need to switch tabs to orient before a Frame? This would make the Desk a true strategic anchor. Open design call — flag for Quenton. P2 (later) — the toolbar tab is working."
     },
     "LAB-041": {
       "id": "LAB-041",

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -400,6 +400,185 @@
     display: inline-block;
   }
 
+  /* ── Leg view: Snap Circuit board (Phase 5) ──
+     Five vertically-stacked component cards (Frame, Comprehend, Sync,
+     Produce, Debrief). Each card has a "component glyph" (battery /
+     transistor / capacitor / signal / output) on the left, header on top,
+     content below. Wires are visual: short vertical bars between cards
+     indicating signal flow direction. */
+  .leg-board {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    max-width: 760px;
+    margin: 0 auto;
+  }
+  .leg-board-empty {
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-bd);
+    border-radius: 6px;
+    padding: 24px 18px;
+    text-align: center;
+    font-family: var(--font-px);
+    font-size: 11.5px;
+    color: #6f7a90;
+    line-height: 1.6;
+  }
+  .leg-board-empty button {
+    color: var(--accent);
+    text-decoration: underline dotted;
+    cursor: pointer;
+    background: none;
+    border: none;
+    font-family: inherit;
+    font-size: inherit;
+    padding: 0;
+  }
+  .leg-zone {
+    display: grid;
+    grid-template-columns: 56px 1fr;
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-bd);
+    border-radius: 6px;
+    overflow: hidden;
+  }
+  .leg-zone[data-zone="frame"]      { border-color: rgba(74,123,212,0.55); }
+  .leg-zone[data-zone="comprehend"] { border-color: rgba(212,160,48,0.55); }
+  .leg-zone[data-zone="sync"]       { border-color: rgba(45,138,126,0.55); }
+  .leg-zone[data-zone="produce"]    { border-color: rgba(226,160,74,0.55); }
+  .leg-zone[data-zone="debrief"]    { border-color: rgba(74,138,90,0.55); }
+  .leg-zone-glyph {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 24px;
+    background: rgba(0,0,0,0.18);
+    border-right: 1px solid var(--panel-bd);
+    color: var(--fg);
+  }
+  .leg-zone[data-zone="frame"]      .leg-zone-glyph { color: #6f9ee0; }
+  .leg-zone[data-zone="comprehend"] .leg-zone-glyph { color: #d4a030; }
+  .leg-zone[data-zone="sync"]       .leg-zone-glyph { color: #5cb09a; }
+  .leg-zone[data-zone="produce"]    .leg-zone-glyph { color: #e2a04a; }
+  .leg-zone[data-zone="debrief"]    .leg-zone-glyph { color: #4a8a5a; }
+  .leg-zone-body {
+    padding: 10px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .leg-zone-header {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+  }
+  .leg-zone-title {
+    font-family: var(--font-px);
+    font-size: 11px;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    color: var(--accent);
+  }
+  .leg-zone-component {
+    font-family: var(--font-px);
+    font-size: 9.5px;
+    color: var(--accent-dim);
+    letter-spacing: 1px;
+  }
+  .leg-zone-status {
+    margin-left: auto;
+    font-family: var(--font-px);
+    font-size: 9.5px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    padding: 1px 5px;
+    border: 1px solid var(--panel-bd);
+    border-radius: 2px;
+    color: var(--accent-dim);
+  }
+  .leg-zone-status.lit { color: var(--accent); border-color: var(--accent); background: rgba(226,160,74,0.10); }
+  .leg-zone-status.done { color: #4a8a5a; border-color: rgba(74,138,90,0.55); background: rgba(74,138,90,0.08); }
+  .leg-zone-content {
+    margin-top: 4px;
+    font-size: 12.5px;
+    color: var(--fg);
+    line-height: 1.45;
+  }
+  .leg-zone-empty {
+    color: #6f7a90;
+    font-style: italic;
+    font-size: 11.5px;
+  }
+  .leg-chip-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    margin: 4px 0;
+  }
+  .leg-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 2px 6px 2px 7px;
+    background: rgba(74,123,212,0.14);
+    border: 1px solid rgba(74,123,212,0.45);
+    border-radius: 10px;
+    font-size: 11px;
+    color: var(--fg);
+  }
+  .leg-chip.bonus { background: rgba(226,160,74,0.10); border-color: rgba(226,160,74,0.40); }
+  .leg-chip .leg-chip-id {
+    font-family: var(--font-px);
+    font-size: 9.5px;
+    color: #6f9ee0;
+    font-weight: bold;
+    letter-spacing: 0.5px;
+  }
+  .leg-chip.bonus .leg-chip-id { color: #d4a030; }
+  .leg-zone-line {
+    font-size: 11.5px;
+    color: var(--accent-dim);
+  }
+  .leg-zone-line .lzl-label { font-family: var(--font-px); font-size: 9.5px; letter-spacing: 1px; margin-right: 6px; }
+  .leg-zone-line .lzl-value { color: var(--fg); }
+  .leg-wire {
+    width: 2px;
+    height: 14px;
+    background: var(--panel-bd);
+    margin: 0 auto;
+    position: relative;
+  }
+  .leg-wire::after {
+    content: '▼';
+    position: absolute;
+    bottom: -2px;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 8px;
+    color: var(--panel-bd);
+  }
+  .leg-comprehend-list {
+    margin: 4px 0 0;
+    padding: 0;
+    list-style: none;
+  }
+  .leg-comprehend-list li {
+    padding: 4px 6px;
+    border-left: 2px solid rgba(212,160,48,0.45);
+    margin: 4px 0;
+    font-size: 12px;
+    background: rgba(255,255,255,0.02);
+  }
+  .leg-comprehend-list .lcl-when {
+    display: block;
+    font-family: var(--font-px);
+    font-size: 9px;
+    letter-spacing: 1px;
+    color: var(--accent-dim);
+    margin-bottom: 2px;
+  }
+
   /* ── Comprehend (on-demand re-immersion notes attached to the active leg) ── */
   .course-comprehend {
     background: var(--panel-bg);
@@ -3401,6 +3580,7 @@
   <div id="view-toggle" role="tablist" aria-label="Lab view">
     <button class="vt-btn active" data-view="floor"     role="tab">Floor</button>
     <button class="vt-btn"        data-view="course"    role="tab">Course</button>
+    <button class="vt-btn"        data-view="leg"       role="tab">Leg</button>
     <button class="vt-btn"        data-view="priority"  role="tab">Priority</button>
     <button class="vt-btn"        data-view="timeline"  role="tab">Timeline</button>
     <button class="vt-btn"        data-view="by-status" role="tab">By Status</button>
@@ -3536,6 +3716,18 @@
   <h2 class="alt-heading">By-status view</h2>
   <p class="alt-sub">Kanban-style board. Click any card to open it in the floor drawer.</p>
   <div class="bs-board" id="bs-board"></div>
+</div>
+
+<!-- ── Leg view (Phase 5: Snap Circuit board) ──
+     Iconic re-skin of the active leg as a five-zone circuit board:
+     Frame (power source) · Comprehend (amplifier) · Sync (filter) ·
+     Produce (live signal) · Debrief (output stage). Honors the WS004
+     Snap-Circuits-vs-DOS aspiration: same data the JSON has, rendered
+     as a board you can read at a glance. -->
+<div id="leg-view" class="alt-view">
+  <h2 class="alt-heading">Leg · circuit board</h2>
+  <p class="alt-sub">Active leg rendered as a five-stage circuit. Each zone is one phase of the leg; signal flows top-to-bottom from the power source (Frame) to the output stage (Debrief).</p>
+  <div id="leg-body"></div>
 </div>
 
 <!-- ── Course view ──
@@ -6997,7 +7189,7 @@
      ────────────────────────────────────────────────────────────── */
 
   const VIEW_KEY = STORAGE_KEY + '::active-view';
-  const VIEWS = ['floor', 'course', 'priority', 'timeline', 'by-status'];
+  const VIEWS = ['floor', 'course', 'leg', 'priority', 'timeline', 'by-status'];
   let activeView = 'floor';
 
   function loadActiveView() {
@@ -7061,6 +7253,7 @@
     const isAlt = name !== 'floor';
     document.body.classList.toggle('alt-view-active', isAlt);
     document.getElementById('course-view').classList.toggle('visible', name === 'course');
+    document.getElementById('leg-view').classList.toggle('visible', name === 'leg');
     document.getElementById('priority-view').classList.toggle('visible', name === 'priority');
     document.getElementById('timeline-view').classList.toggle('visible', name === 'timeline');
     document.getElementById('by-status-view').classList.toggle('visible', name === 'by-status');
@@ -7070,6 +7263,7 @@
 
   function renderActiveAltView() {
     if (activeView === 'course')     renderCourseView();
+    if (activeView === 'leg')        renderLegView();
     if (activeView === 'priority')   renderPriorityView();
     if (activeView === 'timeline')   renderTimelineView();
     if (activeView === 'by-status')  renderByStatusView();
@@ -7703,6 +7897,155 @@
       </div>
     `;
   }
+
+  /* ── Leg view: Snap Circuit board (Phase 5) ──
+     Renders the active leg as a five-zone circuit board. Each zone reads
+     from the corresponding leg sub-record and the linked Frame/Debrief
+     cards. Read-only; click-throughs to forms come in v0.2. */
+  function renderLegView() {
+    const wrap = document.getElementById('leg-body');
+    if (!wrap) return;
+    const leg = findActiveLeg();
+    if (!leg) {
+      wrap.innerHTML =
+        '<div class="leg-board-empty">' +
+          'No active leg this week. ' +
+          '<button type="button" data-act="goto-frame">Open Frame Workshop</button> ' +
+          'and save a card to start one — the circuit lights up as the leg fills out.' +
+        '</div>';
+      return;
+    }
+    const frame = findFrameCardForLeg(leg);
+    const debrief = findDebriefCardForLeg(leg);
+
+    const zones = [];
+    zones.push(renderLegZoneFrame(leg, frame));
+    zones.push('<div class="leg-wire" aria-hidden="true"></div>');
+    zones.push(renderLegZoneComprehend(leg));
+    zones.push('<div class="leg-wire" aria-hidden="true"></div>');
+    zones.push(renderLegZoneSync(leg));
+    zones.push('<div class="leg-wire" aria-hidden="true"></div>');
+    zones.push(renderLegZoneProduce(leg));
+    zones.push('<div class="leg-wire" aria-hidden="true"></div>');
+    zones.push(renderLegZoneDebrief(leg, debrief));
+    wrap.innerHTML =
+      '<div class="leg-board-empty" style="margin-bottom:14px;text-align:left;background:transparent;border:none;padding:6px 0;">' +
+        '<strong style="color:var(--accent);">' + escapeHTML(leg.id) + '</strong> · leg ' + escapeHTML(String(leg.leg_number)) + ' of ' + COURSE_LEG_COUNT +
+        ' · <span style="text-transform:uppercase;letter-spacing:1px;font-size:10px;">' + escapeHTML(leg.status) + '</span>' +
+      '</div>' +
+      '<div class="leg-board">' + zones.join('') + '</div>';
+  }
+  function findDebriefCardForLeg(leg) {
+    if (!leg || !leg.debrief_card_id) return null;
+    return loadDebriefCards().find(c => c && c.savedAt === leg.debrief_card_id) || null;
+  }
+  function legZoneShell(zoneId, glyph, component, title, statusClass, statusLabel, contentHTML) {
+    return `<div class="leg-zone" data-zone="${zoneId}">
+      <div class="leg-zone-glyph" aria-hidden="true">${glyph}</div>
+      <div class="leg-zone-body">
+        <div class="leg-zone-header">
+          <span class="leg-zone-title">${escapeHTML(title)}</span>
+          <span class="leg-zone-component">${escapeHTML(component)}</span>
+          <span class="leg-zone-status ${statusClass}">${escapeHTML(statusLabel)}</span>
+        </div>
+        <div class="leg-zone-content">${contentHTML}</div>
+      </div>
+    </div>`;
+  }
+  function renderLegZoneFrame(leg, card) {
+    if (!card) {
+      return legZoneShell('frame', '🔋', 'power source', 'Frame', '', 'unset',
+        '<div class="leg-zone-empty">No Frame card linked. Open Frame Workshop and save a card to power the leg.</div>');
+    }
+    const mustArr  = Array.isArray(card.must) ? card.must
+                   : (typeof card.must === 'string' && card.must.trim() ? [{ id: 'free', title: card.must.slice(0, 80) }] : []);
+    const bonusArr = Array.isArray(card.stretch) ? card.stretch
+                   : (typeof card.stretch === 'string' && card.stretch.trim() ? [{ id: 'free', title: card.stretch.slice(0, 80) }] : []);
+    const mustChips = mustArr.length > 0
+      ? '<div class="leg-chip-row">' + mustArr.map(r => `<span class="leg-chip"><span class="leg-chip-id">${escapeHTML((r && r.id) || '·')}</span><span>${escapeHTML((r && r.title) || '')}</span></span>`).join('') + '</div>'
+      : '<div class="leg-zone-empty">No musts named yet.</div>';
+    const bonusChips = bonusArr.length > 0
+      ? '<div class="leg-chip-row">' + bonusArr.map(r => `<span class="leg-chip bonus"><span class="leg-chip-id">${escapeHTML((r && r.id) || '·')}</span><span>${escapeHTML((r && r.title) || '')}</span></span>`).join('') + '</div>'
+      : '';
+    const inLine = (card.in || '').trim();
+    const inHTML = inLine
+      ? `<div class="leg-zone-line"><span class="lzl-label">DOING</span><span class="lzl-value">${escapeHTML(inLine.slice(0, 240))}</span></div>`
+      : '';
+    return legZoneShell('frame', '🔋', 'power source', 'Frame', 'lit', mustArr.length + ' musts · ' + bonusArr.length + ' bonus',
+      inHTML + mustChips + bonusChips);
+  }
+  function renderLegZoneComprehend(leg) {
+    const notes = Array.isArray(leg.comprehend) ? leg.comprehend : [];
+    if (notes.length === 0) {
+      return legZoneShell('comprehend', '⚡', 'amplifier', 'Comprehend', '', 'idle',
+        '<div class="leg-zone-empty">No notes yet. Capture re-immersion notes from the Course view to amplify what you\'re holding in mind.</div>');
+    }
+    const recent = notes.slice(-3).reverse();
+    const items = recent.map(n =>
+      `<li><span class="lcl-when">${escapeHTML(fmtComprehendWhen(n && n.at))}</span>${escapeHTML((n && n.text) || '').replace(/\n/g, '<br>')}</li>`
+    ).join('');
+    const more = notes.length > 3
+      ? `<div class="leg-zone-line"><span class="lzl-label">+${notes.length - 3} earlier</span></div>`
+      : '';
+    return legZoneShell('comprehend', '⚡', 'amplifier', 'Comprehend', 'lit', notes.length + ' note' + (notes.length === 1 ? '' : 's'),
+      '<ul class="leg-comprehend-list">' + items + '</ul>' + more);
+  }
+  function renderLegZoneSync(leg) {
+    if (!leg.sync) {
+      return legZoneShell('sync', '⏚', 'filter', 'Sync', '', 'deferred',
+        '<div class="leg-zone-empty">Sync station deferred to a later phase. The slot exists; the form does not yet.</div>');
+    }
+    const summary = (leg.sync && leg.sync.summary) || JSON.stringify(leg.sync).slice(0, 200);
+    return legZoneShell('sync', '⏚', 'filter', 'Sync', 'lit', 'captured',
+      `<div class="leg-zone-line"><span class="lzl-value">${escapeHTML(summary)}</span></div>`);
+  }
+  function renderLegZoneProduce(leg) {
+    const p = leg.produce || { selected: [], bonuses: [], notes: [] };
+    const selectedCount = (p.selected || []).length;
+    const bonusCount    = (p.bonuses  || []).length;
+    const noteCount     = (p.notes    || []).length;
+    const totalActivity = selectedCount + bonusCount + noteCount;
+    if (totalActivity === 0) {
+      return legZoneShell('produce', '〰', 'live signal', 'Produce', '', 'quiet',
+        '<div class="leg-zone-empty">No produce activity logged yet. The Produce ledger lights up as items are picked up and bonuses are claimed.</div>');
+    }
+    const lines = [];
+    if (selectedCount > 0) lines.push(`<div class="leg-zone-line"><span class="lzl-label">SELECTED</span><span class="lzl-value">${selectedCount}</span></div>`);
+    if (bonusCount > 0)    lines.push(`<div class="leg-zone-line"><span class="lzl-label">BONUSES</span><span class="lzl-value">${bonusCount}</span></div>`);
+    if (noteCount > 0)     lines.push(`<div class="leg-zone-line"><span class="lzl-label">NOTES</span><span class="lzl-value">${noteCount}</span></div>`);
+    return legZoneShell('produce', '〰', 'live signal', 'Produce', 'lit', 'flowing',
+      lines.join(''));
+  }
+  function renderLegZoneDebrief(leg, card) {
+    if (!card) {
+      const status = leg.status === 'debriefed' ? 'done' : '';
+      const label  = leg.status === 'debriefed' ? 'closed' : 'pending';
+      return legZoneShell('debrief', '🔊', 'output stage', 'Debrief', status, label,
+        '<div class="leg-zone-empty">No Debrief card yet. Open Debrief Booth, save a card, and the leg closes — the output stage lights green.</div>');
+    }
+    const courseHeld = card.course_held && DB_COURSE_HELD_LABEL[card.course_held]
+      ? DB_COURSE_HELD_LABEL[card.course_held]
+      : (card.course_held || '—');
+    const caught = (card.caught || '').slice(0, 220);
+    const caughtHTML = caught
+      ? `<div class="leg-zone-line"><span class="lzl-label">CAUGHT</span><span class="lzl-value">${escapeHTML(caught)}</span></div>`
+      : '';
+    const heldHTML = `<div class="leg-zone-line"><span class="lzl-label">COURSE HELD</span><span class="lzl-value">${escapeHTML(courseHeld)}</span></div>`;
+    const changes = leg.changes_to_course;
+    const changesHTML = changes && changes.summary
+      ? `<div class="leg-zone-line"><span class="lzl-label">CHANGES</span><span class="lzl-value">${escapeHTML(String(changes.summary).slice(0, 200))}</span></div>`
+      : '';
+    return legZoneShell('debrief', '🔊', 'output stage', 'Debrief', 'done', 'closed',
+      heldHTML + caughtHTML + changesHTML);
+  }
+
+  // Leg-view click handler (jump to Frame Workshop from the empty-state).
+  document.addEventListener('click', (e) => {
+    if (e.target && e.target.dataset && e.target.dataset.act === 'goto-frame') {
+      if (typeof setView === 'function') setView('floor');
+      if (typeof openDrawer === 'function') openDrawer('frame-workshop');
+    }
+  });
 
   /* ── On-demand Comprehend (Phase 3) ──
      Single textarea + Capture button. Appends a timestamped note to the

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -368,37 +368,33 @@
     height: auto;
     display: block;
   }
-  /* ── Hex Map v0.2 (Phase 1: biome regions + 4-channel encoding) ──
-     Channels (per Quenton design dialog):
-       Hue        → biome (area accent) — stable identity
-       Luminosity → relevance to current course (4-state ramp)
-       Stroke     → priority (2px ring on P0, 1px on others)
-       Motion     → attention call-out (single pulse on select; ambient
-                    breath on the active leg's working set)
-     Drops the v0.1 fill-vs-outline + teal frontier ring + purple
-     "both" ring — luminosity now carries the frontier signal cleanly,
-     and P0's red ring stacks on any luminosity without fighting. */
+  /* ── Hex Map v0.3 (concentric rings + map-legend palette) ──
+     Per the author's "make a real map" direction:
+       - Layout: concentric rings. P0 anchors the center (the must-have
+         course for this week). P1 expands outward. P2 outermost.
+         Ring position carries priority (was: red P0 stroke).
+       - Hue: area = biome = map-legend color. Color-blind-safe palette
+         (Okabe-Ito 8). Legend below the map maps area → color.
+       - Luminosity: relevance to current course (4-state, unchanged).
+       - Motion: pulse on click + ambient breath on active leg's
+         working set (unchanged).
+     Drops from v0.2: red P0 stroke (spatial position carries it now),
+     biome region backgrounds (rings replace clustering), per-hex
+     LAB-### labels (genus:species hover tooltip is the reveal). */
   .hex-cell {
-    stroke: #2a2a35;
+    stroke: rgba(255,255,255,0.18);
     stroke-width: 1;
     transition: opacity 200ms ease;
+    cursor: default;
   }
-  .hex-cell:hover { stroke: var(--accent); stroke-width: 1.5; cursor: default; }
-  /* P0 = priority ring. Second-channeled with stroke-width: 2 (vs 1 for
-     non-P0) so the cue survives any color-vision profile. */
-  .hex-cell.p0 {
-    stroke: #c25450;
-    stroke-width: 2;
-    filter: drop-shadow(0 0 3px rgba(194,84,80,0.55));
-  }
+  .hex-cell:hover { stroke: var(--accent); stroke-width: 2; }
   /* Active = item is in the active leg's Frame card. Saturation boost +
      subtle glow so the working set pops without the ambient breath
      having to start before the user has even glanced at it. */
   .hex-cell.active {
-    filter: saturate(1.1) drop-shadow(0 0 4px rgba(255,255,255,0.18));
-  }
-  .hex-cell.active.p0 {
-    filter: saturate(1.1) drop-shadow(0 0 4px rgba(194,84,80,0.6));
+    stroke: rgba(255,255,255,0.55);
+    stroke-width: 2;
+    filter: saturate(1.15) drop-shadow(0 0 4px rgba(255,255,255,0.22));
   }
   /* Pulse-on-select: single bump, fades. Acknowledgment, not ambience. */
   @keyframes hex-pulse-once {
@@ -434,43 +430,28 @@
   @media (prefers-reduced-motion: reduce) {
     .hex-cell.breathing { animation: none; }
   }
-  .hex-label {
-    font-family: var(--font-px);
-    font-size: 7px;
-    fill: #fff;
-    text-anchor: middle;
-    dominant-baseline: middle;
-    pointer-events: none;
-    opacity: 0.85;
+  /* Ring bands — faint concentric circles behind the hex spiral. Help the
+     eye see the priority structure (P0 ring, P1 ring, P2 ring) without
+     drawing strong borders that compete with the hexes. */
+  .hex-ring-band {
+    fill: none;
+    stroke: rgba(255,255,255,0.06);
+    stroke-width: 1.5;
+    stroke-dasharray: 4 4;
   }
-  /* Biome region — labeled cluster wrapping each area's hexes. The
-     translucent background tints the cluster with the biome's hue. */
-  .hex-region-bg {
-    rx: 8;
-    ry: 8;
-    stroke-width: 1;
-    fill-opacity: 0.06;
-    stroke-opacity: 0.45;
-  }
-  .hex-region-label {
+  .hex-ring-label {
     font-family: var(--font-px);
     font-size: 9.5px;
     font-weight: bold;
-    letter-spacing: 1.5px;
-    text-transform: uppercase;
-    fill: var(--accent-dim);
-    dominant-baseline: hanging;
+    letter-spacing: 2px;
+    fill: rgba(255,255,255,0.32);
+    text-anchor: middle;
     pointer-events: none;
   }
-  .hex-region-count {
-    font-family: var(--font-px);
-    font-size: 9px;
-    fill: #6f7a90;
-    dominant-baseline: hanging;
-    pointer-events: none;
-  }
-  /* Legend now shows the encoding channels rather than swatches per
-     biome — the regions themselves carry the biome legend. */
+  /* Map legend (v0.3): area name → color swatch. Replaces the v0.2
+     channel-state legend; the ring bands carry the priority signal,
+     so the legend's job is just genus identification (which biome is
+     which color). */
   .course-hexmap-legend {
     display: flex;
     flex-wrap: wrap;
@@ -482,23 +463,42 @@
     font-size: 10px;
     color: var(--accent-dim);
   }
-  .course-hexmap-legend .lg-item { display: inline-flex; align-items: center; gap: 5px; }
+  .course-hexmap-legend .lg-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    color: var(--fg);
+  }
   .course-hexmap-legend .lg-swatch {
     display: inline-block;
     width: 14px;
     height: 12px;
     border-radius: 2px;
+  }
+  /* v0.3: a small secondary legend strip explaining the luminosity
+     ramp. Smaller + dimmer than the area legend so the area-legend
+     reads as the primary "key." */
+  .course-hexmap-key {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 14px;
+    margin-top: 6px;
+    font-family: var(--font-px);
+    font-size: 9.5px;
+    color: var(--accent-dim);
+  }
+  .course-hexmap-key .lg-item { display: inline-flex; align-items: center; gap: 4px; }
+  .course-hexmap-key .lg-swatch {
+    display: inline-block;
+    width: 12px;
+    height: 10px;
+    border-radius: 2px;
     background: #5e6f8a;
   }
-  .course-hexmap-legend .lg-swatch.dim   { opacity: 0.18; }
-  .course-hexmap-legend .lg-swatch.avail { opacity: 0.50; }
-  .course-hexmap-legend .lg-swatch.front { opacity: 1.0; }
-  .course-hexmap-legend .lg-swatch.act   { opacity: 1.0; box-shadow: 0 0 4px rgba(255,255,255,0.4); }
-  .course-hexmap-legend .lg-ring {
-    display: inline-block;
-    width: 12px; height: 12px; border-radius: 50%;
-    border: 2px solid;
-  }
+  .course-hexmap-key .lg-swatch.dim   { opacity: 0.18; }
+  .course-hexmap-key .lg-swatch.avail { opacity: 0.50; }
+  .course-hexmap-key .lg-swatch.front { opacity: 1.0; }
+  .course-hexmap-key .lg-swatch.act   { opacity: 1.0; box-shadow: 0 0 4px rgba(255,255,255,0.5); }
 
   /* ── Leg view: Snap Circuit board (Phase 5) ──
      Five vertically-stacked component cards (Frame, Comprehend, Sync,
@@ -8318,21 +8318,27 @@
     panel.innerHTML = html;
   }
 
-  /* ── Hex Map v0.2 (Course view) ──
-     Biome regions (cluster per area, labeled, translucent biome-colored
-     background) + 4-channel encoding (hue=biome, luminosity=relevance,
-     stroke=priority, motion=attention). Per Quenton's design dialog. */
+  /* ── Hex Map v0.3 (Course view) ──
+     Concentric rings carry priority (P0 center → P1 mid → P2 outer).
+     Color carries biome (area). Luminosity carries relevance. Motion
+     carries attention. Hover reveals genus:species ("Frame Workshop:
+     chapter draft"). Per the author's "make a real map" direction.
+
+     Color palette: Okabe-Ito 8-color qualitative scheme. Designed to
+     be distinguishable to all common color-vision profiles (protan-,
+     deutan-, tritanopia). Each accent in the lab data maps to one
+     Okabe-Ito hue; legend below the map shows the binding. */
   const HEX_ACCENT_FILL = {
-    blue:   '#4a7bd4',
-    amber:  '#d4a030',
-    green:  '#4a8a5a',
-    orange: '#e2a04a',
-    teal:   '#2d8a7e',
-    tan:    '#8a7a5a',
-    warm:   '#a88a5a',
-    dark:   '#555555',
-    red:    '#c25450',
-    purple: '#9a6fc2'
+    blue:   '#0072B2',  // Okabe-Ito blue
+    amber:  '#E69F00',  // Okabe-Ito orange (warm yellow)
+    green:  '#009E73',  // Okabe-Ito bluish green
+    orange: '#D55E00',  // Okabe-Ito vermillion
+    teal:   '#56B4E9',  // Okabe-Ito sky blue
+    tan:    '#CC79A7',  // Okabe-Ito reddish purple
+    warm:   '#F0E442',  // Okabe-Ito yellow
+    dark:   '#888888',  // neutral gray (Okabe-Ito uses black; lighter for our dark bg)
+    red:    '#D55E00',  // collapse to vermillion
+    purple: '#CC79A7'   // collapse to reddish purple
   };
   // Phase 1 (v0.2) luminosity ramp. Four states designed against ~3:1
   // contrast steps (perceptually distinct without being shouty).
@@ -8375,6 +8381,42 @@
     return set;
   }
 
+  /* Concentric hex spiral generator (axial coordinates).
+     Yields {q, r, ring} for each hex starting at center (ring 0) and
+     spiraling outward. Used to assign items to ring positions in the
+     v0.3 layout: P0 fills inner positions first, P1 next, P2 last.
+     Algorithm cribbed from Red Blob Games' canonical hex-grid reference.
+     6 axial directions in a stable spiral order: */
+  const HEX_DIRS = [
+    { q:  1, r:  0 }, // 0: E
+    { q:  1, r: -1 }, // 1: NE
+    { q:  0, r: -1 }, // 2: NW
+    { q: -1, r:  0 }, // 3: W
+    { q: -1, r:  1 }, // 4: SW
+    { q:  0, r:  1 }  // 5: SE
+  ];
+  function* hexSpiral(maxRing) {
+    yield { q: 0, r: 0, ring: 0 };
+    for (let ring = 1; ring <= maxRing; ring++) {
+      // Start at the SW corner: `ring` steps in direction 4 from center.
+      let q = HEX_DIRS[4].q * ring;
+      let r = HEX_DIRS[4].r * ring;
+      for (let side = 0; side < 6; side++) {
+        for (let step = 0; step < ring; step++) {
+          yield { q, r, ring };
+          q += HEX_DIRS[side].q;
+          r += HEX_DIRS[side].r;
+        }
+      }
+    }
+  }
+  // Flat-top axial → pixel center.
+  function hexAxialToPixel(q, r, S) {
+    const x = S * (1.5 * q);
+    const y = S * (Math.sqrt(3) * (r + q / 2));
+    return { x, y };
+  }
+
   function renderCourseHexMap() {
     const wrap = document.getElementById('course-hexmap');
     if (!wrap) return;
@@ -8387,158 +8429,175 @@
       return;
     }
 
-    // ── Group items into biome regions (one cluster per area) ──
-    const byArea = new Map();
-    items.forEach(it => {
-      const aId = it.areaId || '__orphan';
-      if (!byArea.has(aId)) byArea.set(aId, { areaId: aId, areaName: it.areaName || aId, items: [] });
-      byArea.get(aId).items.push(it);
-    });
-    // Sort items within each region: P0 first (so the eye lands on
-    // the most-urgent biome resident), then by status rank, then by id.
-    byArea.forEach(r => {
-      r.items.sort((a, b) => {
-        const pa = priorityRank(a.priority) - priorityRank(b.priority);
-        if (pa !== 0) return pa;
-        const sa = statusRank(a.status) - statusRank(b.status);
-        if (sa !== 0) return sa;
-        return (a.id || '').localeCompare(b.id || '');
-      });
-    });
-    // Sort regions: biggest first (so the layout has a stable feel
-    // — the dominant biomes anchor the top-left corner).
-    const regions = Array.from(byArea.values()).sort((a, b) => {
-      if (b.items.length !== a.items.length) return b.items.length - a.items.length;
-      return (a.areaName || '').localeCompare(b.areaName || '');
+    // ── Sort items into priority tiers, then by area within each tier ──
+    // Within a tier, same-area items pack adjacently in the spiral.
+    // Within an area+tier, status-rank (in-progress first) so the most-
+    // active items land closer to the center of their tier band.
+    const tierOrder = { P0: 0, P1: 1, P2: 2 };
+    const sorted = items.slice().sort((a, b) => {
+      const ta = tierOrder[a.priority] !== undefined ? tierOrder[a.priority] : 3;
+      const tb = tierOrder[b.priority] !== undefined ? tierOrder[b.priority] : 3;
+      if (ta !== tb) return ta - tb;
+      // Within tier: cluster by area.
+      const ax = (a.areaName || '').localeCompare(b.areaName || '');
+      if (ax !== 0) return ax;
+      const sa = statusRank(a.status) - statusRank(b.status);
+      if (sa !== 0) return sa;
+      return (a.id || '').localeCompare(b.id || '');
     });
 
-    // ── Hex + cluster geometry ──
-    const S = 22;                       // hex side length (smaller than v0.1; clusters get denser)
-    const STEP_X = 1.5 * S;             // 33
-    const STEP_Y = Math.sqrt(3) * S;    // ~38
-    const OFFSET_Y = STEP_Y / 2;        // ~19 (odd-col offset)
-    const HEX_PAD = 8;                  // padding inside a region around the hex grid
-    const LABEL_H = 14;                 // height reserved above hexes for the region label
-    const REGION_GAP = 14;              // gap between regions (both axes)
-    const CANVAS_W = 740;               // target width (matches .course-hexmap max-width)
-
-    function regionDims(r) {
-      const n = r.items.length;
-      const cols = Math.min(3, n);
-      const rows = Math.ceil(n / cols);
-      const w = HEX_PAD * 2 + 2 * S + (cols - 1) * STEP_X;
-      const oddOffset = cols > 1 ? OFFSET_Y : 0;
-      const h = HEX_PAD * 2 + LABEL_H + STEP_Y + (rows - 1) * STEP_Y + oddOffset;
-      return { cols, rows, w, h };
+    // ── Compute the per-tier ring boundaries ──
+    // Total cumulative hex positions through ring N = 1 + 3N(N+1).
+    // We need enough rings to fit all items.
+    function ringCapacity(maxRing) {
+      return 1 + 3 * maxRing * (maxRing + 1);
     }
-    // Pre-compute region dimensions so we can pack them.
-    regions.forEach(r => {
-      const d = regionDims(r);
-      r.cols = d.cols;
-      r.rows = d.rows;
-      r.w    = d.w;
-      r.h    = d.h;
+    let needRings = 0;
+    while (ringCapacity(needRings) < items.length) needRings++;
+    // For each tier, find the ring range it occupies.
+    const tierCounts = { P0: 0, P1: 0, P2: 0 };
+    sorted.forEach(it => {
+      const k = it.priority in tierCounts ? it.priority : 'P2';
+      tierCounts[k]++;
     });
+    // Boundary rings: which ring contains the LAST hex of P0, P1, P2.
+    // Computed by walking item count cumulatively against ring capacity.
+    function ringOfPosition(pos) {
+      // Returns the ring number that contains the position-th hex in spiral order.
+      let r = 0;
+      while (ringCapacity(r) <= pos) r++;
+      return r;
+    }
+    const lastP0Pos = tierCounts.P0 - 1;
+    const lastP1Pos = tierCounts.P0 + tierCounts.P1 - 1;
+    const lastP2Pos = tierCounts.P0 + tierCounts.P1 + tierCounts.P2 - 1;
+    const p0LastRing = lastP0Pos >= 0 ? ringOfPosition(lastP0Pos) : -1;
+    const p1LastRing = lastP1Pos >= 0 ? ringOfPosition(lastP1Pos) : p0LastRing;
+    const p2LastRing = lastP2Pos >= 0 ? ringOfPosition(lastP2Pos) : p1LastRing;
 
-    // ── Pack regions: greedy left-to-right, wrap to next row when overflow ──
-    let cursorX = 0, cursorY = 0, rowMaxH = 0, totalH = 0, totalW = 0;
-    regions.forEach(r => {
-      if (cursorX + r.w > CANVAS_W && cursorX > 0) {
-        // Wrap to next row.
-        cursorX = 0;
-        cursorY += rowMaxH + REGION_GAP;
-        rowMaxH = 0;
+    // ── Hex geometry ──
+    const S = 26;                       // hex side length
+    const STEP_X = 1.5 * S;             // ~39 (flat-top horizontal step)
+    const STEP_Y = Math.sqrt(3) * S;    // ~45 (flat-top vertical step)
+    const PAD = S + 8;                  // canvas edge padding
+    // Canvas radius: ring N reaches ~N * STEP_X horizontally, ~N * STEP_Y vertically.
+    const radiusX = needRings * STEP_X + S;
+    const radiusY = needRings * STEP_Y + S;
+    const CANVAS_W = radiusX * 2 + PAD * 2;
+    const CANVAS_H = radiusY * 2 + PAD * 2;
+    const CENTER_X = CANVAS_W / 2;
+    const CENTER_Y = CANVAS_H / 2;
+
+    // ── Walk the spiral, assigning each item to a hex coordinate ──
+    const positions = [];
+    const gen = hexSpiral(needRings);
+    for (let i = 0; i < items.length; i++) {
+      const next = gen.next().value;
+      if (!next) break;
+      positions.push(next);
+    }
+
+    // ── Render each hex ──
+    const cells = sorted.map((it, i) => {
+      const pos = positions[i];
+      if (!pos) return '';
+      const px = hexAxialToPixel(pos.q, pos.r, S);
+      const cx = CENTER_X + px.x;
+      const cy = CENTER_Y + px.y;
+      const itemAccent = (AREA_VISUALS[it.areaId] && AREA_VISUALS[it.areaId].accent) || 'dark';
+      const fill = HEX_ACCENT_FILL[itemAccent] || HEX_ACCENT_FILL.dark;
+      const opacity = hexLuminosityFor(it, frontierSet);
+      const isActive = workingSet.has(it.id);
+      const classes = ['hex-cell'];
+      if (isActive) {
+        classes.push('active');
+        // Ambient breath only on the active leg's working set.
+        classes.push('breathing');
       }
-      r.x = cursorX;
-      r.y = cursorY;
-      cursorX += r.w + REGION_GAP;
-      if (r.h > rowMaxH) rowMaxH = r.h;
-      if (cursorY + r.h > totalH) totalH = cursorY + r.h;
-      if (r.x + r.w > totalW) totalW = r.x + r.w;
+      const points = hexPolygonPoints(cx, cy, S);
+      // Genus:species hover format per author's design call.
+      const genus = it.areaName || '(orphan)';
+      const species = it.title || '(no title)';
+      const inFrontier = frontierSet.has(it.id);
+      const stateBits = [];
+      if (isActive)    stateBits.push('in active leg');
+      if (inFrontier)  stateBits.push('in frontier');
+      stateBits.push(it.priority);
+      stateBits.push(it.status);
+      const stateText = stateBits.length > 0 ? ' · ' + stateBits.join(' · ') : '';
+      return `<polygon class="${classes.join(' ')}" data-item="${escapeHTML(it.id)}" points="${points}" fill="${fill}" fill-opacity="${opacity}">
+        <title>${escapeHTML(genus)}: ${escapeHTML(species)}${stateText}</title>
+      </polygon>`;
     });
-    // Canvas dimensions (a bit of padding on the right + bottom).
-    const CANVAS_H = totalH + REGION_GAP;
-    const CANVAS_W_FINAL = Math.max(totalW + REGION_GAP, CANVAS_W);
 
-    // ── Render each region as an SVG group ──
-    const regionGroups = regions.map(r => {
-      const accent = (AREA_VISUALS[r.areaId] && AREA_VISUALS[r.areaId].accent) || 'dark';
-      const tint = HEX_ACCENT_FILL[accent] || HEX_ACCENT_FILL.dark;
+    // ── Ring-band guides (faint dashed circles + ring labels) ──
+    // Drawn behind the hexes so they don't compete. Only drawn for tier
+    // boundaries (P0 outer edge, P1 outer edge), not every ring.
+    const bandRadius = (ringNum) => ringNum * STEP_X + S * 0.5;
+    const bands = [];
+    if (p0LastRing >= 0 && tierCounts.P0 > 0) {
+      const r0 = bandRadius(p0LastRing);
+      bands.push(`<circle class="hex-ring-band" cx="${CENTER_X}" cy="${CENTER_Y}" r="${r0.toFixed(2)}" />`);
+      bands.push(`<text class="hex-ring-label" x="${CENTER_X}" y="${(CENTER_Y - r0 - 6).toFixed(2)}">P0 · ${tierCounts.P0}</text>`);
+    }
+    if (p1LastRing > p0LastRing && tierCounts.P1 > 0) {
+      const r1 = bandRadius(p1LastRing);
+      bands.push(`<circle class="hex-ring-band" cx="${CENTER_X}" cy="${CENTER_Y}" r="${r1.toFixed(2)}" />`);
+      bands.push(`<text class="hex-ring-label" x="${CENTER_X}" y="${(CENTER_Y - r1 - 6).toFixed(2)}">P1 · ${tierCounts.P1}</text>`);
+    }
+    if (p2LastRing > p1LastRing && tierCounts.P2 > 0) {
+      const r2 = bandRadius(p2LastRing);
+      bands.push(`<text class="hex-ring-label" x="${CENTER_X}" y="${(CENTER_Y - r2 - 6).toFixed(2)}">P2 · ${tierCounts.P2}</text>`);
+    }
 
-      const hexes = r.items.map((it, i) => {
-        const col = i % r.cols;
-        const row = Math.floor(i / r.cols);
-        // Local cx/cy within the region (region has its own coordinate origin).
-        const cx = HEX_PAD + S + col * STEP_X;
-        const cy = HEX_PAD + LABEL_H + (STEP_Y / 2) + row * STEP_Y + (col % 2 ? OFFSET_Y : 0);
-        const itemAccent = (AREA_VISUALS[it.areaId] && AREA_VISUALS[it.areaId].accent) || 'dark';
-        const fill = HEX_ACCENT_FILL[itemAccent] || HEX_ACCENT_FILL.dark;
-        const opacity = hexLuminosityFor(it, frontierSet);
-        const isActive = workingSet.has(it.id);
-        const classes = ['hex-cell'];
-        if (it.priority === 'P0') classes.push('p0');
-        if (isActive) {
-          classes.push('active');
-          // Ambient breath only on the active leg's working set.
-          classes.push('breathing');
-        }
-        const points = hexPolygonPoints(cx, cy, S);
-        const numShort = (it.id || '').replace(/^LAB-/, '');
-        return `<g>
-          <polygon class="${classes.join(' ')}" data-item="${escapeHTML(it.id)}" points="${points}" fill="${fill}" fill-opacity="${opacity}">
-            <title>${escapeHTML(it.id)} · ${escapeHTML(it.title)} · ${escapeHTML(it.priority)} · ${escapeHTML(it.status)} · ${escapeHTML(it.areaName)}${isActive ? ' · in active leg' : ''}${frontierSet.has(it.id) ? ' · in frontier' : ''}</title>
-          </polygon>
-          <text class="hex-label" x="${cx.toFixed(2)}" y="${cy.toFixed(2)}">${escapeHTML(numShort)}</text>
-        </g>`;
-      }).join('\n');
-
-      // Region background + label (region-local coordinates 0..r.w, 0..r.h).
-      // rx/ry as SVG presentation attributes serve as a fallback for browsers
-      // that don't support rx/ry as CSS properties (Firefox <122, Safari <17).
-      const bg = `<rect class="hex-region-bg" x="0" y="0" width="${r.w}" height="${r.h}" rx="8" ry="8" fill="${tint}" stroke="${tint}" />`;
-      const labelY = HEX_PAD - 2;
-      const label = `<text class="hex-region-label" x="${HEX_PAD}" y="${labelY}">${escapeHTML(r.areaName)}</text>` +
-                    `<text class="hex-region-count" x="${(r.w - HEX_PAD).toFixed(2)}" y="${labelY}" text-anchor="end">${r.items.length}</text>`;
-
-      return `<g transform="translate(${r.x.toFixed(2)},${r.y.toFixed(2)})">
-        ${bg}
-        ${label}
-        ${hexes}
-      </g>`;
-    }).join('\n');
+    // ── Build the area legend (genus → color) ──
+    // Show one chip per unique area present in the lab, sorted by name.
+    const areaSet = new Map();
+    items.forEach(it => {
+      const k = it.areaId || '__orphan';
+      if (!areaSet.has(k)) {
+        const accent = (AREA_VISUALS[it.areaId] && AREA_VISUALS[it.areaId].accent) || 'dark';
+        areaSet.set(k, {
+          name: it.areaName || k,
+          color: HEX_ACCENT_FILL[accent] || HEX_ACCENT_FILL.dark,
+          count: 0
+        });
+      }
+      areaSet.get(k).count++;
+    });
+    const areasForLegend = Array.from(areaSet.values()).sort((a, b) => a.name.localeCompare(b.name));
+    const legendHTML = areasForLegend.map(a =>
+      `<span class="lg-item"><span class="lg-swatch" style="background:${a.color}"></span>${escapeHTML(a.name)}<span style="color:var(--accent-dim);margin-left:2px;">·${a.count}</span></span>`
+    ).join('');
 
     const inFrontierCount = items.filter(it => frontierSet.has(it.id)).length;
     const activeCount = workingSet.size;
     wrap.innerHTML = `
       <p class="course-hexmap-title">Map · ${items.length} items · ${inFrontierCount} in frontier · ${activeCount} active in current leg</p>
-      <p class="course-hexmap-sub">v0.2: regions = areas (biomes). Brightness = relevance (archived dim → in-frontier bright → active brightest). P0 ring = red. The current leg's working items breathe slowly. Hover for details.</p>
-      <svg viewBox="0 0 ${CANVAS_W_FINAL.toFixed(2)} ${CANVAS_H.toFixed(2)}" preserveAspectRatio="xMidYMid meet" role="img" aria-label="Lab map: ${items.length} items grouped by area (biome). ${inFrontierCount} in this Course's frontier. ${activeCount} in the active leg's working set.">
-        ${regionGroups}
+      <p class="course-hexmap-sub">v0.3: rings = priority (P0 center → P1 → P2). Color = area (see legend). Brightness = relevance (archived dim → in-frontier bright → active brightest). The current leg's working items breathe slowly. Hover any hex for the area + item title.</p>
+      <svg viewBox="0 0 ${CANVAS_W.toFixed(2)} ${CANVAS_H.toFixed(2)}" preserveAspectRatio="xMidYMid meet" role="img" aria-label="Lab map: ${items.length} items in concentric rings (P0 center, P1 mid, P2 outer). Color carries area. ${inFrontierCount} in frontier; ${activeCount} active in current leg.">
+        ${bands.join('\n')}
+        ${cells.join('\n')}
       </svg>
-      <div class="course-hexmap-legend">
-        <span class="lg-item"><span class="lg-swatch dim"></span>archived (terrain)</span>
+      <div class="course-hexmap-legend">${legendHTML}</div>
+      <div class="course-hexmap-key">
+        <span class="lg-item"><span class="lg-swatch dim"></span>archived</span>
         <span class="lg-item"><span class="lg-swatch avail"></span>available</span>
         <span class="lg-item"><span class="lg-swatch front"></span>in frontier</span>
-        <span class="lg-item"><span class="lg-swatch act"></span>active in current leg (breathes)</span>
-        <span class="lg-item"><span class="lg-ring" style="border-color:#c25450"></span>P0</span>
+        <span class="lg-item"><span class="lg-swatch act"></span>active (breathes)</span>
       </div>
     `;
 
-    // Phase 1 motion: single-pulse-on-select. Wired here so the listener
-    // is fresh after each render (innerHTML wipes prior listeners).
+    // Single-pulse-on-select wiring (unchanged from v0.2).
     const svg = wrap.querySelector('svg');
     if (svg) {
       svg.addEventListener('click', (e) => {
         const tgt = e.target;
         if (!tgt || !tgt.classList || !tgt.classList.contains('hex-cell')) return;
-        // Re-trigger the keyframe by removing + re-adding the class.
         tgt.classList.remove('pulse-once');
-        // Force reflow so the animation restarts when the class is re-added.
         void tgt.getBoundingClientRect();
         tgt.classList.add('pulse-once');
       });
-      // Clean up the class once the animation finishes so a future click
-      // can fire it again (and so it doesn't stick on the DOM).
       svg.addEventListener('animationend', (e) => {
         if (e.target && e.target.classList && e.target.classList.contains('pulse-once')) {
           e.target.classList.remove('pulse-once');

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -5872,7 +5872,7 @@
     "LAB-009": {
       "id": "LAB-009",
       "title": "Comprehend form",
-      "status": "backlog",
+      "status": "drafted",
       "priority": "P1",
       "area": "comprehend-station",
       "brief": "Load remaining state from agents and prior work.",
@@ -6233,7 +6233,7 @@
       "id": "LAB-049",
       "title": "Build canvas: drag-and-drop affordance (v0.5+)",
       "status": "backlog",
-      "priority": "P3",
+      "priority": "P2",
       "area": "director-desk",
       "brief": "v0.4 ships click-to-place per Quenton's design call. If lived use shows DnD would be meaningfully better, this is the upgrade path.",
       "full": "v0.4 ships click-to-place as the placement interaction. Quenton's design call: don't build drag-and-drop until click-to-place has been dogfooded and we know whether DnD would actually improve the experience. Click-to-place is simpler, works on mobile, and has lower implementation cost.\n\nIf after lived use the author finds that rearranging pieces on the board is frequent and click-to-place (click item → click destination) feels slow, DnD is the upgrade path. Track that signal in Debrief entries.\n\nNot a blocker. P3."
@@ -6251,7 +6251,7 @@
       "id": "LAB-051",
       "title": "Map world v0.1 — phase boxes live in the map (long-term)",
       "status": "backlog",
-      "priority": "P3",
+      "priority": "P2",
       "area": "director-desk",
       "brief": "Author's long-vision: each phase-box eventually lives in 'map world.' Central traversable space; phase-cycler moves through which phase the user is in. Library/research/tools become buildings.",
       "full": "Author's long-vision for the lab (captured 2026-05-04, not a near-term build item):\n\nEach phase-box (Frame, Comprehend, Sync, Produce, Debrief — outside Recover) eventually lives in 'map world' — a central traversable space. A phase-cycler at the bottom of the screen moves through which phase the user is currently in relative to the map. Moving through phases is literally moving through the map.\n\nLibrary and research tools become buildings in the map world. Resources are rooms you enter, not tabs you click.\n\nThis is a long-vision capture, not a near-term spec. The design questions (what does 'traversable space' mean at a technical level? how does it compose with the existing Hex Map lenses?) are for Quenton when the time comes.\n\nNot v0.4. Not v0.5. Capture for the road map. P3."
@@ -6278,7 +6278,7 @@
       "id": "LAB-054",
       "title": "Walk Studio: JSON-loaded WALKS (vs hardcoded const)",
       "status": "backlog",
-      "priority": "P3",
+      "priority": "P2",
       "area": "comprehend-station",
       "brief": "v0.1 keeps WALKS as a const in lab HTML. Move to cognitive-lab/exports/walks.json with lab-server.py persistence pattern (or static JSON fetch) when 5+ walks exist.",
       "full": "v0.1 stores the WALKS array as a hardcoded const inside the lab HTML. This is acceptable at 1–3 walks — Claude edits the HTML directly when authoring a new walk.\n\nAt 5+ walks, the const becomes unwieldy and the round-trip cost of editing HTML grows. At that point, move WALKS to a standalone JSON file: `cognitive-lab/exports/walks.json`. The lab fetches it on load (or on Walk Studio open) via `fetch('./exports/walks.json')`.\n\nCan follow the same persistence pattern as lab-server.py's other exports — or start as a static file that Claude edits directly, promoting to server-managed later.\n\nP3. The const approach works fine until volume forces the move. Do not build this preemptively."
@@ -6287,7 +6287,7 @@
       "id": "LAB-055",
       "title": "Walk Studio: in-lab walk authoring UI",
       "status": "backlog",
-      "priority": "P3",
+      "priority": "P2",
       "area": "comprehend-station",
       "brief": "v0.1 has Claude editing the WALKS const in HTML. v0.2 (later): an in-lab form to add/edit/delete walks. Whole feature, warrants its own design pass.",
       "full": "v0.1: walk authoring means Claude edits the WALKS const (or walks.json once LAB-054 lands) directly in the file. This is the right choice at low walk volume — it's transparent and doesn't need a UI.\n\nv0.2 (later): an in-lab form inside Walk Studio for creating and editing walks. Fields: id, title, kind (deck/product), and a step editor (heading, body, target_route per step).\n\nThis is a whole feature — UI design, data persistence, validation — warrants its own design pass with Quenton before building. Don't sketch it until Claude-authored walks become genuinely limiting.\n\nP3. The Claude-authoring pattern works; build the UI only when it's clearly blocking the author from creating walks without technical help."
@@ -6296,7 +6296,7 @@
       "id": "LAB-056",
       "title": "Walk Studio: sandbox-Course mode for state-mutating walks",
       "status": "backlog",
-      "priority": "P3",
+      "priority": "P2",
       "area": "comprehend-station",
       "brief": "v0.1 warns on step 0 of state-mutating walks. v0.2 could create a temporary throwaway Course on walk-start and discard on close.",
       "full": "v0.1 handles state-mutating walks (walks that create Courses, start Legs, write Comprehend entries) with a step-0 mutation warning: 'This walk will write to your lab state. Open a fresh Course first if you want a sandbox.'\n\nv0.2 option: Walk Studio creates a temporary Course (id: 'WALK-SANDBOX') on walk-start and discards it on walk-close. The walk plays out against throwaway state that doesn't affect the author's real Course history.\n\nThe warning-only approach is acceptable for v0.1 and possibly indefinitely — experienced authors can manage their own state. The sandbox only earns its keep if walks routinely mutate in ways the author regrets.\n\nP3. Warning-only is fine. Build the sandbox only if dogfood surfaces repeated state-mutation regret."
@@ -6305,7 +6305,7 @@
       "id": "LAB-057",
       "title": "Walk Studio: multi-walk sequences",
       "status": "backlog",
-      "priority": "P3",
+      "priority": "P2",
       "area": "comprehend-station",
       "brief": "v0.2: walks that reference other walks (e.g., a 'build the v0.4 from scratch' sequence that chains multiple walks). Needs a walk-graph data model.",
       "full": "v0.1 walks are standalone: each has its own steps, and completing one doesn't automatically start another.\n\nv0.2: a walk can reference a sequence of other walks — e.g., 'Build the v0.4 from scratch' = build-canvas-walk → course-planning-walk → frame-walk, played in order. The author completes each sub-walk, then the sequence auto-advances to the next.\n\nNeeds a walk-graph data model: each walk gets an optional `next_walk_id` field, or a top-level Sequence object that lists an ordered array of walk IDs.\n\nWarrants a design pass before building — the interaction shape (does the sequence show progress across sub-walks? does each sub-walk feel self-contained or stitched?) is not obvious.\n\nP3. Standalone walks are the right starting point. Build sequences when a multi-walk training arc is actually needed."
@@ -8743,7 +8743,11 @@
             '<a href="' + escapeHTML(activeWalk.deck_href) + '" target="_blank" rel="noopener" title="Open this deck in a new tab">↗ open</a>' +
             '<a href="#" data-act="walk-close" title="Close this walk">× close</a>' +
           '</div>' +
-          '<iframe class="comp-studio-iframe" src="' + escapeHTML(activeWalk.deck_href) + '" title="' + escapeHTML(activeWalk.title) + '"></iframe>' +
+          // Sandbox the deck iframe with the same allowlist as the
+          // product walk iframe. Symmetric pattern; closes the
+          // window.top navigation gap if a future deck author tries
+          // anything cute.
+          '<iframe class="comp-studio-iframe" src="' + escapeHTML(activeWalk.deck_href) + '" title="' + escapeHTML(activeWalk.title) + '" sandbox="allow-scripts allow-same-origin allow-forms"></iframe>' +
         '</div>';
     } else {
       // Product walk: split internal pane (narrative + Back/Next on top,

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -921,6 +921,166 @@
     line-height: 1.5;
   }
   .comp-snap-recent .comp-snap-body { display: none; }
+  /* Walk Studio (Move 2c): sidebar + main split for decks + walks. */
+  .comp-studio {
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-bd);
+    border-radius: 6px;
+    overflow: hidden;
+  }
+  .comp-studio-header {
+    padding: 8px 14px;
+    background: rgba(74,123,212,0.06);
+    border-bottom: 1px solid var(--panel-bd);
+    font-family: var(--font-px);
+    font-size: 10.5px;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    color: #6f9ee0;
+  }
+  .comp-studio-layout {
+    display: grid;
+    grid-template-columns: 220px 1fr;
+    gap: 0;
+    min-height: 360px;
+  }
+  @media (max-width: 720px) {
+    .comp-studio-layout { grid-template-columns: 1fr; }
+  }
+  .comp-studio-sidebar {
+    border-right: 1px solid var(--panel-bd);
+    padding: 10px 8px;
+    background: rgba(0,0,0,0.18);
+    overflow-y: auto;
+    max-height: 540px;
+  }
+  .comp-studio-section-label {
+    font-family: var(--font-px);
+    font-size: 9px;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    color: var(--accent-dim);
+    padding: 4px 6px 6px;
+    margin-top: 4px;
+  }
+  .comp-studio-section-label:first-child { margin-top: 0; }
+  .comp-studio-item {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    width: 100%;
+    text-align: left;
+    background: transparent;
+    border: 1px solid transparent;
+    color: var(--fg);
+    padding: 7px 9px;
+    border-radius: 4px;
+    margin: 2px 0;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 12px;
+    line-height: 1.35;
+    position: relative;
+  }
+  .comp-studio-item:hover {
+    background: rgba(74,123,212,0.10);
+    border-color: rgba(74,123,212,0.45);
+  }
+  .comp-studio-item.active {
+    background: rgba(74,123,212,0.18);
+    border-color: #6f9ee0;
+  }
+  .comp-studio-item-title {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: 500;
+  }
+  .comp-studio-item-glyph {
+    font-family: var(--font-px);
+    font-size: 11px;
+    color: #6f9ee0;
+  }
+  .comp-studio-item.kind-product .comp-studio-item-glyph { color: #d4a030; }
+  .comp-studio-item-sub {
+    font-family: var(--font-px);
+    font-size: 9.5px;
+    color: var(--accent-dim);
+    margin-top: 1px;
+  }
+  /* Polish (Move 2e fold): on hover, the first step or deck blurb pops
+     out beside the sidebar item. Scoped tooltip element. */
+  .comp-studio-item-preview {
+    position: absolute;
+    left: calc(100% + 6px);
+    top: 0;
+    z-index: 30;
+    background: rgba(0,0,0,0.94);
+    border: 1px solid var(--panel-bd);
+    border-radius: 4px;
+    padding: 8px 10px;
+    width: 240px;
+    font-family: inherit;
+    font-size: 11px;
+    line-height: 1.45;
+    color: var(--fg);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.5);
+    display: none;
+    pointer-events: none;
+  }
+  .comp-studio-item:hover .comp-studio-item-preview { display: block; }
+  .comp-studio-main {
+    padding: 0;
+    background: var(--bg);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+  .comp-studio-main-empty {
+    padding: 40px 24px;
+    text-align: center;
+    color: #6f7a90;
+    font-family: var(--font-px);
+    font-size: 11px;
+    line-height: 1.6;
+  }
+  .comp-studio-main-empty strong { color: var(--accent); }
+  .comp-studio-iframe-wrap {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 360px;
+  }
+  .comp-studio-iframe-bar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 6px 12px;
+    background: rgba(0,0,0,0.30);
+    border-bottom: 1px solid var(--panel-bd);
+    font-family: var(--font-px);
+    font-size: 10px;
+    color: var(--accent-dim);
+  }
+  .comp-studio-iframe-bar .comp-studio-bar-title { color: var(--fg); flex: 1; }
+  .comp-studio-iframe-bar a {
+    color: var(--accent-dim);
+    text-decoration: none;
+    border: 1px solid var(--panel-bd);
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-size: 9.5px;
+  }
+  .comp-studio-iframe-bar a:hover { color: var(--accent); border-color: var(--accent); }
+  .comp-studio-iframe {
+    flex: 1;
+    width: 100%;
+    border: none;
+    min-height: 360px;
+    background: #000;
+  }
 
   /* Hex hover tooltip (Move 1): instant HTML tooltip layer. Native SVG
      <title> tooltips have a ~1 sec delay; this surfaces immediately on
@@ -8038,6 +8198,52 @@
     return new Date(iso).toISOString().slice(0, 10);
   }
 
+  /* Walk Studio (Moves 2c-2e). Hardcoded WALKS for v0.1 — migrate to
+     JSON when there are 5+ walks. Each entry has:
+       id           unique identifier
+       title        sidebar label
+       kind         'deck' or 'product' (Move 2d adds product walks)
+       subtitle?    short blurb under the title
+       preview?     hover-tooltip text (Move 2e polish fold)
+       deck_href?   for kind:'deck' — iframe src (relative path)
+       target_route? for kind:'product' — hash route to boot the lab
+                     iframe into for the walk's first step
+       steps?       for kind:'product' — array of {narrative, target_selector?}
+       mutates?     for kind:'product' — true if the walk modifies state
+                     (triggers the step-0 mutation warning) */
+  const WALKS = [
+    {
+      id: 'deck-rogaine-spine',
+      title: 'The Rogaine Spine',
+      kind: 'deck',
+      subtitle: '16 slides · v0.4 build arc',
+      preview: 'Comprehension deck for the rogaine-spine arc. Walk through what shipped, why it was shaped this way, and how the pieces add up to one moving thing.',
+      deck_href: 'comprehension-deck-v0.1.html'
+    },
+    {
+      id: 'deck-turn-v0.1-map',
+      title: 'Turn v0.1 Map',
+      kind: 'deck',
+      subtitle: '21 slides · 4 acts · beginner-facing',
+      preview: 'The original turn-architecture deck. Frame · Comprehend · Sync · Produce · Debrief · Recover, with the three meta-disciplines (Trim · Heartbeat · Transition).',
+      deck_href: 'turn-v0.1-map.html'
+    }
+  ];
+  // Active walk + step state. Session-scoped so a refresh resets the
+  // walk's progress (per Quenton: progress is session, completion is
+  // durable on the leg's comprehend log).
+  const COMP_ACTIVE_WALK_KEY = 'cognitive-lab-v0.1::comp-active-walk';
+  function getActiveWalkId() {
+    try { return sessionStorage.getItem(COMP_ACTIVE_WALK_KEY); }
+    catch { return null; }
+  }
+  function setActiveWalkId(id) {
+    try {
+      if (id) sessionStorage.setItem(COMP_ACTIVE_WALK_KEY, id);
+      else sessionStorage.removeItem(COMP_ACTIVE_WALK_KEY);
+    } catch {}
+  }
+
   // Snapshot collapse state — sessionStorage so a single dogfood
   // session preserves the user's preference but a new browser session
   // starts fresh (snapshot expanded by default — that's the orient case).
@@ -8167,8 +8373,104 @@
       });
     });
 
-    // 2c-2e fill in the studio. Empty for now.
-    studio.innerHTML = '';
+    // ── Walk Studio (Move 2c) ──
+    renderComprehendStudio(studio);
+  }
+
+  function renderComprehendStudio(studio) {
+    const activeId = getActiveWalkId();
+    const activeWalk = WALKS.find(w => w.id === activeId) || null;
+    const decks = WALKS.filter(w => w.kind === 'deck');
+    const products = WALKS.filter(w => w.kind === 'product');
+
+    function itemHTML(walk) {
+      const isActive = activeWalk && activeWalk.id === walk.id;
+      const glyph = walk.kind === 'deck' ? '◆' : '▦';
+      const previewHTML = walk.preview
+        ? `<div class="comp-studio-item-preview">${escapeHTML(walk.preview)}</div>`
+        : '';
+      return `<button type="button"
+        class="comp-studio-item kind-${walk.kind}${isActive ? ' active' : ''}"
+        data-walk="${escapeHTML(walk.id)}"
+        title="${escapeHTML(walk.title)}">
+        <span class="comp-studio-item-title">
+          <span class="comp-studio-item-glyph" aria-hidden="true">${glyph}</span>
+          ${escapeHTML(walk.title)}
+        </span>
+        ${walk.subtitle ? `<span class="comp-studio-item-sub">${escapeHTML(walk.subtitle)}</span>` : ''}
+        ${previewHTML}
+      </button>`;
+    }
+
+    const sidebarHTML =
+      `<div class="comp-studio-section-label">Decks (${decks.length})</div>` +
+      (decks.length === 0 ? '<div class="comp-snap-empty">No decks yet.</div>' : decks.map(itemHTML).join('')) +
+      (products.length > 0
+        ? `<div class="comp-studio-section-label">Product walks (${products.length})</div>${products.map(itemHTML).join('')}`
+        : '');
+
+    let mainHTML;
+    if (!activeWalk) {
+      mainHTML =
+        '<div class="comp-studio-main-empty">' +
+          'Pick a <strong>deck</strong> or <strong>walk</strong> from the sidebar to load it here.<br>' +
+          '<span style="opacity:0.7;">Decks open in an embedded reader · product walks layer narrative + a live lab iframe.</span>' +
+        '</div>';
+    } else if (activeWalk.kind === 'deck') {
+      // Deck: iframe loads it directly. Bar shows title + close + open-in-tab.
+      mainHTML =
+        '<div class="comp-studio-iframe-wrap">' +
+          '<div class="comp-studio-iframe-bar">' +
+            '<span class="comp-studio-bar-title">' + escapeHTML(activeWalk.title) + '</span>' +
+            '<a href="' + escapeHTML(activeWalk.deck_href) + '" target="_blank" rel="noopener" title="Open this deck in a new tab">↗ open</a>' +
+            '<a href="#" data-act="walk-close" title="Close this walk">× close</a>' +
+          '</div>' +
+          '<iframe class="comp-studio-iframe" src="' + escapeHTML(activeWalk.deck_href) + '" title="' + escapeHTML(activeWalk.title) + '"></iframe>' +
+        '</div>';
+    } else {
+      // Product walk (Move 2d) — placeholder until 2d wires the step renderer.
+      mainHTML = '<div class="comp-studio-main-empty">Product walks land in Move 2d.</div>';
+    }
+
+    studio.innerHTML =
+      '<div class="comp-studio">' +
+        '<div class="comp-studio-header">Walk Studio · ' + WALKS.length + ' available</div>' +
+        '<div class="comp-studio-layout">' +
+          '<div class="comp-studio-sidebar">' + sidebarHTML + '</div>' +
+          '<div class="comp-studio-main">' + mainHTML + '</div>' +
+        '</div>' +
+      '</div>';
+
+    // Sidebar click → activate walk. Calls logComprehendDeckOpen for
+    // decks since iframe-loading doesn't fire the document-level
+    // anchor-click handler that DECK_FILE_RE listens for.
+    studio.querySelectorAll('.comp-studio-item').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const id = btn.dataset.walk;
+        if (!id) return;
+        const walk = WALKS.find(w => w.id === id);
+        if (!walk) return;
+        if (getActiveWalkId() === id) {
+          // Re-clicking the active walk closes it.
+          setActiveWalkId(null);
+        } else {
+          setActiveWalkId(id);
+          if (walk.kind === 'deck' && walk.deck_href && typeof logComprehendDeckOpen === 'function') {
+            logComprehendDeckOpen(walk.deck_href);
+          }
+        }
+        renderComprehendStudio(studio);
+      });
+    });
+    // Close button in iframe bar.
+    const closeLink = studio.querySelector('[data-act="walk-close"]');
+    if (closeLink) {
+      closeLink.addEventListener('click', (e) => {
+        e.preventDefault();
+        setActiveWalkId(null);
+        renderComprehendStudio(studio);
+      });
+    }
   }
 
   // Wire debrief controls (bound once at load)

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -2524,6 +2524,58 @@
   }
   .course-header-bar .ch-link:hover { color: var(--fg); }
 
+  /* ── Debrief Workshop: rogaine-shape extras (Phase 4) ──
+     Score display is auto-computed read-only summary. Radio group is
+     the "Course held?" three-state pick that surfaces the framed-but-
+     deviated case as a first-class outcome. */
+  .db-score-display {
+    background: var(--bg);
+    border: 1px solid var(--panel-bd);
+    border-radius: 4px;
+    padding: 8px 10px;
+    font-family: var(--font-px);
+    font-size: 11.5px;
+    color: var(--fg);
+    line-height: 1.5;
+  }
+  .db-score-display .db-score-line {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 16px;
+    align-items: baseline;
+  }
+  .db-score-display .db-score-label {
+    color: var(--accent-dim);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    font-size: 10px;
+  }
+  .db-score-display .db-score-value { color: var(--fg); font-weight: bold; }
+  .db-score-display .db-score-empty { color: #6f7a90; font-style: italic; }
+  .db-radio-group {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-bottom: 8px;
+  }
+  .db-radio {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 5px 8px;
+    border: 1px solid var(--panel-bd);
+    border-radius: 4px;
+    font-size: 13px;
+    color: var(--fg);
+    cursor: pointer;
+    background: rgba(0,0,0,0.10);
+  }
+  .db-radio:hover { background: rgba(226,160,74,0.06); }
+  .db-radio input[type="radio"] {
+    margin: 0;
+    accent-color: var(--accent);
+  }
+
   /* ── Workshop modes ── */
   .ws-mode { display: none; flex-direction: column; gap: 12px; }
   .ws-mode.active { display: flex; }
@@ -3728,7 +3780,7 @@
           </div>
         </div>
 
-        <!-- DB-EDITING -->
+        <!-- DB-EDITING — rogaine shape (Phase 4): Score · Caught · Course held? · Better moves · Capacity + next -->
         <div class="ws-mode" id="db-editing">
           <div class="ws-mode-header">
             <button class="ws-back-btn" id="db-cancel-btn">← Cancel</button>
@@ -3738,48 +3790,62 @@
 
             <div class="frame-batch">
               <div class="frame-batch-header">
-                <div class="frame-batch-title">Subject</div>
-                <div class="frame-batch-subtitle">What produce stage are you debriefing?</div>
+                <div class="frame-batch-title">Score</div>
+                <div class="frame-batch-subtitle">Auto-computed from this leg's Frame card. You verify; you don't fill.</div>
               </div>
               <div>
-                <label>Produce stage</label>
-                <textarea id="db-subject" placeholder="Name the produce stage / session / work block being debriefed."></textarea>
+                <div id="db-score-display" class="db-score-display">No active leg — open Frame Workshop and save a card to start one.</div>
               </div>
             </div>
 
             <div class="frame-batch">
               <div class="frame-batch-header">
-                <div class="frame-batch-title">Six probe fields</div>
-                <div class="frame-batch-subtitle">Interleaved-with-checkpoints in dogfood mode. Order suggested, not rigid.</div>
+                <div class="frame-batch-title">Caught</div>
+                <div class="frame-batch-subtitle">What you actually came home with. Be specific.</div>
               </div>
               <div>
-                <label>What we Framed</label>
-                <textarea id="db-framed" placeholder="What was the original frame (scope, outcome, approach, safety) for the produce stage? Pull the Frame card if available."></textarea>
+                <textarea id="db-caught" placeholder="The catches. Items shipped, milestones crossed, effort burned."></textarea>
+              </div>
+            </div>
+
+            <div class="frame-batch">
+              <div class="frame-batch-header">
+                <div class="frame-batch-title">Course held?</div>
+                <div class="frame-batch-subtitle">Did the day match what you framed? Pick one.</div>
+              </div>
+              <div class="db-radio-group">
+                <label class="db-radio"><input type="radio" name="db-course-held" value="as-set"> Ran the course as set</label>
+                <label class="db-radio"><input type="radio" name="db-course-held" value="different"> Ran a different course (course changed mid-leg)</label>
+                <label class="db-radio"><input type="radio" name="db-course-held" value="wrong-from-start"> Course was wrong from the start</label>
               </div>
               <div>
-                <label>What actually happened</label>
-                <textarea id="db-actual" placeholder="The real shape of the work. Where did it actually go?"></textarea>
+                <label>What changed it <span class="ff-hint">if different or wrong-from-start</span></label>
+                <textarea id="db-changed-it" placeholder="What invalidated the original course? What did you switch to?"></textarea>
+              </div>
+            </div>
+
+            <div class="frame-batch">
+              <div class="frame-batch-header">
+                <div class="frame-batch-title">Better moves</div>
+                <div class="frame-batch-subtitle">What would the coach say? Optional — leave blank for the future Course Coach to fill.</div>
               </div>
               <div>
-                <label>Where they diverged</label>
-                <textarea id="db-diverged" placeholder="Gap between framed and actual. Surprises, drift, scope creep, scope shrink."></textarea>
+                <textarea id="db-better-moves" placeholder="What would the next-leg version of yourself do differently?"></textarea>
+              </div>
+            </div>
+
+            <div class="frame-batch">
+              <div class="frame-batch-header">
+                <div class="frame-batch-title">Capacity + next</div>
+                <div class="frame-batch-subtitle">Gauge read · what's queued for the next leg.</div>
               </div>
               <div>
-                <label>What to sustain</label>
-                <textarea id="db-sustain" placeholder="What worked that we want to keep doing. Concrete moves, not vibes."></textarea>
-              </div>
-              <div>
-                <label>What to improve</label>
-                <textarea id="db-improve" placeholder="What to change next time. Concrete moves, not vibes."></textarea>
-              </div>
-              <div>
-                <label>Capacity reading + next-up</label>
-                <textarea id="db-capacity" placeholder="Gauge read at end of debrief. Cleared / grounded? What's the next phase, or does recovery insert? What's queued for the next produce?"></textarea>
+                <textarea id="db-capacity" placeholder="Gauge read at end of debrief. Cleared / grounded? What's the next phase, or does recovery insert? What's queued for the next leg?"></textarea>
               </div>
             </div>
 
             <div class="frame-form-actions">
-              <button class="ff-btn primary" id="db-save">Save</button>
+              <button class="ff-btn primary" id="db-save">Save Debrief</button>
               <button class="ff-btn" id="db-clear">Clear fields</button>
               <span class="ff-saved" id="db-saved">✓ saved</span>
             </div>
@@ -6314,15 +6380,30 @@
 
   /* ── Debrief Workshop ── */
   const DEBRIEF_KEY = 'cognitive-lab-v0.1::debrief-cards';
-  const DB_FIELDS = ['subject','framed','actual','diverged','sustain','improve','capacity'];
+  // Phase 4 input fields (rogaine shape). DOM ids: db-caught, db-changed-it,
+  // db-better-moves, db-capacity. course_held is a radio group; not in this list.
+  const DB_FIELDS = ['caught','changed_it','better_moves','capacity'];
+  // Legacy fields kept readable in view-mode for back-compat with older cards.
+  const DB_FIELDS_LEGACY = ['subject','framed','actual','diverged','sustain','improve'];
   const DB_LABELS = {
-    subject:  'Produce stage',
-    framed:   'What we Framed',
-    actual:   'What actually happened',
-    diverged: 'Where they diverged',
-    sustain:  'What to sustain',
-    improve:  'What to improve',
-    capacity: 'Capacity reading + next-up'
+    // Phase 4 labels
+    caught:        'Caught',
+    course_held:   'Course held?',
+    changed_it:    'What changed it',
+    better_moves:  'Better moves',
+    capacity:      'Capacity + next',
+    // Legacy labels
+    subject:       'Produce stage',
+    framed:        'What we Framed',
+    actual:        'What actually happened',
+    diverged:      'Where they diverged',
+    sustain:       'What to sustain',
+    improve:       'What to improve'
+  };
+  const DB_COURSE_HELD_LABEL = {
+    'as-set':           'Ran the course as set',
+    'different':        'Ran a different course (course changed mid-leg)',
+    'wrong-from-start': 'Course was wrong from the start'
   };
 
   function loadDebriefCards() {
@@ -6333,16 +6414,96 @@
     try { localStorage.setItem(DEBRIEF_KEY, JSON.stringify(arr)); } catch {}
     postSave('debrief-cards', arr);
   }
+  function dbReadCourseHeld() {
+    const checked = document.querySelector('input[name="db-course-held"]:checked');
+    return checked ? checked.value : '';
+  }
+  function dbSetCourseHeld(value) {
+    document.querySelectorAll('input[name="db-course-held"]').forEach(r => {
+      r.checked = (value && r.value === value);
+    });
+  }
   function clearDebriefForm() {
-    DB_FIELDS.forEach(f => { const el = document.getElementById('db-'+f); if (el) el.value = ''; });
+    DB_FIELDS.forEach(f => { const el = document.getElementById('db-'+f.replace(/_/g, '-')); if (el) el.value = ''; });
+    dbSetCourseHeld('');
+    renderDebriefScore();
   }
   function loadIntoDebriefForm(card) {
-    DB_FIELDS.forEach(f => { const el = document.getElementById('db-'+f); if (el) el.value = card[f] || ''; });
+    DB_FIELDS.forEach(f => {
+      const el = document.getElementById('db-'+f.replace(/_/g, '-'));
+      if (el) el.value = card[f] || '';
+    });
+    dbSetCourseHeld(card && card.course_held);
+    renderDebriefScore();
   }
   function readDebriefForm() {
     const card = { savedAt: new Date().toISOString(), date: todayDateString() };
-    DB_FIELDS.forEach(f => { const el = document.getElementById('db-'+f); card[f] = el ? el.value.trim() : ''; });
+    DB_FIELDS.forEach(f => {
+      const el = document.getElementById('db-'+f.replace(/_/g, '-'));
+      card[f] = el ? el.value.trim() : '';
+    });
+    card.course_held = dbReadCourseHeld();
     return card;
+  }
+  function dbCardHasContent(card) {
+    if (!card) return false;
+    if (card.course_held) return true;
+    return DB_FIELDS.some(f => (card[f] || '').toString().trim().length > 0);
+  }
+  /* Score auto-derive from active leg's Frame card.
+     Phase 4 only counts plan-side: Musts (from frame.must) and Bonus (from
+     frame.stretch). When leg.produce.selected is populated by future phases,
+     "completed" counts will replace plan counts. */
+  function renderDebriefScore() {
+    const el = document.getElementById('db-score-display');
+    if (!el) return;
+    const leg = findActiveLeg();
+    if (!leg) {
+      el.innerHTML = '<span class="db-score-empty">No active leg — open Frame Workshop and save a card to start one.</span>';
+      return;
+    }
+    const card = findFrameCardForLeg(leg);
+    if (!card) {
+      el.innerHTML =
+        '<div class="db-score-line">' +
+          '<span class="db-score-label">Leg</span><span class="db-score-value">' + escapeHTML(leg.id) + '</span>' +
+          '<span class="db-score-empty">No Frame card linked yet.</span>' +
+        '</div>';
+      return;
+    }
+    const mustArr  = Array.isArray(card.must) ? card.must
+                   : (typeof card.must === 'string' && card.must.trim() ? [{ id: 'free' }] : []);
+    const bonusArr = Array.isArray(card.stretch) ? card.stretch
+                   : (typeof card.stretch === 'string' && card.stretch.trim() ? [{ id: 'free' }] : []);
+    const flavors = mustArr
+      .map(r => r && r.done_this_turn)
+      .filter(Boolean);
+    const flavorMix = flavors.length === 0 ? 'no per-Done flavors named' : flavors.join(' · ');
+    el.innerHTML =
+      '<div class="db-score-line">' +
+        '<span class="db-score-label">Leg</span><span class="db-score-value">' + escapeHTML(leg.id) + '</span>' +
+        '<span class="db-score-label">Musts planned</span><span class="db-score-value">' + mustArr.length + '/3</span>' +
+        '<span class="db-score-label">Bonus planned</span><span class="db-score-value">' + bonusArr.length + '</span>' +
+        '<span class="db-score-label">Flavor mix</span><span class="db-score-value">' + escapeHTML(flavorMix) + '</span>' +
+      '</div>';
+  }
+  /* changes_to_course writeback. Phase 4 captures the Debrief outcome on the
+     active leg, links the just-saved Debrief card, bumps the leg's status to
+     debriefed. The frontier add/remove UI is queued for a future LAB item;
+     today the writeback records the qualitative outcome only. */
+  function attachDebriefToLeg(card) {
+    if (!card || !card.savedAt) return null;
+    const leg = findActiveLeg();
+    if (!leg) return null;
+    leg.debrief_card_id = card.savedAt;
+    leg.changes_to_course = {
+      at: new Date().toISOString(),
+      debrief_card_id: card.savedAt,
+      course_held: card.course_held || '',
+      summary: card.changed_it || ''
+    };
+    leg.status = 'debriefed';
+    return upsertLeg(leg);
   }
   function flashDebriefSaved() {
     const el = document.getElementById('db-saved');
@@ -6378,8 +6539,9 @@
       `<span id="db-date">${todayDateString()}</span>`;
     if (card) loadIntoDebriefForm(card); else clearDebriefForm();
     setDbMode('editing');
+    renderDebriefScore();
     setTimeout(() => {
-      const first = document.getElementById('db-subject');
+      const first = document.getElementById('db-caught');
       if (first) first.focus();
     }, 50);
   }
@@ -6390,12 +6552,26 @@
     if (!card) return;
     dbEditingOriginalIdx = idx;
     document.getElementById('db-viewing-date').textContent = card.date || '(no date)';
-    const rows = DB_FIELDS
-      .filter(f => card[f] && card[f].length > 0)
-      .map(f => `<div class="ws-vb-row"><div class="lbl">${DB_LABELS[f]}</div><div class="val">${escapeHTML(card[f])}</div></div>`)
-      .join('');
+    // Phase 4 view renderer: show new fields first, then legacy fields if they
+    // exist on the card (back-compat for cards saved under the pre-rogaine shape).
+    const rowParts = [];
+    if (card.course_held) {
+      rowParts.push(`<div class="ws-vb-row"><div class="lbl">${DB_LABELS.course_held}</div><div class="val">${escapeHTML(DB_COURSE_HELD_LABEL[card.course_held] || card.course_held)}</div></div>`);
+    }
+    DB_FIELDS.forEach(f => {
+      const v = card[f];
+      if (v && (typeof v !== 'string' || v.length > 0)) {
+        rowParts.push(`<div class="ws-vb-row"><div class="lbl">${DB_LABELS[f]}</div><div class="val">${escapeHTML(v)}</div></div>`);
+      }
+    });
+    DB_FIELDS_LEGACY.forEach(f => {
+      const v = card[f];
+      if (v && (typeof v !== 'string' || v.length > 0)) {
+        rowParts.push(`<div class="ws-vb-row"><div class="lbl">${DB_LABELS[f]} <span class="ff-hint" style="margin-left:4px;">legacy</span></div><div class="val">${escapeHTML(v)}</div></div>`);
+      }
+    });
     document.getElementById('db-viewing-body').innerHTML =
-      rows || '<div style="color:#888;font-size:12px;font-style:italic;">Empty card.</div>';
+      rowParts.length > 0 ? rowParts.join('') : '<div style="color:#888;font-size:12px;font-style:italic;">Empty card.</div>';
     setDbMode('viewing');
   }
 
@@ -6446,10 +6622,12 @@
       const g = groups[key];
       const items = g.cards.slice().reverse().map(({card, idx}) => {
         const time = (card.date || '').slice(11) || '·';
-        const subject = (card.subject || '').slice(0, 110);
+        // Phase 4: prefer the new "caught" field; fall back to legacy "subject"
+        // for older cards. Either way, truncate to 110 chars.
+        const headline = (card.caught || card.subject || '').slice(0, 110);
         return `<div class="ws-recent-card" data-idx="${idx}">
           <div class="rc-date">${escapeHTML(time)}</div>
-          <div class="rc-must">${escapeHTML(subject || '(no subject)')}</div>
+          <div class="rc-must">${escapeHTML(headline || '(no caught yet)')}</div>
         </div>`;
       }).join('');
       const labelClass = g.isToday ? 'ws-recent-group-label today' : 'ws-recent-group-label';
@@ -6469,11 +6647,8 @@
 
     const cancelBtn = document.getElementById('db-cancel-btn');
     if (cancelBtn) cancelBtn.addEventListener('click', () => {
-      const hasContent = DB_FIELDS.some(f => {
-        const el = document.getElementById('db-'+f);
-        return el && el.value.trim();
-      });
-      if (hasContent && !confirm('Discard this card? Unsaved changes will be lost.')) return;
+      const draft = readDebriefForm();
+      if (dbCardHasContent(draft) && !confirm('Discard this card? Unsaved changes will be lost.')) return;
       dbEnterResting();
     });
 
@@ -6508,30 +6683,36 @@
     const saveBtn = document.getElementById('db-save');
     if (saveBtn) saveBtn.addEventListener('click', () => {
       const card = readDebriefForm();
-      const filled = DB_FIELDS.filter(f => card[f]).length;
-      if (filled === 0) return;
+      if (!dbCardHasContent(card)) return;
       const cards = loadDebriefCards();
       if (dbEditingOriginalIdx >= 0 && cards[dbEditingOriginalIdx]) {
-        card.date = cards[dbEditingOriginalIdx].date || card.date;
+        const orig = cards[dbEditingOriginalIdx];
+        // Preserve date + savedAt + any legacy fields (subject, framed, actual,
+        // diverged, sustain, improve) that the new form no longer edits.
+        card.date = orig.date || card.date;
+        card.savedAt = orig.savedAt || card.savedAt;
+        DB_FIELDS_LEGACY.forEach(f => { if (orig[f] !== undefined) card[f] = orig[f]; });
         cards[dbEditingOriginalIdx] = card;
       } else {
         cards.push(card);
       }
       saveDebriefCards(cards);
+      // Phase 4: link the active leg to this Debrief card and write back the
+      // changes_to_course outcome. Bumps leg.status to 'debriefed'. Course
+      // Header re-renders so the leg's new status shows immediately.
+      attachDebriefToLeg(card);
+      renderCourseHeader();
       flashDebriefSaved();
       setTimeout(() => dbEnterResting(), 600);
     });
 
     const clearBtn = document.getElementById('db-clear');
     if (clearBtn) clearBtn.addEventListener('click', () => {
-      const hasContent = DB_FIELDS.some(f => {
-        const el = document.getElementById('db-'+f);
-        return el && el.value.trim();
-      });
-      if (hasContent && !confirm('Clear all fields?')) return;
+      const draft = readDebriefForm();
+      if (dbCardHasContent(draft) && !confirm('Clear all fields?')) return;
       clearDebriefForm();
       setTimeout(() => {
-        const first = document.getElementById('db-subject');
+        const first = document.getElementById('db-caught');
         if (first) first.focus();
       }, 30);
     });

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -8541,10 +8541,12 @@
               ? '<span class="comp-snap-empty">No comprehend activity on this leg yet.</span>'
               : `<ul class="comp-snap-recent">${entries.map((e, i) => {
                   const p = comprehendEntryParts(e);
-                  return `<li class="cc-${p.kind}" data-idx="${i}" role="button" tabindex="0">
+                  // Collapsed row shows when + kind chip only — body
+                  // reveals on click (drilldown polish). Avoids the
+                  // double-render-on-expand issue grepzilla flagged.
+                  return `<li class="cc-${p.kind}" data-idx="${i}" role="button" tabindex="0" aria-expanded="false">
                     <span class="comp-snap-when">${escapeHTML(fmtComprehendWhen(e && e.at))}</span>
                     <span class="cc-kind cc-kind-${p.kind}">${escapeHTML(p.label)}</span>
-                    ${p.bodyHTML}
                     <div class="comp-snap-body">${p.bodyHTML}</div>
                   </li>`;
                 }).join('')}</ul>`
@@ -8596,13 +8598,16 @@
     }
     // Recent-entry drilldown (polish fold).
     snapshot.querySelectorAll('.comp-snap-recent li').forEach(li => {
-      li.addEventListener('click', () => {
-        li.classList.toggle('expanded');
-      });
+      const toggle = () => {
+        const next = !li.classList.contains('expanded');
+        li.classList.toggle('expanded', next);
+        li.setAttribute('aria-expanded', next ? 'true' : 'false');
+      };
+      li.addEventListener('click', toggle);
       li.addEventListener('keydown', (e) => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
-          li.classList.toggle('expanded');
+          toggle();
         }
       });
     });
@@ -8766,11 +8771,14 @@
     const doneBtn = studio.querySelector('[data-act="walk-done"]');
     if (doneBtn) doneBtn.addEventListener('click', () => {
       // Move 2e: log walk completion to leg.comprehend[]. The walk's
-      // active-id state clears after; the entry is durable.
+      // active-id state clears after; the entry is durable. Use the
+      // 1-indexed step position when Done fires (== full step count
+      // today since Done only renders on isLast, but this stays correct
+      // if a future walk adds an early-exit Done).
       const id = getActiveWalkId();
       const walk = id ? WALKS.find(w => w.id === id) : null;
       if (walk) {
-        const stepsCompleted = (walk.steps || []).length;
+        const stepsCompleted = getWalkStep() + 1;
         logComprehendWalkComplete(walk.id, stepsCompleted);
       }
       setActiveWalkId(null);
@@ -9156,6 +9164,14 @@
     } catch { return 'floor'; }
   }
   function saveActiveView(v) {
+    // Skip the write when running inside a Walk Studio iframe (?walk=1).
+    // Iframe and parent share localStorage; without this guard, the
+    // user's tab navigation inside the walk would silently rewrite the
+    // parent's persisted view and cause a surprising view-jump after
+    // the walk closes.
+    try {
+      if (new URLSearchParams(location.search).get('walk') === '1') return;
+    } catch {}
     try { localStorage.setItem(VIEW_KEY, v); } catch {}
   }
 
@@ -9877,6 +9893,11 @@
     } catch { return 'build'; }
   }
   function saveCourseHexLens(v) {
+    // Same walk-mode guard as saveActiveView: don't contaminate the
+    // parent's persisted lens preference from inside a walk iframe.
+    try {
+      if (new URLSearchParams(location.search).get('walk') === '1') return;
+    } catch {}
     try { localStorage.setItem(COURSE_HEX_LENS_KEY, v); } catch {}
   }
   let courseHexLens = loadCourseHexLens();
@@ -11758,11 +11779,13 @@
     document.body.insertBefore(banner, document.body.firstChild);
     // Hide the Comprehend Station area from assistive tech as well as
     // visually — the CSS already opacity-dims it; aria-hidden suppresses
-    // screen-reader announcements of the inert overlay text.
-    document.addEventListener('DOMContentLoaded', () => {
-      const inertArea = document.querySelector('.area[data-area="comprehend-station"]');
-      if (inertArea) inertArea.setAttribute('aria-hidden', 'true');
-    });
+    // screen-reader announcements of the inert overlay text. The script
+    // runs as deferred-inline at the bottom of <body>, so the DOM is
+    // fully parsed by now and the area element is queryable directly
+    // (a DOMContentLoaded wrapper would never fire — that event has
+    // already passed by the time this code executes).
+    const inertArea = document.querySelector('.area[data-area="comprehend-station"]');
+    if (inertArea) inertArea.setAttribute('aria-hidden', 'true');
   })();
 
   hydrateFromServer().then(() => {

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -671,6 +671,19 @@
     cursor: not-allowed;
     pointer-events: none;
   }
+  /* Drawer status message — surfaced when Apply template returns 0
+     (nothing new to place). Plain dim text, fades out so it doesn't
+     pile up in the DOM. */
+  .bc-drawer-msg {
+    font-family: var(--font-px);
+    font-size: 10px;
+    color: var(--accent);
+    margin: 0 0 8px;
+    padding: 4px 6px;
+    background: rgba(226,160,74,0.08);
+    border-radius: 3px;
+    text-align: center;
+  }
   /* In-hand state (Move 3d): drawer item that's currently being held,
      ready to snap into a cell. Highlighted with accent border + bg. */
   .bc-drawer-item.bc-in-hand {
@@ -9155,9 +9168,10 @@
           <p class="bc-drawer-title">Tool drawer · ${drawerItems.length} items</p>
           <p class="bc-drawer-sub">Pieces grouped by area. Click to take in hand; click again to drop. With one in hand, click a cell to snap it.</p>
           <div class="bc-drawer-actions">
-            <button type="button" class="bc-drawer-action" data-act="apply-template" ${(course.frontier || []).length === 0 ? 'disabled' : ''} title="Snap this Course's frontier items to the board in priority + area order. Skips items already placed.">▦ Apply template</button>
-            <button type="button" class="bc-drawer-action danger" data-act="clear-board" ${placedCount === 0 ? 'disabled' : ''} title="Remove all placements from the board.">✕ Clear board</button>
+            <button type="button" class="bc-drawer-action" data-act="apply-template" ${(course.frontier || []).length === 0 ? 'disabled' : ''} title="Snap this Course's frontier items to the board in priority + area order. Skips items already placed."><span aria-hidden="true">▦</span> Apply template</button>
+            <button type="button" class="bc-drawer-action danger" data-act="clear-board" ${placedCount === 0 ? 'disabled' : ''} title="Remove all placements from the board."><span aria-hidden="true">✕</span> Clear board</button>
           </div>
+          <p class="bc-drawer-msg" id="bc-drawer-msg" hidden></p>
           ${drawerInner}
         </div>
       </div>
@@ -9231,9 +9245,16 @@
           if (act === 'apply-template') {
             const placed = applyBuildTemplate(items);
             if (placed === 0) {
-              // Either frontier is empty, every frontier item is already
-              // placed, or the canvas is full. The button's disabled state
-              // catches empty-frontier; the others fall through silently.
+              // Empty-frontier is caught by the disabled state. The other
+              // zero-cases are: every frontier item is already placed, or
+              // the canvas is full. Surface a brief inline message so the
+              // user gets feedback rather than silence.
+              const msg = drawer.querySelector('#bc-drawer-msg');
+              if (msg) {
+                msg.textContent = 'Nothing new to place — every frontier item is already on the board.';
+                msg.hidden = false;
+                setTimeout(() => { msg.hidden = true; msg.textContent = ''; }, 2400);
+              }
               return;
             }
             bcInHand = null;

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -648,13 +648,15 @@
     color: var(--fg);
     background: rgba(255,255,255,0.02);
   }
+  /* Phase 1.5: timestamp + kind chip + body all sit inline on one row
+     for scannability across mixed-kind entries. */
   .course-comprehend-entry .cc-when {
-    display: block;
+    display: inline-block;
     font-family: var(--font-px);
     font-size: 9.5px;
     letter-spacing: 1px;
     color: var(--accent-dim);
-    margin-bottom: 3px;
+    margin-right: 8px;
   }
 
   /* Phase 1.5: kind labels for mixed-kind comprehend timelines (note ·
@@ -675,12 +677,11 @@
   .cc-kind-note      { color: #d4a030; background: rgba(212,160,48,0.10); border: 1px solid rgba(212,160,48,0.35); }
   .cc-kind-synthesis { color: #5cb09a; background: rgba(92,176,154,0.10); border: 1px solid rgba(92,176,154,0.35); }
   .cc-kind-deck      { color: #6f9ee0; background: rgba(74,123,212,0.10); border: 1px solid rgba(74,123,212,0.35); }
-  /* Tighten the cc-when line in mixed-kind mode so the kind chip sits on
-     the same row as the timestamp + body for scannability. */
-  .course-comprehend-entry .cc-when { display: inline-block; margin-right: 8px; margin-bottom: 0; }
   .course-comprehend-entry .cc-body { color: var(--fg); }
-  /* Synthesis entries: emphasize the item id with the px font */
+  /* Synthesis + deck entries: px-font emphasis on the body since they're
+     ID-shaped or path-shaped, not prose. */
   .course-comprehend-entry.cc-synthesis .cc-body,
+  .course-comprehend-entry.cc-deck .cc-body,
   .leg-comprehend-list li.cc-synthesis,
   .leg-comprehend-list li.cc-deck { font-family: var(--font-px); font-size: 11.5px; }
 
@@ -8290,10 +8291,13 @@
     // Adds a comprehend entry to the active leg. No-op if no active leg
     // (orphan signals are dropped silently — by design; the leg is the
     // unit of comprehension and we don't try to back-fill).
+    // Note: `at` is always authoritative — any `at` on the caller's entry
+    // is overwritten with `new Date().toISOString()`. Callers should not
+    // pass `at`; if you need backdating, use upsertLeg directly.
     const leg = findActiveLeg();
     if (!leg) return null;
     leg.comprehend = Array.isArray(leg.comprehend) ? leg.comprehend.slice() : [];
-    leg.comprehend.push(Object.assign({ at: new Date().toISOString() }, entry));
+    leg.comprehend.push(Object.assign({}, entry, { at: new Date().toISOString() }));
     return upsertLeg(leg);
   }
   function logComprehendSynthesis(itemId, prevStatus, nextStatus) {
@@ -8305,10 +8309,8 @@
     });
     // If the user is on the Course or Leg view when this fires, surface
     // the new entry immediately. Best-effort: render functions guard.
-    if (typeof activeView !== 'undefined') {
-      if (activeView === 'course' && typeof renderCourseComprehend === 'function') renderCourseComprehend();
-      if (activeView === 'leg'    && typeof renderLegView          === 'function') renderLegView();
-    }
+    if (activeView === 'course' && typeof renderCourseComprehend === 'function') renderCourseComprehend();
+    if (activeView === 'leg'    && typeof renderLegView          === 'function') renderLegView();
   }
   function logComprehendDeckOpen(href) {
     // Called when the user clicks an artifact-link whose href matches a
@@ -8318,10 +8320,8 @@
       kind: 'deck',
       source: clean
     });
-    if (typeof activeView !== 'undefined') {
-      if (activeView === 'course' && typeof renderCourseComprehend === 'function') renderCourseComprehend();
-      if (activeView === 'leg'    && typeof renderLegView          === 'function') renderLegView();
-    }
+    if (activeView === 'course' && typeof renderCourseComprehend === 'function') renderCourseComprehend();
+    if (activeView === 'leg'    && typeof renderLegView          === 'function') renderLegView();
   }
   // Delegated click handler for any artifact-link in the lab. Fires the
   // deck-open log only when the href matches the deck file pattern. Does

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -4643,10 +4643,20 @@
       "name": "Deck Theater",
       "type": "aux / artifact",
       "accent": "teal",
-      "description": "The v0.2 presentation. Four acts, 21 slides. Beginner-facing.",
+      "description": "Where the lab's presentation decks live. Each deck is a different shape (turn map for newcomers, comprehension passes for re-immersion after big design arcs).",
       "items": [],
       "artifacts": [
-        { "label": "turn-v0.1-map.html (open deck)", "href": "turn-v0.1-map.html" }
+        { "label": "turn-v0.1-map.html (the v0.2 turn map · 4 acts · 21 slides · beginner-facing)", "href": "turn-v0.1-map.html" },
+        { "label": "comprehension-deck-v0.1.html (the rogaine spine · 16 slides · Comprehend phase artifact for the 2026-05-04 build arc)", "href": "comprehension-deck-v0.1.html" }
+      ],
+      "experiments": [
+        {
+          "id": "exp-deck-2026-05-04-comprehension-deck",
+          "title": "Comprehension deck for the rogaine spine arc",
+          "date": "2026-05-04 (early morning)",
+          "observation": "After the overnight build run shipped Course tier + Hex Map + Leg wrapper + Course Header + on-demand Comprehend + Debrief revision + Snap Circuit Leg view, the author wanted a re-immersion pass before vetting. Asked for a highly visual deck walking through the new surfaces and the rationale. Built comprehension-deck-v0.1.html — 16 vertical scroll-snap slides, color-matched to the lab, with the Hex Map and Snap Circuit visuals echoed inside the deck.",
+          "impact": "Comprehend station now has a concrete artifact-shape: a deck that re-renders an arc the way it was built. Filed under Deck Theater so future big arcs can drop their own comprehension decks here. The pattern itself becomes a play: ship the work, then ship the deck that walks the work."
+        }
       ],
       "notes": []
     }

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -368,11 +368,65 @@
     height: auto;
     display: block;
   }
-  .hex-cell { stroke: #2a2a35; stroke-width: 1; transition: opacity 120ms ease; }
+  /* ── Hex Map v0.2 (Phase 1: biome regions + 4-channel encoding) ──
+     Channels (per Quenton design dialog):
+       Hue        → biome (area accent) — stable identity
+       Luminosity → relevance to current course (4-state ramp)
+       Stroke     → priority (2px ring on P0, 1px on others)
+       Motion     → attention call-out (single pulse on select; ambient
+                    breath on the active leg's working set)
+     Drops the v0.1 fill-vs-outline + teal frontier ring + purple
+     "both" ring — luminosity now carries the frontier signal cleanly,
+     and P0's red ring stacks on any luminosity without fighting. */
+  .hex-cell {
+    stroke: #2a2a35;
+    stroke-width: 1;
+    transition: opacity 200ms ease;
+  }
   .hex-cell:hover { stroke: var(--accent); stroke-width: 1.5; cursor: default; }
-  .hex-cell.p0 { stroke: #c25450; stroke-width: 2; filter: drop-shadow(0 0 3px rgba(194,84,80,0.55)); }
-  .hex-cell.in-frontier { stroke: #5cb09a; stroke-width: 2.5; filter: drop-shadow(0 0 4px rgba(92,176,154,0.6)); }
-  .hex-cell.in-frontier.p0 { stroke: #b890d4; filter: drop-shadow(0 0 5px rgba(184,144,212,0.7)); }
+  /* P0 = priority ring. Second-channeled with stroke-width: 2 (vs 1 for
+     non-P0) so the cue survives any color-vision profile. */
+  .hex-cell.p0 {
+    stroke: #c25450;
+    stroke-width: 2;
+    filter: drop-shadow(0 0 3px rgba(194,84,80,0.55));
+  }
+  /* Active = item is in the active leg's Frame card. Saturation boost +
+     subtle glow so the working set pops without the ambient breath
+     having to start before the user has even glanced at it. */
+  .hex-cell.active {
+    filter: saturate(1.1) drop-shadow(0 0 4px rgba(255,255,255,0.18));
+  }
+  .hex-cell.active.p0 {
+    filter: saturate(1.1) drop-shadow(0 0 4px rgba(194,84,80,0.6));
+  }
+  /* Pulse-on-select: single bump, fades. Acknowledgment, not ambience. */
+  @keyframes hex-pulse-once {
+    0%   { filter: brightness(1.0); }
+    40%  { filter: brightness(1.18); }
+    100% { filter: brightness(1.0); }
+  }
+  .hex-cell.pulse-once { animation: hex-pulse-once 600ms ease-out; }
+  .hex-cell.pulse-once.p0 {
+    /* Preserve P0 drop-shadow during the pulse animation by stacking
+       the brightness filter via a second filter layer on the keyframe. */
+    animation: hex-pulse-once 600ms ease-out;
+  }
+  /* Ambient breath on the active leg's working set. Slow ±5% opacity
+     oscillation so peripheral vision picks up "something's alive over
+     there" without the focused eye seeing motion. */
+  @keyframes hex-breath {
+    0%, 100% { opacity: 1.0; }
+    50%      { opacity: 0.95; }
+  }
+  .hex-cell.breathing {
+    animation: hex-breath 6s ease-in-out infinite;
+  }
+  /* Motion-sensitivity guardrail — disable ambient breath but keep the
+     single-pulse acknowledgment (it's a discrete event, not ambient). */
+  @media (prefers-reduced-motion: reduce) {
+    .hex-cell.breathing { animation: none; }
+  }
   .hex-label {
     font-family: var(--font-px);
     font-size: 7px;
@@ -382,10 +436,38 @@
     pointer-events: none;
     opacity: 0.85;
   }
+  /* Biome region — labeled cluster wrapping each area's hexes. The
+     translucent background tints the cluster with the biome's hue. */
+  .hex-region-bg {
+    rx: 8;
+    ry: 8;
+    stroke-width: 1;
+    fill-opacity: 0.06;
+    stroke-opacity: 0.45;
+  }
+  .hex-region-label {
+    font-family: var(--font-px);
+    font-size: 9.5px;
+    font-weight: bold;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    fill: var(--accent-dim);
+    dominant-baseline: hanging;
+    pointer-events: none;
+  }
+  .hex-region-count {
+    font-family: var(--font-px);
+    font-size: 9px;
+    fill: #6f7a90;
+    dominant-baseline: hanging;
+    pointer-events: none;
+  }
+  /* Legend now shows the encoding channels rather than swatches per
+     biome — the regions themselves carry the biome legend. */
   .course-hexmap-legend {
     display: flex;
     flex-wrap: wrap;
-    gap: 12px 18px;
+    gap: 10px 18px;
     margin-top: 12px;
     padding-top: 10px;
     border-top: 1px solid var(--panel-bd);
@@ -394,10 +476,21 @@
     color: var(--accent-dim);
   }
   .course-hexmap-legend .lg-item { display: inline-flex; align-items: center; gap: 5px; }
-  .course-hexmap-legend .lg-swatch { width: 12px; height: 12px; border-radius: 2px; display: inline-block; }
-  .course-hexmap-legend .lg-ring {
-    width: 12px; height: 12px; border-radius: 50%; border: 2px solid;
+  .course-hexmap-legend .lg-swatch {
     display: inline-block;
+    width: 14px;
+    height: 12px;
+    border-radius: 2px;
+    background: #5e6f8a;
+  }
+  .course-hexmap-legend .lg-swatch.dim   { opacity: 0.18; }
+  .course-hexmap-legend .lg-swatch.avail { opacity: 0.50; }
+  .course-hexmap-legend .lg-swatch.front { opacity: 1.0; }
+  .course-hexmap-legend .lg-swatch.act   { opacity: 1.0; box-shadow: 0 0 4px rgba(255,255,255,0.4); }
+  .course-hexmap-legend .lg-ring {
+    display: inline-block;
+    width: 12px; height: 12px; border-radius: 50%;
+    border: 2px solid;
   }
 
   /* ── Leg view: Snap Circuit board (Phase 5) ──
@@ -8136,10 +8229,10 @@
     panel.innerHTML = html;
   }
 
-  /* ── Hex Map (Course view, read-only v0.1) ──
-     Renders all Map items as flat-top hexes. Fill = area accent. Opacity = status
-     fog. P0 ring = red glow. Frontier ring = bright accent halo. Spatial layout
-     packs by area (no semantic adjacency yet). */
+  /* ── Hex Map v0.2 (Course view) ──
+     Biome regions (cluster per area, labeled, translucent biome-colored
+     background) + 4-channel encoding (hue=biome, luminosity=relevance,
+     stroke=priority, motion=attention). Per Quenton's design dialog. */
   const HEX_ACCENT_FILL = {
     blue:   '#4a7bd4',
     amber:  '#d4a030',
@@ -8152,13 +8245,18 @@
     red:    '#c25450',
     purple: '#9a6fc2'
   };
-  const HEX_STATUS_OPACITY = {
-    'archived':    0.30,
-    'live':        0.55,
-    'backlog':     0.75,
-    'drafted':     0.90,
-    'in-progress': 1.00
-  };
+  // Phase 1 (v0.2) luminosity ramp. Four states designed against ~3:1
+  // contrast steps (perceptually distinct without being shouty).
+  // Logarithmic-ish: each step roughly halves the previous.
+  //   archived (terminal)          → 0.18   (below hue-recognition; reads as terrain)
+  //   available (not in frontier)  → 0.50
+  //   in frontier (in scope)       → 1.00
+  //   active (in current leg)      → 1.00 + .active class for saturation boost
+  function hexLuminosityFor(it, frontierSet) {
+    if (it.status === 'archived') return 0.18;
+    if (frontierSet && frontierSet.has(it.id)) return 1.0;
+    return 0.50;
+  }
 
   function hexPolygonPoints(cx, cy, s) {
     // Flat-top hex centered at (cx, cy) with side length s. Six vertices.
@@ -8173,74 +8271,189 @@
     ].map(p => p[0].toFixed(2) + ',' + p[1].toFixed(2)).join(' ');
   }
 
+  // Returns the set of LAB item IDs that are in the active leg's Frame
+  // card's must[] (the leg's working set). Used by the Hex Map to
+  // apply the .active and .breathing classes on those hexes.
+  function getActiveLegWorkingSet() {
+    const set = new Set();
+    if (typeof findActiveLeg !== 'function') return set;
+    const leg = findActiveLeg();
+    if (!leg) return set;
+    const card = (typeof findFrameCardForLeg === 'function') ? findFrameCardForLeg(leg) : null;
+    if (!card) return set;
+    const must = Array.isArray(card.must) ? card.must : [];
+    must.forEach(r => { if (r && r.id) set.add(r.id); });
+    return set;
+  }
+
   function renderCourseHexMap() {
     const wrap = document.getElementById('course-hexmap');
     if (!wrap) return;
     const c = getOrInitCourseDraft();
     const frontierSet = new Set(c.frontier || []);
+    const workingSet = getActiveLegWorkingSet();
     const items = allItemsArray();
     if (items.length === 0) {
       wrap.innerHTML = '<p class="course-hexmap-title">Map</p><p class="course-hexmap-sub">No items in the lab yet.</p>';
       return;
     }
-    // Sort items: by area (alphabetic for stable layout), then priority, then id.
-    const sorted = items.slice().sort((a, b) => {
-      const ax = (a.areaName || 'zzz').localeCompare(b.areaName || 'zzz');
-      if (ax !== 0) return ax;
-      const pr = priorityRank(a.priority) - priorityRank(b.priority);
-      if (pr !== 0) return pr;
-      return (a.id || '').localeCompare(b.id || '');
+
+    // ── Group items into biome regions (one cluster per area) ──
+    const byArea = new Map();
+    items.forEach(it => {
+      const aId = it.areaId || '__orphan';
+      if (!byArea.has(aId)) byArea.set(aId, { areaId: aId, areaName: it.areaName || aId, items: [] });
+      byArea.get(aId).items.push(it);
+    });
+    // Sort items within each region: P0 first (so the eye lands on
+    // the most-urgent biome resident), then by status rank, then by id.
+    byArea.forEach(r => {
+      r.items.sort((a, b) => {
+        const pa = priorityRank(a.priority) - priorityRank(b.priority);
+        if (pa !== 0) return pa;
+        const sa = statusRank(a.status) - statusRank(b.status);
+        if (sa !== 0) return sa;
+        return (a.id || '').localeCompare(b.id || '');
+      });
+    });
+    // Sort regions: biggest first (so the layout has a stable feel
+    // — the dominant biomes anchor the top-left corner).
+    const regions = Array.from(byArea.values()).sort((a, b) => {
+      if (b.items.length !== a.items.length) return b.items.length - a.items.length;
+      return (a.areaName || '').localeCompare(b.areaName || '');
     });
 
-    // Lay out in a flat-top hex grid. ~8 cols wide. Odd cols offset down.
-    const COLS = 8;
-    const S = 30;                       // hex side length
-    const STEP_X = 1.5 * S;             // horizontal step (col)
-    const STEP_Y = Math.sqrt(3) * S;    // vertical step (row)
-    const OFFSET_Y = STEP_Y / 2;        // odd-col vertical offset
-    const PAD = S + 4;                  // canvas padding
+    // ── Hex + cluster geometry ──
+    const S = 22;                       // hex side length (smaller than v0.1; clusters get denser)
+    const STEP_X = 1.5 * S;             // 33
+    const STEP_Y = Math.sqrt(3) * S;    // ~38
+    const OFFSET_Y = STEP_Y / 2;        // ~19 (odd-col offset)
+    const HEX_PAD = 8;                  // padding inside a region around the hex grid
+    const LABEL_H = 14;                 // height reserved above hexes for the region label
+    const REGION_GAP = 14;              // gap between regions (both axes)
+    const CANVAS_W = 740;               // target width (matches .course-hexmap max-width)
 
-    const cells = sorted.map((it, i) => {
-      const col = i % COLS;
-      const row = Math.floor(i / COLS);
-      const cx = PAD + col * STEP_X;
-      const cy = PAD + row * STEP_Y + (col % 2 ? OFFSET_Y : 0);
-      const accent = (AREA_VISUALS[it.areaId] && AREA_VISUALS[it.areaId].accent) || 'dark';
-      const fill = HEX_ACCENT_FILL[accent] || HEX_ACCENT_FILL.dark;
-      const opacity = HEX_STATUS_OPACITY[it.status] || 0.75;
-      const classes = ['hex-cell'];
-      if (it.priority === 'P0') classes.push('p0');
-      if (frontierSet.has(it.id)) classes.push('in-frontier');
-      const points = hexPolygonPoints(cx, cy, S);
-      const numShort = (it.id || '').replace(/^LAB-/, '');
-      return `<g>
-        <polygon class="${classes.join(' ')}" points="${points}" fill="${fill}" fill-opacity="${opacity}">
-          <title>${escapeHTML(it.id)} · ${escapeHTML(it.title)} · ${escapeHTML(it.priority)} · ${escapeHTML(it.status)} · ${escapeHTML(it.areaName)}</title>
-        </polygon>
-        <text class="hex-label" x="${cx.toFixed(2)}" y="${cy.toFixed(2)}">${escapeHTML(numShort)}</text>
+    function regionDims(r) {
+      const n = r.items.length;
+      const cols = Math.min(3, n);
+      const rows = Math.ceil(n / cols);
+      const w = HEX_PAD * 2 + 2 * S + (cols - 1) * STEP_X;
+      const oddOffset = cols > 1 ? OFFSET_Y : 0;
+      const h = HEX_PAD * 2 + LABEL_H + STEP_Y + (rows - 1) * STEP_Y + oddOffset;
+      return { cols, rows, w, h };
+    }
+    // Pre-compute region dimensions so we can pack them.
+    regions.forEach(r => {
+      const d = regionDims(r);
+      r.cols = d.cols;
+      r.rows = d.rows;
+      r.w    = d.w;
+      r.h    = d.h;
+    });
+
+    // ── Pack regions: greedy left-to-right, wrap to next row when overflow ──
+    let cursorX = 0, cursorY = 0, rowMaxH = 0, totalH = 0, totalW = 0;
+    regions.forEach(r => {
+      if (cursorX + r.w > CANVAS_W && cursorX > 0) {
+        // Wrap to next row.
+        cursorX = 0;
+        cursorY += rowMaxH + REGION_GAP;
+        rowMaxH = 0;
+      }
+      r.x = cursorX;
+      r.y = cursorY;
+      cursorX += r.w + REGION_GAP;
+      if (r.h > rowMaxH) rowMaxH = r.h;
+      if (cursorY + r.h > totalH) totalH = cursorY + r.h;
+      if (r.x + r.w > totalW) totalW = r.x + r.w;
+    });
+    // Canvas dimensions (a bit of padding on the right + bottom).
+    const CANVAS_H = totalH + REGION_GAP;
+    const CANVAS_W_FINAL = Math.max(totalW + REGION_GAP, CANVAS_W);
+
+    // ── Render each region as an SVG group ──
+    const regionGroups = regions.map(r => {
+      const accent = (AREA_VISUALS[r.areaId] && AREA_VISUALS[r.areaId].accent) || 'dark';
+      const tint = HEX_ACCENT_FILL[accent] || HEX_ACCENT_FILL.dark;
+
+      const hexes = r.items.map((it, i) => {
+        const col = i % r.cols;
+        const row = Math.floor(i / r.cols);
+        // Local cx/cy within the region (region has its own coordinate origin).
+        const cx = HEX_PAD + S + col * STEP_X;
+        const cy = HEX_PAD + LABEL_H + (STEP_Y / 2) + row * STEP_Y + (col % 2 ? OFFSET_Y : 0);
+        const itemAccent = (AREA_VISUALS[it.areaId] && AREA_VISUALS[it.areaId].accent) || 'dark';
+        const fill = HEX_ACCENT_FILL[itemAccent] || HEX_ACCENT_FILL.dark;
+        const opacity = hexLuminosityFor(it, frontierSet);
+        const isActive = workingSet.has(it.id);
+        const classes = ['hex-cell'];
+        if (it.priority === 'P0') classes.push('p0');
+        if (isActive) {
+          classes.push('active');
+          // Ambient breath only on the active leg's working set.
+          classes.push('breathing');
+        }
+        const points = hexPolygonPoints(cx, cy, S);
+        const numShort = (it.id || '').replace(/^LAB-/, '');
+        return `<g>
+          <polygon class="${classes.join(' ')}" data-item="${escapeHTML(it.id)}" points="${points}" fill="${fill}" fill-opacity="${opacity}">
+            <title>${escapeHTML(it.id)} · ${escapeHTML(it.title)} · ${escapeHTML(it.priority)} · ${escapeHTML(it.status)} · ${escapeHTML(it.areaName)}${isActive ? ' · in active leg' : ''}${frontierSet.has(it.id) ? ' · in frontier' : ''}</title>
+          </polygon>
+          <text class="hex-label" x="${cx.toFixed(2)}" y="${cy.toFixed(2)}">${escapeHTML(numShort)}</text>
+        </g>`;
+      }).join('\n');
+
+      // Region background + label (region-local coordinates 0..r.w, 0..r.h).
+      const bg = `<rect class="hex-region-bg" x="0" y="0" width="${r.w}" height="${r.h}" fill="${tint}" stroke="${tint}" />`;
+      const labelY = HEX_PAD - 2;
+      const label = `<text class="hex-region-label" x="${HEX_PAD}" y="${labelY}">${escapeHTML(r.areaName)}</text>` +
+                    `<text class="hex-region-count" x="${(r.w - HEX_PAD).toFixed(2)}" y="${labelY}" text-anchor="end">${r.items.length}</text>`;
+
+      return `<g transform="translate(${r.x.toFixed(2)},${r.y.toFixed(2)})">
+        ${bg}
+        ${label}
+        ${hexes}
       </g>`;
-    });
+    }).join('\n');
 
-    const lastRow = Math.floor((sorted.length - 1) / COLS);
-    const width  = PAD * 2 + (COLS - 1) * STEP_X + S;
-    const height = PAD * 2 + lastRow * STEP_Y + OFFSET_Y;
-
+    const inFrontierCount = items.filter(it => frontierSet.has(it.id)).length;
+    const activeCount = workingSet.size;
     wrap.innerHTML = `
-      <p class="course-hexmap-title">Map · ${sorted.length} items · ${frontierSet.size} in this Course's frontier</p>
-      <p class="course-hexmap-sub">Read-only v0.1. Fill = area accent. Opacity = status (archived dim → in-progress bright). Red glow = P0. Teal glow = in this Course's frontier. Hover for details.</p>
-      <svg viewBox="0 0 ${width.toFixed(2)} ${height.toFixed(2)}" preserveAspectRatio="xMidYMid meet" role="img" aria-label="Lab map: ${sorted.length} items as hexes, with ${frontierSet.size} highlighted as the active Course's frontier">
-        ${cells.join('\n')}
+      <p class="course-hexmap-title">Map · ${items.length} items · ${inFrontierCount} in frontier · ${activeCount} active in current leg</p>
+      <p class="course-hexmap-sub">v0.2: regions = areas (biomes). Brightness = relevance (archived dim → in-frontier bright → active brightest). P0 ring = red. The current leg's working items breathe slowly. Hover for details.</p>
+      <svg viewBox="0 0 ${CANVAS_W_FINAL.toFixed(2)} ${CANVAS_H.toFixed(2)}" preserveAspectRatio="xMidYMid meet" role="img" aria-label="Lab map: ${items.length} items grouped by area (biome). ${inFrontierCount} in this Course's frontier. ${activeCount} in the active leg's working set.">
+        ${regionGroups}
       </svg>
       <div class="course-hexmap-legend">
-        <span class="lg-item"><span class="lg-swatch" style="background:#4a7bd4"></span>Frame</span>
-        <span class="lg-item"><span class="lg-swatch" style="background:#d4a030"></span>Pilot Check</span>
-        <span class="lg-item"><span class="lg-swatch" style="background:#a88a5a"></span>Library / Warm</span>
-        <span class="lg-item"><span class="lg-swatch" style="background:#2d8a7e"></span>Teal areas</span>
-        <span class="lg-item"><span class="lg-swatch" style="background:#555"></span>Director's Desk / Dark</span>
+        <span class="lg-item"><span class="lg-swatch dim"></span>archived (terrain)</span>
+        <span class="lg-item"><span class="lg-swatch avail"></span>available</span>
+        <span class="lg-item"><span class="lg-swatch front"></span>in frontier</span>
+        <span class="lg-item"><span class="lg-swatch act"></span>active in current leg (breathes)</span>
         <span class="lg-item"><span class="lg-ring" style="border-color:#c25450"></span>P0</span>
-        <span class="lg-item"><span class="lg-ring" style="border-color:#5cb09a"></span>In frontier</span>
       </div>
     `;
+
+    // Phase 1 motion: single-pulse-on-select. Wired here so the listener
+    // is fresh after each render (innerHTML wipes prior listeners).
+    const svg = wrap.querySelector('svg');
+    if (svg) {
+      svg.addEventListener('click', (e) => {
+        const tgt = e.target;
+        if (!tgt || !tgt.classList || !tgt.classList.contains('hex-cell')) return;
+        // Re-trigger the keyframe by removing + re-adding the class.
+        tgt.classList.remove('pulse-once');
+        // Force reflow so the animation restarts when the class is re-added.
+        void tgt.getBoundingClientRect();
+        tgt.classList.add('pulse-once');
+      });
+      // Clean up the class once the animation finishes so a future click
+      // can fire it again (and so it doesn't stick on the DOM).
+      svg.addEventListener('animationend', (e) => {
+        if (e.target && e.target.classList && e.target.classList.contains('pulse-once')) {
+          e.target.classList.remove('pulse-once');
+        }
+      });
+    }
   }
 
   /* Format helper used by both the Comprehend section and the Leg view's

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -4635,13 +4635,15 @@
     'frame-cards':   '/api/save/frame-cards',
     'debrief-cards': '/api/save/debrief-cards',
     'pilot-checks':  '/api/save/pilot-checks',
-    'courses':       '/api/save/courses'
+    'courses':       '/api/save/courses',
+    'legs':          '/api/save/legs'
   };
   const SERVER_LOAD_PATHS = {
     'frame-cards':   '/exports/frame-cards.json',
     'debrief-cards': '/exports/debrief-cards.json',
     'pilot-checks':  '/exports/pilot-checks.json',
-    'courses':       '/exports/courses.json'
+    'courses':       '/exports/courses.json',
+    'legs':          '/exports/legs.json'
   };
   function postSave(type, arr) {
     const url = SERVER_SAVE_PATHS[type];
@@ -4670,7 +4672,8 @@
       ['frame-cards',   FRAME_KEY],
       ['debrief-cards', DEBRIEF_KEY],
       ['pilot-checks',  PC_KEY],
-      ['courses',       COURSE_KEY]
+      ['courses',       COURSE_KEY],
+      ['legs',          LEG_KEY]
     ];
     await Promise.all(pairs.map(async ([type, key]) => {
       const data = await loadFromServer(type);
@@ -4744,6 +4747,100 @@
     else arr.push(course);
     saveCourses(arr);
     return course;
+  }
+
+  /* ── Leg wrapper (one Full Turn — Frame · Comprehend · Sync · Produce · Debrief) ──
+     A Leg is one slot inside a Course. Sub-records:
+       frame_card_id       → ID of the Frame card (in frame-cards.json) once framed
+       comprehend[]        → 0..n on-demand notes: {at, text}
+       sync                → 0..1 sync state (deferred to a later phase)
+       produce             → running ledger: {selected[], bonuses[], notes[]}
+       debrief_card_id     → ID of Debrief card once debriefed
+       changes_to_course   → 0..1 delta written back to the Course frontier on debrief
+     ID convention: LEG-YYYY-MM-DD-A (date + letter for multi-leg days).
+     The leg references the Course it belongs to via course_ref. */
+  const LEG_KEY = 'cognitive-lab-v0.1::legs';
+
+  function todayDateOnly(date) {
+    const d = date ? new Date(date.getTime()) : new Date();
+    return d.toISOString().slice(0, 10);
+  }
+  function nextLegLetter(courseId, dateStr) {
+    // Returns 'A'/'B'/'C'/... for the next leg created on the given day in the given course.
+    const existing = loadLegs().filter(l =>
+      l && l.course_ref === courseId && l.date === dateStr
+    );
+    const letters = existing.map(l => (l.id || '').slice(-1));
+    let code = 'A'.charCodeAt(0);
+    while (letters.includes(String.fromCharCode(code))) code++;
+    return String.fromCharCode(code);
+  }
+  function legId(courseId, dateStr, letter) {
+    return 'LEG-' + dateStr + '-' + letter;
+  }
+
+  function loadLegs() {
+    try { return JSON.parse(localStorage.getItem(LEG_KEY) || '[]'); }
+    catch { return []; }
+  }
+  function saveLegs(arr) {
+    try { localStorage.setItem(LEG_KEY, JSON.stringify(arr)); } catch {}
+    postSave('legs', arr);
+  }
+
+  function findLegById(id) {
+    return loadLegs().find(l => l && l.id === id) || null;
+  }
+  function findActiveLeg() {
+    // Active = the most-recently-touched leg in the active course that's not
+    // archived/debriefed. Falls back to the most recent leg overall.
+    const courseId = isoWeekId();
+    const all = loadLegs().filter(l => l && l.course_ref === courseId);
+    if (all.length === 0) return null;
+    const open = all.filter(l => l.status !== 'debriefed' && l.status !== 'archived');
+    const pool = open.length > 0 ? open : all;
+    pool.sort((a, b) => (b.updatedAt || '').localeCompare(a.updatedAt || ''));
+    return pool[0];
+  }
+  function findLegsForCourse(courseId) {
+    return loadLegs()
+      .filter(l => l && l.course_ref === courseId)
+      .sort((a, b) => (a.createdAt || '').localeCompare(b.createdAt || ''));
+  }
+
+  function newLegDraft(opts) {
+    const o = opts || {};
+    const dateStr = o.date || todayDateOnly();
+    const courseId = o.course_ref || isoWeekId();
+    // Compute next leg_number from existing legs in the same course.
+    const inCourse = findLegsForCourse(courseId);
+    const legNumber = Math.min(inCourse.length + 1, COURSE_LEG_COUNT);
+    const letter = o.letter || nextLegLetter(courseId, dateStr);
+    const now = new Date().toISOString();
+    return {
+      id: legId(courseId, dateStr, letter),
+      course_ref: courseId,
+      leg_number: legNumber,            // 1..COURSE_LEG_COUNT
+      status: 'planning',               // planning · in-progress · debriefed · archived
+      date: dateStr,
+      frame_card_id: null,
+      comprehend: [],                   // [{at: ISO, text: string}]
+      sync: null,                       // {at, ...} once captured
+      produce: { selected: [], bonuses: [], notes: [] },
+      debrief_card_id: null,
+      changes_to_course: null,          // {at, frontier_added: [...], frontier_removed: [...], notes}
+      createdAt: now,
+      updatedAt: now
+    };
+  }
+  function upsertLeg(leg) {
+    const arr = loadLegs();
+    const idx = arr.findIndex(l => l && l.id === leg.id);
+    leg.updatedAt = new Date().toISOString();
+    if (idx >= 0) arr[idx] = leg;
+    else arr.push(leg);
+    saveLegs(arr);
+    return leg;
   }
 
   /* ── Frame Workshop: storage helpers ── */

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -1911,14 +1911,18 @@
     margin-top: 4px;
     align-items: center;
   }
-  .frame-form-actions .ff-saved {
+  .frame-form-actions .ff-saved,
+  .course-actions .ff-saved,
+  .course-comprehend-actions .ff-saved {
     font-size: 11px;
     color: var(--success);
     opacity: 0;
     transition: opacity 0.2s;
     margin-left: 6px;
   }
-  .frame-form-actions .ff-saved.show { opacity: 1; }
+  .frame-form-actions .ff-saved.show,
+  .course-actions .ff-saved.show,
+  .course-comprehend-actions .ff-saved.show { opacity: 1; }
   .frame-form-actions .ff-btn {
     font-family: var(--font-px);
     font-size: 10px;

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -5529,19 +5529,19 @@
       "id": "LAB-043",
       "title": "Hex Map adjacency v0.2 — semantic clusters within biomes",
       "status": "backlog",
-      "priority": "P3",
+      "priority": "P2",
       "area": "director-desk",
       "brief": "Phase 1 packs hexes per area in a 3-col grid within biomes. Open question: should items near related items within a biome cluster? Deferred until lived use shows it matters.",
-      "full": "Hex Map v0.2 (Phase 1) groups hexes into biome regions with a simple 3-column packing. Per Quenton's design dialog (turn 3), semantic adjacency within a biome — e.g., chapter chunks near their source documents, Frame near Pilot Check in the capacity cluster — was explicitly deferred. Rationale: the biome regions already provide 80% of the spatial grammar; adding within-biome adjacency logic before seeing how the map is actually used risks premature optimization. Revisit after one Course of dogfood. If the author navigates the map by looking for known relationships, semantic adjacency is worth the complexity. If they navigate by biome + label, it isn't. P3."
+      "full": "Hex Map v0.2 (Phase 1) groups hexes into biome regions with a simple 3-column packing. Per Quenton's design dialog (turn 3), semantic adjacency within a biome — e.g., chapter chunks near their source documents, Frame near Pilot Check in the capacity cluster — was explicitly deferred. Rationale: the biome regions already provide 80% of the spatial grammar; adding within-biome adjacency logic before seeing how the map is actually used risks premature optimization. Revisit after one Course of dogfood. If the author navigates the map by looking for known relationships, semantic adjacency is worth the complexity. If they navigate by biome + label, it isn't. P2 (later)."
     },
     "LAB-044": {
       "id": "LAB-044",
       "title": "Comprehend Signals expansion (Frame field activity)",
       "status": "backlog",
-      "priority": "P3",
+      "priority": "P2",
       "area": "comprehend-station",
       "brief": "Phase 1.5 explicitly deferred auto-logging Frame card field activity (Doing/Not Doing/Approach). Wait one Course of dogfood; if the Comprehend zone stays sparse, expand.",
-      "full": "Phase 1.5 drew the Comprehend surveillance line at intentional acts the user would expect to leave a record: notes (manual), synthesis (status cycle), deck-opens. Frame card field activity — typing in Doing, Not Doing, or Approach — was explicitly excluded. Rationale: field edits are exploratory; the user may type and delete without committing. Logging field edits would capture intent-noise rather than intent-signal. However, if one Course of lived use shows the Comprehend zone staying sparse (few captures, thin record), expansion to field activity may be warranted. The question to answer at that point: what's the right commit event? (Save button? Field blur? Word count threshold?) Deferred to Quenton and the author after dogfood. P3."
+      "full": "Phase 1.5 drew the Comprehend surveillance line at intentional acts the user would expect to leave a record: notes (manual), synthesis (status cycle), deck-opens. Frame card field activity — typing in Doing, Not Doing, or Approach — was explicitly excluded. Rationale: field edits are exploratory; the user may type and delete without committing. Logging field edits would capture intent-noise rather than intent-signal. However, if one Course of lived use shows the Comprehend zone staying sparse (few captures, thin record), expansion to field activity may be warranted. The question to answer at that point: what's the right commit event? (Save button? Field blur? Word count threshold?) Deferred to Quenton and the author after dogfood. P2 (later)."
     },
     "LAB-045": {
       "id": "LAB-045",
@@ -5556,7 +5556,7 @@
       "id": "LAB-046",
       "title": "Comprehend sufficient threshold (Course Coach territory)",
       "status": "backlog",
-      "priority": "P3",
+      "priority": "P2",
       "area": "comprehend-station",
       "brief": "Phase 1.5 deferred: at what density/count does Comprehend register as sufficient? Don't pre-design — that's the Course Coach's job (LAB-034). Captured so it's not forgotten.",
       "full": "Phase 1.5 deliberately deferred the question of sufficiency: when has a leg's Comprehend phase loaded enough context to proceed to Produce? This is not a question Larry or the lab UI should answer alone — it's Course Coach territory (LAB-034). The Course Coach reads leg histories and can detect patterns like 'legs where Comprehend had < 2 entries correlated with mid-leg re-immersion interruptions.' Pre-designing a sufficiency threshold now would be premature — it would encode a guess before the data exists to inform it. Capture the question here so it's not forgotten when LAB-034 becomes active. P3."
@@ -8887,7 +8887,10 @@
           const color = HEX_ACCENT_FILL[accent] || HEX_ACCENT_FILL.dark;
           const itemsHTML = g.items.map(it => {
             const idShort = (it.id || '').replace(/^LAB-/, '');
-            const pri = it.priority || 'P2';
+            // Allowlist priority before injecting into class/text. Schema
+            // is P0/P1/P2; anything else falls back to P2 so the class
+            // attribute can't be poisoned by a hand-edited JSON value.
+            const pri = ['P0','P1','P2'].includes(it.priority) ? it.priority : 'P2';
             return `<button type="button" class="bc-drawer-item" data-item="${escapeHTML(it.id)}" title="${escapeHTML(it.areaName || '')}: ${escapeHTML(it.title || '')}">
               <span class="bc-drawer-item-id">${escapeHTML(idShort)}</span>
               <span class="bc-drawer-item-title">${escapeHTML(it.title || '(no title)')}</span>

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -5302,11 +5302,23 @@
       "accent": "amber",
       "workshop": true,
       "description": "Where the lab orients you. Re-immerse on prior legs, walk decks, take guided product walks of new features. The phase that loads remaining state from agents and prior work — first step in the cycle (C-before-F).",
-      "items": ["LAB-009","LAB-010","LAB-044","LAB-046"],
+      "items": ["LAB-009","LAB-010","LAB-044","LAB-046","LAB-052","LAB-053","LAB-054","LAB-055","LAB-056","LAB-057"],
       "artifacts": [
         { "label": "turn-v0.1-phases-and-leverage.md (Comprehend section)", "href": "turn-v0.1-phases-and-leverage.md" }
       ],
       "chunks": [
+        {
+          "id": "chunk-walk-studio-meta-loop",
+          "title": "Walk Studio meta-loop — the lab teaches itself",
+          "summary": "Claude authors product walks for shipped features into the WALKS const; the author opens them in Comprehend Station; walks log to leg.comprehend[] as kind:'walk' with start/completion. Replaces chat-instructed test loops.",
+          "body": "The realization driving Move 2: when Claude ships a feature and asks for a test, instructions live in chat ('open this URL, click here...'). That's friction. The fix: those instructions live inside the lab as structured walks. The lab teaches itself.\n\nThe full meta-loop:\n1. Claude ships a feature.\n2. Claude authors a product walk into the WALKS const (or later, walks.json).\n3. The author opens Comprehend Station.\n4. The author selects the walk in the Walk Studio sidebar.\n5. The walk renders in an iframe of the live lab; Next/Back steps guide through it.\n6. Walk start and completion log to `leg.comprehend[]` as `kind:'walk'`.\n\n**The iframe pattern:** Walk Studio loads the lab in `?walk=1` mode. Lab init reads the flag, applies `body.walk-mode`, hides Comprehend Station from the floor (opacity 0.3 + pointer-events none + aria-hidden), and suppresses localStorage writes for view+lens so iframe nav doesn't bleed to parent. This prevents a nested Walk Studio inside the iframe (recursion defense).\n\n**Walk schema (v0.1):** `{ id, title, kind: 'deck' | 'product', steps: [{ heading, body, target_route? }] }`. The `target_route` field overrides the iframe's view+lens via URL query — letting a walk step navigate to a specific lens without the author clicking there manually.\n\n**First authored walk:** 'Walk: Build canvas v0.1' — 8 steps, replaces the chat-instructed test of the v0.4 build canvas. Step 0 is a mutation warning for state-mutating walks. Passive Next/Back — no auto-advance on click (v0.2 candidate, LAB-052).\n\n**Logging:** `comprehendEntryParts` extended for `kind:'walk'`; cc-kind-walk chip color is reddish-purple. Leg view zone subtitle counts walks alongside notes, synthesis, and deck entries.\n\nThis is the first durable loop where lab development is self-documented inside the lab itself, not in chat."
+        },
+        {
+          "id": "chunk-comprehend-station-v0.1",
+          "title": "Comprehend Station v0.1 — orientation room ships as a workshop",
+          "summary": "Comprehend Station promoted to workshop:true. 'Where you are' orientation snapshot (4 items, collapsible) + Walk Studio (deck and product walks in sidebar + iframe). Comprehend leads the floor — C-before-F per v0.4 design dialog.",
+          "body": "Move 2 of the v0.4 arc ships Comprehend Station as the lab's orientation center.\n\n**What it is:** a 'Where am I?' snapshot + a Walk Studio. Comprehend = orientation. Before you can pick what to do this turn (Frame), you need to know what just happened.\n\n**Orientation snapshot (2b):** Four items displayed at top of the workshop drawer:\n1. Active leg + Course (or fallback if no active leg)\n2. Last 3 acts from the leg's comprehend[] log\n3. Time since last touch\n4. Last debrief if present\n\nCollapsible via sessionStorage preference. Drilldown: click a recent entry to expand the body inline.\n\n**Walk Studio (2c):** Sidebar + main split. Sidebar lists available walks; main pane shows the selected walk's steps or an iframe of the lab. Two kinds:\n- `deck` — a presentation HTML file loaded in the iframe (e.g., turn-v0.1-map or comprehension-deck-v0.1).\n- `product` — a structured walk with steps rendered beside an iframe of the live lab (see chunk-walk-studio-meta-loop).\n\nHover preview tooltip on each sidebar item.\n\n**C-before-F reorder (2a):** Comprehend Station moves to Band 2 position 1, ahead of Frame Workshop. Band 2 = Comprehend → Frame per the v0.4 design dialog. The principle: orientation precedes scoping. You can't pick what to do this turn until you've spun back up on what just happened. Drawer dispatch updated.\n\n**LAB-009 status note:** Comprehend Station now ships as a workshop with orientation and Walk Studio. The form itself (re-immersion flow, agent-context picker, 'context loaded' gate before Produce) isn't yet built — that's the chapter material. Status: drafted (form ships; chapter material doesn't)."
+        },
         {
           "id": "chunk-comprehend-signals",
           "title": "Comprehend Signals — what the station captures and why",
@@ -5485,6 +5497,18 @@
         }
       ],
       "chunks": [
+        {
+          "id": "chunk-walk-mode-iframe-recursion-defense",
+          "title": "Walk-mode iframe pattern + localStorage isolation",
+          "summary": "Walk Studio loads the lab inside an iframe with ?walk=1. Lab init reads the flag, hides Comprehend Station from the floor, suppresses localStorage writes for view+lens, and prevents nested Walk Studios.",
+          "body": "Walk Studio loads the live lab inside an iframe so product walks can demonstrate the actual UI. The iframe URL gets `?walk=1` appended. This triggers a chain of initialization behavior:\n\n**body.walk-mode class:** applied on `?walk=1`, used as a CSS scoping hook for all walk-mode overrides.\n\n**Comprehend Station hidden in iframe:** The floor tile for Comprehend Station gets `opacity: 0.3`, `pointer-events: none`, and `aria-hidden: true` inside walk mode. Reason: if the user opened a Walk Studio walk inside an iframe that still showed Comprehend Station, they could open Walk Studio again — creating a nested Walk Studio inside an iframe inside the Walk Studio. Recursion defense.\n\n**localStorage suppression:** In walk mode, localStorage writes for `view` and `lens` state are suppressed. The iframe can navigate to different views and lenses (via `target_route` on each step) without bleeding those state changes back to the parent lab's own view/lens. The parent and iframe maintain independent navigation state.\n\n**Drawer dispatch updated:** The floor's drawer dispatch was updated in Move 2a to emit Comprehend Station as the first tile in Band 2 (C-before-F). The walk-mode hiding ensures this doesn't create a recursion vector when Comprehend Station is the walk host.\n\n**Pattern reuse:** Any future feature that embeds the lab in an iframe (e.g., a preview pane, a sandbox mode) should follow the same `?walk=1` flag + localStorage-suppression pattern. It's now a documented convention, not an ad-hoc hack."
+        },
+        {
+          "id": "chunk-c-before-f-floor-reorder",
+          "title": "C-before-F floor reorder — Comprehend leads the phase cycle",
+          "summary": "Comprehend Station moves to Band 2 position 1, ahead of Frame Workshop, per the v0.4 design dialog. Orientation precedes scoping — you can't pick what to do this turn until you've loaded what just happened.",
+          "body": "The v0.4 design dialog (Quenton) established the principle: the leg cycle should be C→F·S·P·D, not F·C·S·P·D. Comprehend leads because orientation precedes scoping.\n\nThe reasoning: Frame asks the author to pick what to do this turn — scope, frontier item, approach. But that decision requires knowing what just happened (last leg's state, what agents shipped, what's changed on the frontier). The author can't pick optimally before they've loaded context. Comprehend-first makes the pickup cost visible and honored rather than skipped.\n\nThe design call: the floor reorders Band 2 to Comprehend → Frame. This is a layout change, not a hard gate. The boot-strip gate (a hard Comprehend checkpoint that must clear before Frame loads) was considered and explicitly rejected for v0.1 — the principle is active; the enforcement mechanism is deferred to LAB-048.\n\nThe practical impact: when the author lands on the lab, Comprehend Station is the first workshop-accented tile they see. The spatial order reinforces the phase order. Walk Studio's first authored walk begins at the Comprehend Station, making the C-before-F principle a lived experience before the author has read the spec.\n\nCross-ref: LAB-048 (Comprehend boot gate, P2 — the mechanism when the principle wants enforcement)."
+        },
         {
           "id": "chunk-build-canvas-v0.1",
           "title": "Build canvas v0.1 — snap-circuit grid, tool drawer, click-to-place, template apply",
@@ -5743,7 +5767,8 @@
         "LAB-030","LAB-031","LAB-032","LAB-033",
         "LAB-034","LAB-035","LAB-036","LAB-037","LAB-038","LAB-039","LAB-040","LAB-041",
         "LAB-042","LAB-043","LAB-044","LAB-045","LAB-046",
-        "LAB-047","LAB-048","LAB-049","LAB-050","LAB-051"
+        "LAB-047","LAB-048","LAB-049","LAB-050","LAB-051",
+        "LAB-052","LAB-053","LAB-054","LAB-055","LAB-056","LAB-057"
       ],
       "artifacts": [],
       "notes": []
@@ -6230,6 +6255,60 @@
       "area": "director-desk",
       "brief": "Author's long-vision: each phase-box eventually lives in 'map world.' Central traversable space; phase-cycler moves through which phase the user is in. Library/research/tools become buildings.",
       "full": "Author's long-vision for the lab (captured 2026-05-04, not a near-term build item):\n\nEach phase-box (Frame, Comprehend, Sync, Produce, Debrief — outside Recover) eventually lives in 'map world' — a central traversable space. A phase-cycler at the bottom of the screen moves through which phase the user is currently in relative to the map. Moving through phases is literally moving through the map.\n\nLibrary and research tools become buildings in the map world. Resources are rooms you enter, not tabs you click.\n\nThis is a long-vision capture, not a near-term spec. The design questions (what does 'traversable space' mean at a technical level? how does it compose with the existing Hex Map lenses?) are for Quenton when the time comes.\n\nNot v0.4. Not v0.5. Capture for the road map. P3."
+    },
+    "LAB-052": {
+      "id": "LAB-052",
+      "title": "Walk Studio: interactive walks (auto-advance on correct click)",
+      "status": "backlog",
+      "priority": "P2",
+      "area": "comprehend-station",
+      "brief": "v0.1 ships passive Next/Back. v0.2: target_selector field on each step; iframe listens for click on the target; advances when matched.",
+      "full": "v0.1 Walk Studio ships with passive Next/Back navigation. The author reads the step description, takes the action manually, then clicks Next.\n\nv0.2: add a `target_selector` field to each walk step. The iframe listens for a click on that selector; when matched, it fires a postMessage to the parent Walk Studio, which auto-advances to the next step.\n\nNeeds per-walk DOM target plumbing. Brittle if selectors change as the lab UI evolves — selector references will need updating when the HTML changes. This is the primary maintenance cost.\n\nOnly worthwhile for walks where the correct-click signal is unambiguous (e.g., 'click the Build tab' — one correct target). Steps with multiple valid actions remain passive.\n\nP2. Passive Next/Back is acceptable; interactive is better for longer walks."
+    },
+    "LAB-053": {
+      "id": "LAB-053",
+      "title": "Walk Studio: persistent walk progress",
+      "status": "backlog",
+      "priority": "P2",
+      "area": "comprehend-station",
+      "brief": "v0.1 progress is sessionStorage (refresh = restart). v0.2: persist progress on the leg or per-walk in localStorage so a long walk can be resumed across browser restarts.",
+      "full": "v0.1 stores walk progress (current step index) in sessionStorage. Refreshing the browser or closing the tab resets to step 0.\n\nv0.2: persist progress either on the active leg's comprehend record (`leg.comprehend[].step_index`) or per-walk in localStorage (`walk-progress/{walk-id}`). Either approach lets the author resume a long walk across browser restarts without losing their place.\n\nOnly matters if walks grow past ~10 steps — shorter walks can be restarted without real cost. Ship v0.1, let lived use surface whether resume is needed before building.\n\nP2 — acceptable to defer until walks are long enough that restart is a real annoyance."
+    },
+    "LAB-054": {
+      "id": "LAB-054",
+      "title": "Walk Studio: JSON-loaded WALKS (vs hardcoded const)",
+      "status": "backlog",
+      "priority": "P3",
+      "area": "comprehend-station",
+      "brief": "v0.1 keeps WALKS as a const in lab HTML. Move to cognitive-lab/exports/walks.json with lab-server.py persistence pattern (or static JSON fetch) when 5+ walks exist.",
+      "full": "v0.1 stores the WALKS array as a hardcoded const inside the lab HTML. This is acceptable at 1–3 walks — Claude edits the HTML directly when authoring a new walk.\n\nAt 5+ walks, the const becomes unwieldy and the round-trip cost of editing HTML grows. At that point, move WALKS to a standalone JSON file: `cognitive-lab/exports/walks.json`. The lab fetches it on load (or on Walk Studio open) via `fetch('./exports/walks.json')`.\n\nCan follow the same persistence pattern as lab-server.py's other exports — or start as a static file that Claude edits directly, promoting to server-managed later.\n\nP3. The const approach works fine until volume forces the move. Do not build this preemptively."
+    },
+    "LAB-055": {
+      "id": "LAB-055",
+      "title": "Walk Studio: in-lab walk authoring UI",
+      "status": "backlog",
+      "priority": "P3",
+      "area": "comprehend-station",
+      "brief": "v0.1 has Claude editing the WALKS const in HTML. v0.2 (later): an in-lab form to add/edit/delete walks. Whole feature, warrants its own design pass.",
+      "full": "v0.1: walk authoring means Claude edits the WALKS const (or walks.json once LAB-054 lands) directly in the file. This is the right choice at low walk volume — it's transparent and doesn't need a UI.\n\nv0.2 (later): an in-lab form inside Walk Studio for creating and editing walks. Fields: id, title, kind (deck/product), and a step editor (heading, body, target_route per step).\n\nThis is a whole feature — UI design, data persistence, validation — warrants its own design pass with Quenton before building. Don't sketch it until Claude-authored walks become genuinely limiting.\n\nP3. The Claude-authoring pattern works; build the UI only when it's clearly blocking the author from creating walks without technical help."
+    },
+    "LAB-056": {
+      "id": "LAB-056",
+      "title": "Walk Studio: sandbox-Course mode for state-mutating walks",
+      "status": "backlog",
+      "priority": "P3",
+      "area": "comprehend-station",
+      "brief": "v0.1 warns on step 0 of state-mutating walks. v0.2 could create a temporary throwaway Course on walk-start and discard on close.",
+      "full": "v0.1 handles state-mutating walks (walks that create Courses, start Legs, write Comprehend entries) with a step-0 mutation warning: 'This walk will write to your lab state. Open a fresh Course first if you want a sandbox.'\n\nv0.2 option: Walk Studio creates a temporary Course (id: 'WALK-SANDBOX') on walk-start and discards it on walk-close. The walk plays out against throwaway state that doesn't affect the author's real Course history.\n\nThe warning-only approach is acceptable for v0.1 and possibly indefinitely — experienced authors can manage their own state. The sandbox only earns its keep if walks routinely mutate in ways the author regrets.\n\nP3. Warning-only is fine. Build the sandbox only if dogfood surfaces repeated state-mutation regret."
+    },
+    "LAB-057": {
+      "id": "LAB-057",
+      "title": "Walk Studio: multi-walk sequences",
+      "status": "backlog",
+      "priority": "P3",
+      "area": "comprehend-station",
+      "brief": "v0.2: walks that reference other walks (e.g., a 'build the v0.4 from scratch' sequence that chains multiple walks). Needs a walk-graph data model.",
+      "full": "v0.1 walks are standalone: each has its own steps, and completing one doesn't automatically start another.\n\nv0.2: a walk can reference a sequence of other walks — e.g., 'Build the v0.4 from scratch' = build-canvas-walk → course-planning-walk → frame-walk, played in order. The author completes each sub-walk, then the sequence auto-advances to the next.\n\nNeeds a walk-graph data model: each walk gets an optional `next_walk_id` field, or a top-level Sequence object that lists an ordered array of walk IDs.\n\nWarrants a design pass before building — the interaction shape (does the sequence show progress across sub-walks? does each sub-walk feel self-contained or stitched?) is not obvious.\n\nP3. Standalone walks are the right starting point. Build sequences when a multi-walk training arc is actually needed."
     }
   }
 }

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -632,6 +632,82 @@
     font-size: 11px;
     padding: 8px 6px;
   }
+  /* In-hand state (Move 3d): drawer item that's currently being held,
+     ready to snap into a cell. Highlighted with accent border + bg. */
+  .bc-drawer-item.bc-in-hand {
+    background: rgba(226,160,74,0.18);
+    border-color: var(--accent);
+    box-shadow: 0 0 0 1px var(--accent);
+  }
+  /* In-hand cursor on the canvas: empty cells get a subtle "drop me here"
+     pulse; the cursor itself becomes a crosshair. */
+  .bc-canvas.bc-in-hand .bc-cell:not(.bc-cell-occupied) { cursor: crosshair; }
+  .bc-canvas.bc-in-hand .bc-cell:not(.bc-cell-occupied) .bc-cell-bg {
+    fill: rgba(226,160,74,0.05);
+    stroke: rgba(226,160,74,0.30);
+  }
+  .bc-canvas.bc-in-hand .bc-cell:not(.bc-cell-occupied):hover .bc-cell-bg {
+    fill: rgba(226,160,74,0.20);
+    stroke: var(--accent);
+    stroke-width: 1.6;
+  }
+  /* Placed piece — small filled hex inside the cell. Color = area accent.
+     Shows the LAB-### number as a label so the user can read what's where
+     without hovering. */
+  .bc-placed-hex {
+    stroke: rgba(0,0,0,0.45);
+    stroke-width: 1;
+    cursor: pointer;
+    transition: filter 120ms ease;
+  }
+  .bc-cell:hover .bc-placed-hex { filter: brightness(1.15); }
+  .bc-placed-label {
+    font-family: var(--font-px);
+    font-size: 8px;
+    font-weight: bold;
+    fill: #fff;
+    text-anchor: middle;
+    dominant-baseline: middle;
+    pointer-events: none;
+    text-shadow: 0 1px 1px rgba(0,0,0,0.6);
+  }
+  /* Action chip — floats next to a clicked occupied cell. Two actions
+     today: Pick up (returns piece to hand for re-placement) and Remove
+     (returns piece to drawer). */
+  .bc-canvas-wrap { position: relative; }
+  .bc-action-chip {
+    position: absolute;
+    z-index: 20;
+    background: rgba(0,0,0,0.94);
+    border: 1px solid var(--panel-bd);
+    border-radius: 4px;
+    padding: 4px;
+    display: flex;
+    gap: 2px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.6);
+    font-family: var(--font-px);
+    font-size: 10px;
+  }
+  .bc-action-chip button {
+    background: transparent;
+    border: 1px solid transparent;
+    color: var(--fg);
+    padding: 4px 8px;
+    border-radius: 2px;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: inherit;
+    letter-spacing: 0.5px;
+  }
+  .bc-action-chip button:hover {
+    background: rgba(226,160,74,0.18);
+    border-color: var(--accent);
+  }
+  .bc-action-chip button.danger:hover {
+    background: rgba(194,84,80,0.22);
+    border-color: #c25450;
+    color: #ffb0a8;
+  }
   /* By-function lens (restored from v0.2): clustered biome regions. */
   .hex-region-bg {
     fill-opacity: 0.06;
@@ -5849,6 +5925,10 @@
       bail_conditions: '',
       legs: [],                // shape defined by Leg wrapper (step 1)
       status: 'planning',      // planning · in-progress · debriefed · archived
+      // Build canvas placements (Move 3d): { item_id → {row, col} }.
+      // Position the user has snapped each item to on the snap-circuit
+      // grid. Legacy courses without this field default to {} on read.
+      build_positions: {},
       createdAt: now,
       updatedAt: now
     };
@@ -8805,8 +8885,8 @@
 
   /* Build lens (Moves 3b → 3e).
      3b ships the empty snap-circuit grid (rows A–G × cols 1–10 = 70
-     cells). Cells are clickable but inert until the tool drawer (3c)
-     and click-to-place mechanic (3d) land. */
+     cells). 3c adds the tool drawer. 3d wires click-to-place +
+     persistence + the placed-piece render + action chip. */
   const BC_ROWS    = 7;
   const BC_COLS    = 10;
   const BC_CELL    = 52;       // pixel size of each grid cell
@@ -8816,7 +8896,42 @@
     // "A1", "B7", etc — snap-circuit board convention.
     return BC_ROW_LETTERS[row] + (col + 1);
   }
+  // Move 3d module-level state. Persisted state lives on course.build_positions.
+  let bcInHand = null;        // string item_id when an item is "in hand", else null
+  let bcActionItemId = null;  // item_id whose action chip is currently open
+
+  function getBuildPositions(course) {
+    return (course && course.build_positions) || {};
+  }
+  function findItemAtCell(positions, row, col) {
+    // Returns item_id at (row,col) or null. O(n) over placements; fine
+    // at our scale (≤ 70 placements max).
+    for (const id in positions) {
+      const p = positions[id];
+      if (p && p.row === row && p.col === col) return id;
+    }
+    return null;
+  }
+  function setBuildPosition(itemId, row, col) {
+    const c = getOrInitCourseDraft();
+    c.build_positions = c.build_positions || {};
+    c.build_positions[itemId] = { row, col };
+    upsertCourse(c);
+  }
+  function clearBuildPosition(itemId) {
+    const c = getOrInitCourseDraft();
+    if (c.build_positions && itemId in c.build_positions) {
+      delete c.build_positions[itemId];
+      upsertCourse(c);
+    }
+  }
   function renderCourseLensBuild(slot, items /*, frontierSet, workingSet */) {
+    const course = getOrInitCourseDraft();
+    const positions = getBuildPositions(course);
+    // Build a quick lookup table: items by id (used for placed-piece render).
+    const itemsById = new Map();
+    (items || []).forEach(it => itemsById.set(it.id, it));
+
     const w = BC_LABEL_PAD * 2 + BC_COLS * BC_CELL;
     const h = BC_LABEL_PAD + BC_ROWS * BC_CELL + 8;
 
@@ -8837,8 +8952,8 @@
     }
 
     // Grid cells, wrapped in role="row" groups so the ARIA grid pattern
-    // is complete (grid > row > gridcell). Without row wrappers, JAWS/NVDA
-    // can't construct the grid coordinate system for arrow-key navigation.
+    // is complete (grid > row > gridcell). Cells with placements render
+    // a small filled hex inside (color = area accent) + the LAB-### label.
     const cells = [];
     for (let r = 0; r < BC_ROWS; r++) {
       cells.push(`<g role="row" aria-label="Row ${BC_ROW_LETTERS[r]}">`);
@@ -8846,19 +8961,38 @@
         const x = BC_LABEL_PAD + c * BC_CELL;
         const y = BC_LABEL_PAD + r * BC_CELL;
         const cellId = bcCellId(r, c);
-        cells.push(`<g class="bc-cell" data-row="${r}" data-col="${c}" data-cell="${cellId}" role="gridcell" aria-label="cell ${cellId}, empty">
-          <rect class="bc-cell-bg" x="${x}" y="${y}" width="${BC_CELL}" height="${BC_CELL}" rx="3" ry="3"/>
-          <circle class="bc-cell-snap" cx="${x + BC_CELL / 2}" cy="${y + BC_CELL / 2}" r="3"/>
-        </g>`);
+        const occupiedId = findItemAtCell(positions, r, c);
+        const occupiedItem = occupiedId ? itemsById.get(occupiedId) : null;
+        const isOccupied = !!occupiedItem;
+        const cellClasses = ['bc-cell'];
+        if (isOccupied) cellClasses.push('bc-cell-occupied');
+        const ariaLabel = isOccupied
+          ? `cell ${cellId}: ${(occupiedItem.areaName || '')}: ${(occupiedItem.title || '')}`
+          : `cell ${cellId}, empty`;
+        let inner = `<rect class="bc-cell-bg" x="${x}" y="${y}" width="${BC_CELL}" height="${BC_CELL}" rx="3" ry="3"/>`;
+        if (!isOccupied) {
+          inner += `<circle class="bc-cell-snap" cx="${x + BC_CELL / 2}" cy="${y + BC_CELL / 2}" r="3"/>`;
+        } else {
+          // Render the placed piece inside the cell.
+          const accent = (AREA_VISUALS[occupiedItem.areaId] && AREA_VISUALS[occupiedItem.areaId].accent) || 'dark';
+          const fill = HEX_ACCENT_FILL[accent] || HEX_ACCENT_FILL.dark;
+          const cx = x + BC_CELL / 2;
+          const cy = y + BC_CELL / 2;
+          const hexSide = BC_CELL * 0.36;
+          const points = hexPolygonPoints(cx, cy, hexSide);
+          const numShort = (occupiedId || '').replace(/^LAB-/, '');
+          inner += `<polygon class="bc-placed-hex" data-item="${escapeHTML(occupiedId)}" points="${points}" fill="${fill}"/>`;
+          inner += `<text class="bc-placed-label" x="${cx.toFixed(2)}" y="${cy.toFixed(2)}">${escapeHTML(numShort)}</text>`;
+        }
+        cells.push(`<g class="${cellClasses.join(' ')}" data-row="${r}" data-col="${c}" data-cell="${cellId}" role="gridcell" aria-label="${escapeHTML(ariaLabel)}">${inner}</g>`);
       }
       cells.push(`</g>`);
     }
 
     // ── Drawer: items grouped by area (biome) ──
-    // Move 3c renders all items as not-yet-placed; Move 3d wires
-    // course.build_positions and filters the drawer by what's still
-    // un-placed.
-    const placedSet = new Set(); // populated by Move 3d
+    // Move 3d filters by course.build_positions — items already placed
+    // don't appear in the drawer.
+    const placedSet = new Set(Object.keys(positions));
     const drawerItems = (items || []).filter(it => !placedSet.has(it.id));
     const byArea = new Map();
     drawerItems.forEach(it => {
@@ -8907,11 +9041,15 @@
           </div>`;
         }).join('');
 
+    const placedCount = Object.keys(positions).length;
+    const inHandHint = bcInHand
+      ? `<strong>${escapeHTML((itemsById.get(bcInHand) && itemsById.get(bcInHand).title) || bcInHand)}</strong> in hand — click an empty cell to snap it. Click the same item in the drawer to drop it.`
+      : `Click an item in the drawer to take it in hand, then click a cell to place it. Click a placed piece for actions (pick up · remove).`;
     slot.innerHTML = `
-      <p class="course-hexmap-sub">Build · empty canvas + tool drawer. Click a cell or item to confirm interaction (real click-to-place lands in Move 3d).</p>
+      <p class="course-hexmap-sub">Build · ${placedCount} placed · ${drawerItems.length} in drawer. ${inHandHint}</p>
       <div class="bc-build-layout">
         <div class="bc-canvas-wrap">
-          <svg class="bc-canvas" viewBox="0 0 ${w} ${h}" preserveAspectRatio="xMidYMid meet" role="grid" aria-label="Build canvas: ${BC_ROWS}×${BC_COLS} grid, currently empty.">
+          <svg class="bc-canvas${bcInHand ? ' bc-in-hand' : ''}" viewBox="0 0 ${w} ${h}" preserveAspectRatio="xMidYMid meet" role="grid" aria-label="Build canvas: ${BC_ROWS}×${BC_COLS} grid, ${placedCount} placed.">
             ${colLabels.join('')}
             ${rowLabels.join('')}
             ${cells.join('')}
@@ -8919,47 +9057,145 @@
         </div>
         <div class="bc-drawer" aria-label="Item drawer">
           <p class="bc-drawer-title">Tool drawer · ${drawerItems.length} items</p>
-          <p class="bc-drawer-sub">Pieces grouped by area. Click an item to take it in hand (Move 3d wires placement).</p>
+          <p class="bc-drawer-sub">Pieces grouped by area. Click to take in hand; click again to drop. With one in hand, click a cell to snap it.</p>
           ${drawerInner}
         </div>
       </div>
-      <p class="bc-canvas-hint">Coming in 3d–3e: <strong>click-to-place</strong> · <strong>template apply</strong> (frontier as starting position).</p>
+      <p class="bc-canvas-hint">Coming in 3e: <strong>template apply</strong> (frontier as starting position).</p>
     `;
 
-    // Inert click handlers — acknowledge interactions until 3d wires the
-    // real placement mechanic.
+    // Re-apply in-hand visual on the drawer item (rendered after the
+    // drawerInner string was built, so we toggle the class imperatively).
+    if (bcInHand) {
+      const handBtn = slot.querySelector(`.bc-drawer-item[data-item="${bcInHand.replace(/"/g, '\\"')}"]`);
+      if (handBtn) handBtn.classList.add('bc-in-hand');
+    }
+
+    // ── Canvas click handler: place / show action chip ──
     const svg = slot.querySelector('svg.bc-canvas');
     if (svg) {
       svg.addEventListener('click', (e) => {
         const cell = e.target && e.target.closest ? e.target.closest('.bc-cell') : null;
         if (!cell) return;
-        const bg = cell.querySelector('.bc-cell-bg');
-        if (!bg) return;
-        bg.style.transition = 'none';
-        bg.style.fill   = 'rgba(226,160,74,0.22)';
-        bg.style.stroke = 'var(--accent)';
-        setTimeout(() => {
-          bg.style.transition = '';
-          bg.style.fill   = '';
-          bg.style.stroke = '';
-        }, 180);
+        const row = parseInt(cell.dataset.row, 10);
+        const col = parseInt(cell.dataset.col, 10);
+        const occupiedId = findItemAtCell(positions, row, col);
+        if (occupiedId) {
+          if (bcInHand && bcInHand !== occupiedId) {
+            // Swap: in-hand piece takes this cell; the displaced piece
+            // pops back to the drawer (no swap-place; a separate Move
+            // affordance can come in v0.5).
+            clearBuildPosition(occupiedId);
+            setBuildPosition(bcInHand, row, col);
+            bcInHand = null;
+            bcActionItemId = null;
+            renderCourseHexMap();
+            return;
+          }
+          // Open the action chip on this cell.
+          openBuildActionChip(slot, cell, occupiedId);
+          return;
+        }
+        // Empty cell.
+        if (!bcInHand) {
+          // Visual ping (no in-hand item; nothing to place).
+          const bg = cell.querySelector('.bc-cell-bg');
+          if (bg) {
+            bg.style.transition = 'none';
+            bg.style.fill   = 'rgba(226,160,74,0.22)';
+            bg.style.stroke = 'var(--accent)';
+            setTimeout(() => {
+              bg.style.transition = '';
+              bg.style.fill   = '';
+              bg.style.stroke = '';
+            }, 180);
+          }
+          return;
+        }
+        // Place the in-hand item.
+        setBuildPosition(bcInHand, row, col);
+        bcInHand = null;
+        bcActionItemId = null;
+        renderCourseHexMap();
       });
     }
+    // ── Drawer click handler: take / drop in hand ──
     const drawer = slot.querySelector('.bc-drawer');
     if (drawer) {
       drawer.addEventListener('click', (e) => {
         const btn = e.target && e.target.closest ? e.target.closest('.bc-drawer-item') : null;
         if (!btn) return;
-        // Visual ack: brief border pulse on the clicked item.
-        btn.style.transition = 'none';
-        btn.style.borderColor = 'var(--accent)';
-        btn.style.background  = 'rgba(226,160,74,0.18)';
-        setTimeout(() => {
-          btn.style.transition  = '';
-          btn.style.borderColor = '';
-          btn.style.background  = '';
-        }, 180);
+        const id = btn.dataset.item;
+        if (!id) return;
+        bcInHand = (bcInHand === id) ? null : id;
+        bcActionItemId = null;
+        renderCourseHexMap();
       });
+    }
+    // ── Outside-click closes the action chip ──
+    if (bcActionItemId) {
+      // Wait one tick so the chip-opening click doesn't immediately close it.
+      setTimeout(() => {
+        const closer = (e) => {
+          const chip = document.querySelector('.bc-action-chip');
+          if (chip && chip.contains(e.target)) return;
+          bcActionItemId = null;
+          document.removeEventListener('click', closer);
+          renderCourseHexMap();
+        };
+        document.addEventListener('click', closer);
+      }, 0);
+    }
+  }
+
+  /* Build canvas action chip — shown when a placed piece is clicked
+     (without an in-hand swap). Two actions today: Pick up (returns the
+     piece to hand, ready for re-placement) and Remove (returns the
+     piece to the drawer). Move (drag-relocation) is deferred to v0.5+
+     per Quenton; today's Pick-up + place achieves the same outcome in
+     two clicks. */
+  function openBuildActionChip(slot, cellEl, itemId) {
+    bcActionItemId = itemId;
+    // Position the chip relative to the canvas-wrap (which is
+    // position:relative). Use the cell's bounding rect, translated into
+    // wrap-local coords.
+    const wrap = slot.querySelector('.bc-canvas-wrap');
+    if (!wrap) return;
+    // Remove any pre-existing chip first.
+    const existing = wrap.querySelector('.bc-action-chip');
+    if (existing) existing.remove();
+    const cellRect = cellEl.getBoundingClientRect();
+    const wrapRect = wrap.getBoundingClientRect();
+    const left = cellRect.right - wrapRect.left + 4;
+    const top  = cellRect.top   - wrapRect.top;
+    const chip = document.createElement('div');
+    chip.className = 'bc-action-chip';
+    chip.style.left = left + 'px';
+    chip.style.top  = top  + 'px';
+    chip.innerHTML = `
+      <button data-act="pickup" type="button">⇪ Pick up</button>
+      <button data-act="remove" type="button" class="danger">↩ Remove</button>
+      <button data-act="cancel" type="button">×</button>
+    `;
+    chip.addEventListener('click', (e) => {
+      const btn = e.target && e.target.closest ? e.target.closest('button[data-act]') : null;
+      if (!btn) return;
+      const act = btn.dataset.act;
+      if (act === 'pickup') {
+        clearBuildPosition(itemId);
+        bcInHand = itemId;
+      } else if (act === 'remove') {
+        clearBuildPosition(itemId);
+        bcInHand = null;
+      } // 'cancel' just closes
+      bcActionItemId = null;
+      renderCourseHexMap();
+    });
+    wrap.appendChild(chip);
+    // Constrain chip horizontally if it would overflow the wrap.
+    const chipRect = chip.getBoundingClientRect();
+    if (chipRect.right > wrapRect.right - 4) {
+      chip.style.left = (cellRect.left - wrapRect.left - chipRect.width - 4) + 'px';
     }
   }
 

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -337,6 +337,69 @@
     color: var(--accent-dim);
   }
 
+  /* ── Course hex map (the Map / Course visualization, read-only v0.1) ──
+     Each LAB item is a flat-top hex. Fill = area accent. Opacity = status fog
+     (archived dim, in-progress bright). P0 ring = red glow. Frontier ring =
+     bright accent halo. Spatial layout groups by area; no semantic adjacency. */
+  .course-hexmap {
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-bd);
+    border-radius: 6px;
+    padding: 14px 16px;
+    max-width: 760px;
+  }
+  .course-hexmap-title {
+    font-family: var(--font-px);
+    font-size: 10px;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    color: var(--accent-dim);
+    margin: 0 0 8px;
+  }
+  .course-hexmap-sub {
+    font-family: var(--font-px);
+    font-size: 10px;
+    color: #6f7a90;
+    margin: 0 0 10px;
+  }
+  .course-hexmap svg {
+    width: 100%;
+    height: auto;
+    display: block;
+  }
+  .hex-cell { stroke: #2a2a35; stroke-width: 1; transition: opacity 120ms ease; }
+  .hex-cell:hover { stroke: var(--accent); stroke-width: 1.5; cursor: default; }
+  .hex-cell.p0 { stroke: #c25450; stroke-width: 2; filter: drop-shadow(0 0 3px rgba(194,84,80,0.55)); }
+  .hex-cell.in-frontier { stroke: #5cb09a; stroke-width: 2.5; filter: drop-shadow(0 0 4px rgba(92,176,154,0.6)); }
+  .hex-cell.in-frontier.p0 { stroke: #b890d4; filter: drop-shadow(0 0 5px rgba(184,144,212,0.7)); }
+  .hex-label {
+    font-family: var(--font-px);
+    font-size: 7px;
+    fill: #fff;
+    text-anchor: middle;
+    dominant-baseline: middle;
+    pointer-events: none;
+    opacity: 0.85;
+  }
+  .course-hexmap-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px 18px;
+    margin-top: 12px;
+    padding-top: 10px;
+    border-top: 1px solid var(--panel-bd);
+    font-family: var(--font-px);
+    font-size: 10px;
+    color: var(--accent-dim);
+  }
+  .course-hexmap-legend .lg-item { display: inline-flex; align-items: center; gap: 5px; }
+  .course-hexmap-legend .lg-swatch { width: 12px; height: 12px; border-radius: 2px; display: inline-block; }
+  .course-hexmap-legend .lg-ring {
+    width: 12px; height: 12px; border-radius: 50%; border: 2px solid;
+    display: inline-block;
+  }
+
   /* ── Lab tile (shared across alt views) ──
      Each tile pulls its area icon + accent color from the floor,
      so an item visually carries the room it lives in. */
@@ -3265,11 +3328,13 @@
 <!-- ── Course view ──
      A Course is a 7-leg arc (one ISO week). Frontier-not-itinerary: the Course
      names what's *reachable* this week; per-leg Frame picks from the frontier.
-     Step 0a: planning form stub (theme / target_outcome / frontier / bail_conditions). -->
+     Step 0a: planning form (theme / target_outcome / frontier / bail_conditions).
+     Step 0b: Hex Map renders the Map; frontier picks highlight on it. -->
 <div id="course-view" class="alt-view">
   <h2 class="alt-heading">Course · 7-leg arc</h2>
   <p class="alt-sub">A week's planned arc. Set the theme, name the target, declare what's reachable, and the bail conditions. Per-leg Frame picks from the frontier.</p>
   <div id="course-body"></div>
+  <div id="course-hexmap" class="course-hexmap"></div>
 </div>
 
 <!-- ── Cmd-K palette ── -->
@@ -6893,6 +6958,7 @@
     `;
     renderCourseFrontierChips();
     if (courseFrontierPanelOpen) renderCourseFrontierPanel();
+    renderCourseHexMap();
   }
 
   function renderCourseFrontierChips() {
@@ -6943,6 +7009,113 @@
     panel.innerHTML = html;
   }
 
+  /* ── Hex Map (Course view, read-only v0.1) ──
+     Renders all Map items as flat-top hexes. Fill = area accent. Opacity = status
+     fog. P0 ring = red glow. Frontier ring = bright accent halo. Spatial layout
+     packs by area (no semantic adjacency yet). */
+  const HEX_ACCENT_FILL = {
+    blue:   '#4a7bd4',
+    amber:  '#d4a030',
+    green:  '#4a8a5a',
+    orange: '#e2a04a',
+    teal:   '#2d8a7e',
+    tan:    '#8a7a5a',
+    warm:   '#a88a5a',
+    dark:   '#555555',
+    red:    '#c25450',
+    purple: '#9a6fc2'
+  };
+  const HEX_STATUS_OPACITY = {
+    'archived':    0.30,
+    'live':        0.55,
+    'backlog':     0.75,
+    'drafted':     0.90,
+    'in-progress': 1.00
+  };
+
+  function hexPolygonPoints(cx, cy, s) {
+    // Flat-top hex centered at (cx, cy) with side length s. Six vertices.
+    const h = (Math.sqrt(3) / 2) * s;
+    return [
+      [cx + s,     cy        ],
+      [cx + s / 2, cy - h    ],
+      [cx - s / 2, cy - h    ],
+      [cx - s,     cy        ],
+      [cx - s / 2, cy + h    ],
+      [cx + s / 2, cy + h    ]
+    ].map(p => p[0].toFixed(2) + ',' + p[1].toFixed(2)).join(' ');
+  }
+
+  function renderCourseHexMap() {
+    const wrap = document.getElementById('course-hexmap');
+    if (!wrap) return;
+    const c = getOrInitCourseDraft();
+    const frontierSet = new Set(c.frontier || []);
+    const items = allItemsArray();
+    if (items.length === 0) {
+      wrap.innerHTML = '<p class="course-hexmap-title">Map</p><p class="course-hexmap-sub">No items in the lab yet.</p>';
+      return;
+    }
+    // Sort items: by area (alphabetic for stable layout), then priority, then id.
+    const sorted = items.slice().sort((a, b) => {
+      const ax = (a.areaName || 'zzz').localeCompare(b.areaName || 'zzz');
+      if (ax !== 0) return ax;
+      const pr = priorityRank(a.priority) - priorityRank(b.priority);
+      if (pr !== 0) return pr;
+      return (a.id || '').localeCompare(b.id || '');
+    });
+
+    // Lay out in a flat-top hex grid. ~8 cols wide. Odd cols offset down.
+    const COLS = 8;
+    const S = 30;                       // hex side length
+    const STEP_X = 1.5 * S;             // horizontal step (col)
+    const STEP_Y = Math.sqrt(3) * S;    // vertical step (row)
+    const OFFSET_Y = STEP_Y / 2;        // odd-col vertical offset
+    const PAD = S + 4;                  // canvas padding
+
+    const cells = sorted.map((it, i) => {
+      const col = i % COLS;
+      const row = Math.floor(i / COLS);
+      const cx = PAD + col * STEP_X;
+      const cy = PAD + row * STEP_Y + (col % 2 ? OFFSET_Y : 0);
+      const accent = (AREA_VISUALS[it.areaId] && AREA_VISUALS[it.areaId].accent) || 'dark';
+      const fill = HEX_ACCENT_FILL[accent] || HEX_ACCENT_FILL.dark;
+      const opacity = HEX_STATUS_OPACITY[it.status] || 0.75;
+      const classes = ['hex-cell'];
+      if (it.priority === 'P0') classes.push('p0');
+      if (frontierSet.has(it.id)) classes.push('in-frontier');
+      const points = hexPolygonPoints(cx, cy, S);
+      const numShort = (it.id || '').replace(/^LAB-/, '');
+      return `<g>
+        <polygon class="${classes.join(' ')}" points="${points}" fill="${fill}" fill-opacity="${opacity}">
+          <title>${escapeHTML(it.id)} · ${escapeHTML(it.title)} · ${escapeHTML(it.priority)} · ${escapeHTML(it.status)} · ${escapeHTML(it.areaName)}</title>
+        </polygon>
+        <text class="hex-label" x="${cx.toFixed(2)}" y="${cy.toFixed(2)}">${escapeHTML(numShort)}</text>
+      </g>`;
+    });
+
+    const lastRow = Math.floor((sorted.length - 1) / COLS);
+    const width  = PAD * 2 + (COLS - 1) * STEP_X + S;
+    const height = PAD * 2 + lastRow * STEP_Y + OFFSET_Y;
+
+    wrap.innerHTML = `
+      <p class="course-hexmap-title">Map · ${sorted.length} items · ${frontierSet.size} in this Course's frontier</p>
+      <p class="course-hexmap-sub">Read-only v0.1. Fill = area accent. Opacity = status (archived dim → in-progress bright). Red glow = P0. Teal glow = in this Course's frontier. Hover for details.</p>
+      <svg viewBox="0 0 ${width.toFixed(2)} ${height.toFixed(2)}" preserveAspectRatio="xMidYMid meet" role="img" aria-label="Lab map: ${sorted.length} items as hexes, with ${frontierSet.size} highlighted as the active Course's frontier">
+        ${cells.join('\n')}
+      </svg>
+      <div class="course-hexmap-legend">
+        <span class="lg-item"><span class="lg-swatch" style="background:#4a7bd4"></span>Frame</span>
+        <span class="lg-item"><span class="lg-swatch" style="background:#d4a030"></span>Pilot Check</span>
+        <span class="lg-item"><span class="lg-swatch" style="background:#a88a5a"></span>Library / Warm</span>
+        <span class="lg-item"><span class="lg-swatch" style="background:#2d8a7e"></span>Teal areas</span>
+        <span class="lg-item"><span class="lg-swatch" style="background:#555"></span>Director's Desk / Dark</span>
+        <span class="lg-item"><span class="lg-ring" style="border-color:#c25450"></span>P0</span>
+        <span class="lg-item"><span class="lg-ring" style="border-color:#5cb09a"></span>In frontier</span>
+      </div>
+    `;
+  }
+
   // Delegated handlers for the Course view (inputs + frontier picker + save).
   document.getElementById('course-view').addEventListener('click', (e) => {
     const tgt = e.target;
@@ -6976,6 +7149,7 @@
       c.frontier = (c.frontier || []).filter(x => x !== id);
       renderCourseFrontierChips();
       if (courseFrontierPanelOpen) renderCourseFrontierPanel();
+      renderCourseHexMap();
       return;
     }
     const toggleRow = tgt.closest('[data-act="frontier-toggle"]');
@@ -6987,6 +7161,7 @@
       c.frontier = Array.from(set);
       renderCourseFrontierChips();
       renderCourseFrontierPanel();
+      renderCourseHexMap();
       return;
     }
   });

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -8722,9 +8722,12 @@
       rowLabels.push(`<text class="bc-grid-label" x="${x}" y="${y}" text-anchor="end">${BC_ROW_LETTERS[r]}</text>`);
     }
 
-    // Grid cells (each is a clickable group with bg rect + center snap dot)
+    // Grid cells, wrapped in role="row" groups so the ARIA grid pattern
+    // is complete (grid > row > gridcell). Without row wrappers, JAWS/NVDA
+    // can't construct the grid coordinate system for arrow-key navigation.
     const cells = [];
     for (let r = 0; r < BC_ROWS; r++) {
+      cells.push(`<g role="row" aria-label="Row ${BC_ROW_LETTERS[r]}">`);
       for (let c = 0; c < BC_COLS; c++) {
         const x = BC_LABEL_PAD + c * BC_CELL;
         const y = BC_LABEL_PAD + r * BC_CELL;
@@ -8734,6 +8737,7 @@
           <circle class="bc-cell-snap" cx="${x + BC_CELL / 2}" cy="${y + BC_CELL / 2}" r="3"/>
         </g>`);
       }
+      cells.push(`</g>`);
     }
 
     slot.innerHTML = `

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -4941,6 +4941,14 @@
     // Called after a Frame card is saved. Ensures a leg exists for today, in
     // the current ISO-week's course, and links the card to it. Bumps the
     // leg from `planning` → `in-progress` if applicable. Returns the leg.
+    //
+    // INTENTIONAL ORPHAN BEHAVIOR: if the active leg is from a previous day
+    // and was never debriefed, this function starts a fresh leg for today and
+    // leaves the prior leg as `in-progress` in the data. That stale leg stays
+    // findable via findLegsForCourse but is not the active leg going forward.
+    // Phase 4 (Debrief) is responsible for closing stale legs (auto-archive
+    // on next-day open, or surface them in a "stale legs" list). Until then,
+    // multi-day, never-debriefed legs accumulate as a known data state.
     if (!card || !card.savedAt) return null;
     let leg = findActiveLeg();
     const todayStr = todayDateOnly();
@@ -4970,7 +4978,11 @@
 
     // Header chunks. Order: leg id · LED segments · MUSTS · BONUS · MAP · status.
     const legId    = leg ? leg.id : 'No leg yet';
-    const legNum   = leg ? leg.leg_number : 0;
+    // Clamp to 0 so corrupt records (legs with missing/negative leg_number)
+    // render the LED bar as fully ghosted rather than walking the loop oddly.
+    const legNum   = leg && typeof leg.leg_number === 'number' && leg.leg_number > 0
+                       ? Math.min(leg.leg_number, COURSE_LEG_COUNT)
+                       : 0;
     const status   = leg ? leg.status : 'planning';
     const card     = leg ? findFrameCardForLeg(leg) : null;
     const mustArr  = card && Array.isArray(card.must) ? card.must
@@ -4980,6 +4992,12 @@
     const mustsCount = mustArr.length;
     const bonusCount = bonusArr.length;
     const frontierCount = course && Array.isArray(course.frontier) ? course.frontier.length : 0;
+    // allItemsArray is defined later in the script; this typeof guard is
+    // load-order protection. renderCourseHeader is only called after init
+    // (via openDrawer / ff-save / setView), so the function is in scope at
+    // call time. Keep the guard so any earlier caller silently degrades to 0
+    // rather than throwing — flagged by grepzilla2 phase-2 review as the
+    // intentional shape.
     const mapTotal = (typeof allItemsArray === 'function') ? allItemsArray().length : 0;
 
     // 7-segment LED bar. Done = legs strictly before legNum. Current = legNum. Future = the rest.
@@ -6167,7 +6185,6 @@
     const filled = FF_FIELDS.filter(f => fieldIsFilled(card[f])).length;
     if (filled === 0) return;
     const cards = loadFrameCards();
-    let savedCard = card;
     if (editingOriginalIdx >= 0 && cards[editingOriginalIdx]) {
       // preserve original date + savedAt if user is editing an existing card,
       // so the leg-attach link by savedAt stays stable across edits
@@ -6175,7 +6192,6 @@
       card.date = orig.date || card.date;
       card.savedAt = orig.savedAt || card.savedAt;
       cards[editingOriginalIdx] = card;
-      savedCard = card;
     } else {
       cards.push(card);
     }
@@ -6183,7 +6199,7 @@
     // Phase 2: ensure today's leg exists in the active week's course and link
     // the just-saved Frame card to it. New cards bump the leg into in-progress;
     // edits to an already-attached card leave the link unchanged.
-    attachFrameToLeg(savedCard);
+    attachFrameToLeg(card);
     renderCourseHeader();
     flashSaved();
     setTimeout(() => enterResting(), 600);

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -2186,6 +2186,29 @@
     max-width: 100%;
   }
   .ff-chip:hover { background: rgba(74,123,212,0.22); }
+  /* Phase 2: off-frontier picks render with a warm accent and a small ↗
+     badge, distinguishing them visually from on-frontier chips without
+     breaking the picker layout. */
+  .ff-chip.off-frontier {
+    background: rgba(226,160,74,0.12);
+    border-color: rgba(226,160,74,0.45);
+  }
+  .ff-chip.off-frontier:hover { background: rgba(226,160,74,0.22); }
+  .ff-chip.off-frontier .ff-chip-id { color: #e2a04a; }
+  .ff-chip .ff-chip-off-frontier {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: rgba(226,160,74,0.25);
+    color: var(--accent);
+    font-size: 10px;
+    font-family: var(--font-px);
+    line-height: 1;
+    cursor: help;
+  }
   .ff-chip .ff-chip-id {
     font-family: var(--font-px);
     font-size: 10px;
@@ -2254,6 +2277,47 @@
     margin-top: 4px;
   }
   .ff-pp-section-label:first-child { margin-top: 0; }
+  /* Phase 2: scope toggle bar at the top of the picker panel. Two buttons
+     (Frontier · Full lab) with the active scope highlighted. */
+  .ff-pp-scope-bar {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+    padding: 4px 4px 8px;
+    margin-bottom: 6px;
+    border-bottom: 1px dashed var(--panel-bd);
+  }
+  .ff-pp-scope {
+    font-family: var(--font-px);
+    font-size: 10px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    padding: 3px 8px;
+    border: 1px solid var(--panel-bd);
+    border-radius: 3px;
+    background: transparent;
+    color: var(--accent-dim);
+    cursor: pointer;
+  }
+  .ff-pp-scope:hover { color: var(--fg); }
+  .ff-pp-scope.active {
+    background: rgba(226,160,74,0.12);
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+  .ff-pp-scope.disabled,
+  .ff-pp-scope[disabled] {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+  .ff-pp-scope-hint {
+    font-family: inherit;
+    font-size: 11px;
+    color: #6f7a90;
+    font-style: italic;
+    margin-left: 4px;
+  }
   .ff-pp-row {
     display: grid;
     grid-template-columns: 32px 1fr auto;
@@ -5607,6 +5671,12 @@
   let framePickerPanelOpen = { must: false, stretch: false };
   // Which priority tier the picker is currently showing (P0 default, expandable to P1, P2).
   let framePickerExpandTier = { must: 'P0', stretch: 'P0' };
+  // Phase 2 (Frontier Wiring): default the picker scope to the active Course's
+  // frontier. Per the rogaine-spine architecture, per-leg Frame picks *from* the
+  // frontier. The user can expand to the full lab via the toggle, in which case
+  // off-frontier picks get marked on the ref so Debrief can later surface them
+  // as candidate changes_to_course.frontier_added.
+  let framePickerScope = { must: 'frontier', stretch: 'frontier' };
   // Whether the free-text fallback is active per field.
   let framePickerTextMode = { must: false, stretch: false };
   // Which Done-means slot indices have their per-slot Approach unfold open (LAB-027 v3).
@@ -6368,24 +6438,49 @@
         distinction encoded by status badge — no new tier).
         See more: expands to include P1, then P2.  ── */
 
-  function getFramePickerCandidates(tier) {
+  // Returns the active course's frontier as a Set for fast membership checks.
+  // Empty Set if no active course or no frontier — caller should treat that as
+  // "no frontier set" and degrade to the full-lab scope.
+  function getActiveFrontierSet() {
+    const c = (typeof findActiveCourse === 'function') ? findActiveCourse() : null;
+    if (!c || !Array.isArray(c.frontier)) return new Set();
+    return new Set(c.frontier);
+  }
+
+  function getFramePickerCandidates(tier, scope) {
     // Reuse allItemsArray() so picker matches the Priority view's source of truth.
+    // Phase 2: when scope === 'frontier', intersect with the active course's
+    // frontier. Default scope is 'frontier' (the rogaine discipline); the
+    // picker UI exposes a toggle to expand to 'all' (the full lab).
     const items = (typeof allItemsArray === 'function') ? allItemsArray() : [];
     const wantedTiers = tier === 'P0' ? ['P0']
                       : tier === 'P1' ? ['P0','P1']
                       : ['P0','P1','P2'];
-    return items
+    const useScope = scope || 'frontier';
+    let filtered = items
       .filter(it => wantedTiers.includes(it.priority))
-      .filter(it => it.status !== 'live' && it.status !== 'archived')
-      .sort((a, b) => {
-        // Priority first.
-        const pa = priorityRank(a.priority), pb = priorityRank(b.priority);
-        if (pa !== pb) return pa - pb;
-        // Within priority: in-progress, drafted, backlog (statusRank gives 0,1,2 — perfect).
-        const sa = statusRank(a.status), sb = statusRank(b.status);
-        if (sa !== sb) return sa - sb;
-        return a.id.localeCompare(b.id);
-      });
+      .filter(it => it.status !== 'live' && it.status !== 'archived');
+    if (useScope === 'frontier') {
+      const frontier = getActiveFrontierSet();
+      // If frontier is empty (no course set or empty frontier), the caller is
+      // expected to have flipped to 'all' already. As a safety net, return all
+      // candidates rather than an empty list — this prevents an unfillable picker
+      // when the user hasn't planned a course yet.
+      if (frontier.size === 0) {
+        // fall through with no frontier filter
+      } else {
+        filtered = filtered.filter(it => frontier.has(it.id));
+      }
+    }
+    return filtered.sort((a, b) => {
+      // Priority first.
+      const pa = priorityRank(a.priority), pb = priorityRank(b.priority);
+      if (pa !== pb) return pa - pb;
+      // Within priority: in-progress, drafted, backlog (statusRank gives 0,1,2 — perfect).
+      const sa = statusRank(a.status), sb = statusRank(b.status);
+      if (sa !== sb) return sa - sb;
+      return a.id.localeCompare(b.id);
+    });
   }
 
   function renderFramePicker(field) {
@@ -6408,9 +6503,16 @@
     chipsEl.innerHTML = selected.map((ref, i) => {
       const id = escapeHTML(ref.id || '');
       const title = escapeHTML(ref.title || '');
-      const chipHTML = `<span class="ff-chip" data-act="ff-chip" data-field="${field}" data-item="${id}" data-slot-idx="${i}">
+      // Phase 2: off-frontier picks render with a small "↗" badge so the
+      // user sees mid-leg deviations from the planned course at a glance.
+      // Debrief later surfaces these as candidate changes_to_course.
+      const offFrontier = !!ref.off_frontier;
+      const offBadge = offFrontier
+        ? '<span class="ff-chip-off-frontier" title="Off-frontier pick — surfaces in Debrief as a candidate course-frontier change.">↗</span>'
+        : '';
+      const chipHTML = `<span class="ff-chip${offFrontier ? ' off-frontier' : ''}" data-act="ff-chip" data-field="${field}" data-item="${id}" data-slot-idx="${i}">
         <span class="ff-chip-id">${id}</span>
-        <span class="ff-chip-title">${title}</span>${
+        <span class="ff-chip-title">${title}</span>${offBadge}${
           slotsEnabled
             ? `<span class="ff-slot-toggle" aria-hidden="true">${expandedSet.has(i) ? '▾' : '▸'}</span>`
             : ''
@@ -6480,14 +6582,35 @@
 
     // Render the panel contents.
     const tier = framePickerExpandTier[field] || 'P0';
-    const candidates = getFramePickerCandidates(tier);
+    // Phase 2: resolve scope. If frontier is empty and the user hasn't already
+    // flipped to 'all' explicitly, auto-flip and surface a hint instead of an
+    // empty picker. This is the "no course set" / "course has no frontier yet"
+    // safety net.
+    const frontierSet = getActiveFrontierSet();
+    const frontierEmpty = frontierSet.size === 0;
+    if (frontierEmpty && framePickerScope[field] === 'frontier') {
+      framePickerScope[field] = 'all';
+    }
+    const scope = framePickerScope[field] || 'frontier';
+    const candidates = getFramePickerCandidates(tier, scope);
     const selectedIds = new Set(selected.map(r => r.id));
 
     // Group by priority for visual separation.
     const groups = { P0: [], P1: [], P2: [] };
     candidates.forEach(it => { if (groups[it.priority]) groups[it.priority].push(it); });
 
+    // Scope toggle — shows the count in the active scope, lets the user flip.
+    // When frontier is empty, the toggle is disabled and labeled accordingly.
+    const frontierLabel = frontierEmpty
+      ? 'No frontier set'
+      : 'Frontier (' + frontierSet.size + ')';
     let html = '';
+    html += `<div class="ff-pp-scope-bar">
+      <button type="button" class="ff-pp-scope${scope === 'frontier' ? ' active' : ''}${frontierEmpty ? ' disabled' : ''}" data-act="ff-scope" data-field="${field}" data-scope="frontier"${frontierEmpty ? ' disabled' : ''}>${escapeHTML(frontierLabel)}</button>
+      <button type="button" class="ff-pp-scope${scope === 'all' ? ' active' : ''}" data-act="ff-scope" data-field="${field}" data-scope="all">Full lab</button>
+      ${frontierEmpty ? '<span class="ff-pp-scope-hint">No course frontier yet — set one in the Course view to scope this picker.</span>' : ''}
+    </div>`;
+
     ['P0','P1','P2'].forEach(p => {
       if (groups[p].length === 0) return;
       if (tier === 'P0' && p !== 'P0') return;
@@ -6511,8 +6634,13 @@
       }).join('');
     });
 
-    if (html === '') {
-      html = '<div class="ff-pp-empty">Nothing in this tier. Try expanding to P1 or P2.</div>';
+    // The candidate-list emptiness check needs to ignore the scope-bar HTML
+    // we just appended; check after the loop above produced no row content.
+    const hasRows = candidates.length > 0;
+    if (!hasRows) {
+      html += scope === 'frontier'
+        ? '<div class="ff-pp-empty">No frontier items in this tier. Try expanding to P1/P2 or switching to Full lab.</div>'
+        : '<div class="ff-pp-empty">Nothing in this tier. Try expanding to P1 or P2.</div>';
     }
 
     // See-more affordance.
@@ -6553,6 +6681,17 @@
       renderFramePicker(field);
       return;
     }
+    // Phase 2: scope toggle (Frontier / Full lab) inside the picker panel.
+    const scopeBtn = tgt.closest('[data-act="ff-scope"]');
+    if (scopeBtn && !scopeBtn.disabled && !scopeBtn.classList.contains('disabled')) {
+      const field = scopeBtn.dataset.field;
+      const next  = scopeBtn.dataset.scope; // 'frontier' | 'all'
+      if (field && next && framePickerScope[field] !== next) {
+        framePickerScope[field] = next;
+        renderFramePicker(field);
+      }
+      return;
+    }
     // Pick / unpick an item in the panel
     const pickRow = tgt.closest('[data-act="ff-pick"]');
     if (pickRow) {
@@ -6563,8 +6702,13 @@
       const cap  = FF_PICKER_CAPS[field] || 0;
       const cur = framePickerState[field] || [];
       const existsAt = cur.findIndex(r => r.id === id);
+      // Phase 2: tag the new ref with off_frontier=true if the item isn't in
+      // the active course's frontier. Frontier-membership is checked at the
+      // moment of pick so the flag reflects the course state at that time.
+      const frontier = getActiveFrontierSet();
+      const isOffFrontier = frontier.size > 0 && !frontier.has(id);
       if (mode === 'single') {
-        framePickerState[field] = (existsAt >= 0) ? [] : [{ id, title }];
+        framePickerState[field] = (existsAt >= 0) ? [] : [{ id, title, off_frontier: isOffFrontier }];
         if (field === 'must') {
           frameSlotExpanded.must = (existsAt >= 0) ? new Set() : new Set([0]);
         }
@@ -6578,7 +6722,7 @@
           // At cap: silently no-op. The row is rendered .at-cap so the user already sees why.
           return;
         } else {
-          cur.push({ id, title });
+          cur.push({ id, title, off_frontier: isOffFrontier });
           // Auto-expand the just-picked must slot so the user can fill its Approach
           // immediately without an extra click. Stretch slots stay non-unfoldable.
           if (field === 'must') frameSlotExpanded.must.add(cur.length - 1);

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -4148,7 +4148,7 @@
       "accent": "blue",
       "workshop": true,
       "description": "Where the Frame practice and chapter live. The phase that decides what the turn is for.",
-      "items": ["LAB-001","LAB-002","LAB-026","LAB-027","LAB-028"],
+      "items": ["LAB-001","LAB-002","LAB-026","LAB-027","LAB-028","LAB-036"],
       "sources": [
         { "label": "frame-research-and-practice.md (the chunk skeleton)", "href": "frame-research-and-practice.md" },
         { "label": "turn-v0.1-phases-and-leverage.md (Frame section)", "href": "turn-v0.1-phases-and-leverage.md" },
@@ -4186,6 +4186,18 @@
         }
       ],
       "chunks": [
+        {
+          "id": "chunk-course-as-spine-station-as-lens",
+          "title": "Course as spine — each station as a different lens",
+          "summary": "Architectural shift: Frame doesn't file a card, it sets the course. Every later station (Comprehend, Sync, Produce, Debrief) is a different lens on the same course.",
+          "body": "The rogaine-spine arc produced a reframe of the lab's architecture. Previously, each station (Frame, Comprehend, Sync, Produce, Debrief) operated as a separate form/function — you filled in the Frame, then moved to Comprehend, etc. The forms were adjacent, not hierarchical.\n\nThe architectural shift: the Frame card is no longer the unit. The **Leg** is the unit, and the Frame card is the planning artifact *inside* the leg. Each station is a lens on the same underlying work unit:\n\n- **Frame** — sets the course for this leg (scope, frontier pick, approach).\n- **Comprehend** — re-immersion lens (what do I need to load before I can produce?).\n- **Sync** — alignment lens (who else needs to be oriented, what's their state?).\n- **Produce** — execution lens (the work itself, measured against the Frame).\n- **Debrief** — retrospective lens (what happened vs. what was framed? what changes for the next leg?).\n\nThe Leg record wraps all five sub-records. The Snap Circuit board (chunk-snap-circuit-leg-view) renders the five zones in one view — the whole turn at a glance, not five separate drawers.\n\nPractical implication: Frame no longer 'files a card.' Frame 'starts a leg.' The leg stays open until Debrief closes it. This is the persistence model that enables the Course Header bar (shows active leg at top of every workshop drawer) and the Course Coach pattern (reads the leg's full arc, not just individual sub-records)."
+        },
+        {
+          "id": "chunk-course-setter-problem-self-set",
+          "title": "Course-setter problem — when the racer sets their own course",
+          "summary": "IRF Rule C2 (most but not all checkpoints) has to be self-imposed when the racer sets the course, or the asymmetry that makes rogaine work disappears.",
+          "body": "In organized rogaining, the course setter and the racer are different people. The course setter places checkpoints with the constraint that no racer can visit all of them in the time limit — this is IRF (International Rogaining Federation) Rule C2 in spirit: the frontier is larger than any single route through it.\n\nWhen knowledge workers set their own Course, the course-setter problem appears: there's no external constraint forcing the frontier to be genuinely larger than one leg can cover. The temptation is to set an itinerary — a course small enough to complete — which defeats the selectivity that makes rogaining work as a planning metaphor.\n\n**The self-imposed constraint:** a well-set Course should have more frontier items than any seven legs can reach. If you can see yourself completing every frontier item in the week, the frontier is too small. The cognitive work is setting the course *honestly* — naming what's reachable without over-constraining the route.\n\nThis is a calibration note for Frame-Course planning. When the author reviews the week's frontier on Frame, the question is: 'Is this frontier actually larger than I can execute? Am I leaving real selectivity for each leg?' If the answer is no, the Course needs more items, or the P0/frontier split needs rebalancing.\n\nDesign implication: the Course planning form should surface this check — possibly as a heuristic prompt ('Is there more here than any seven legs can reach?'). Deferred to v0.2 Course planning UX."
+        },
         {
           "id": "chunk-frame-form",
           "title": "The form",
@@ -4246,6 +4258,14 @@
       "artifacts": [
         { "label": "turn-v0.1-phases-and-leverage.md (Comprehend section)", "href": "turn-v0.1-phases-and-leverage.md" }
       ],
+      "chunks": [
+        {
+          "id": "chunk-missing-comprehend",
+          "title": "Re-immersion has been doing work without a home",
+          "summary": "Recap-play, session-start prompts, and the new on-demand Comprehend on the Course view all belong in Comprehend Station. The phase has been doing real work without a formal home in the lab.",
+          "body": "Before Phase 3 of the rogaine-spine arc, Comprehend was doing real cognitive work under a different name across several surfaces:\n\n- **Recap-play (Larry's PLAYS.md)** — the presentation-shape re-immersion brief that fires when produce and debrief are time-separated. This is Comprehend's re-immerse step running as an informal play.\n- **SESSION_PROMPTS.md** — the session-start prompts that load prior context before work begins. Structurally, these are Comprehend rituals without the Comprehend label.\n- **Debrief's re-immerse phase** — when the debrief happens >1 day after produce, the debrief opens with a re-immersion step (presentation-shape brief, drill-down detail). This is Comprehend logic inside the Debrief wrapper.\n\nPhase 3 formalizes the on-demand Comprehend: a textarea + log on the Course view, persisted to `course.comprehend[]`. This gives Comprehend a first-class data record and a surface to write to, rather than orphaning it across plays and prompts.\n\n**What Comprehend does:** loads remaining state from prior legs, agent outputs, and source material before the current leg's Produce phase. The phase is *conditional* (skip when the operator is still warm on the prior leg's context) but *high-ROI* when cold-starting or resuming stale work.\n\n**What's still missing:** Comprehend Station has no workshop prototype. The on-demand textarea on the Course view is a placeholder. A full Comprehend Station workshop would have: a structured re-immersion form (what was last built, what's the current frontier state, what agents need to be loaded), an agent-context picker, and a 'context loaded' gate before Produce. This is not yet scoped as a LAB item — flag for Quenton and the author."
+        }
+      ],
       "notes": []
     },
     {
@@ -4280,7 +4300,7 @@
       "accent": "blue",
       "workshop": true,
       "description": "Where Debrief practice and chapter live. Closes the cycle, captures, sets up the next gauge read. Currently the urgent priority — its absence is the gap that creates session-end integration debt.",
-      "items": ["LAB-003","LAB-004","LAB-032"],
+      "items": ["LAB-003","LAB-004","LAB-032","LAB-038"],
       "sources": [
         { "label": "turn-v0.1-phases-and-leverage.md (Debrief section)", "href": "turn-v0.1-phases-and-leverage.md" }
       ],
@@ -4301,6 +4321,12 @@
         }
       ],
       "chunks": [
+        {
+          "id": "chunk-three-goal-frames-and-demote-discipline",
+          "title": "Three goal frames and the demote discipline",
+          "summary": "Race-to-win / race-to-optimize / race-to-finish. Elite rogainers adopt frame 2 and fall back to frame 3 at first sign of trouble. The discipline is: demote the plan when the plan is no longer correct.",
+          "body": "Rogaining surfaces three distinct goal frames a racer can hold:\n\n1. **Race-to-win** — maximize score against the field. Requires perfect route-planning, sustained pace, no bailout.\n2. **Race-to-optimize** — maximize your own performance against your prior runs. Win or lose to the field is secondary; beating your personal benchmark is the goal.\n3. **Race-to-finish** — get to the hash house before the bingo. Score is irrelevant; don't DNF.\n\nElite rogainers move between these frames deliberately. They start in frame 2 (personal optimization), maintain frame 1 awareness (field position), and pre-commit to falling back to frame 3 at the first sign of trouble (capacity drop, time overrun, route failure).\n\nThe critical discipline is the **demotion move**: when conditions change, the racer must be willing to demote from frame 2 to frame 3 *before the evidence is overwhelming.* Waiting until the situation is dire means the demotion is panic, not judgment.\n\nTranslation to knowledge work:\n- Frame 1 = shipping the external deliverable on the external deadline.\n- Frame 2 = running the best possible turn for your own growth and output quality.\n- Frame 3 = closing the leg cleanly and debriefing, even if the produce was minimal.\n\nThe Debrief question 'Course held?' directly captures the demotion: did you stay in your planned frame, or did you correctly demote when the frame was no longer serving you? Demoting correctly is a skill, not a failure. Demoting too late (or never) is the failure mode.\n\nThe 'What changed it' field in the rogaine-shaped Debrief captures the trigger for any demotion — building a personal record of when and why the racer reads the terrain correctly."
+        },
         {
           "id": "chunk-debrief-preliminary-process",
           "title": "Debrief Workshop — preliminary process (v0.1)",
@@ -4353,6 +4379,12 @@
       ],
       "chunks": [
         {
+          "id": "chunk-hash-house-gauge-pilot-check",
+          "title": "Hash house = Pilot Check visit (refuel, re-orient, decide)",
+          "summary": "The lab's heartbeat IS the hash house. Pilot Check = hash-house visit: refuel, re-orient, decide whether to continue. A tightening of an existing instrument, not a new one.",
+          "body": "In rogaining, the **hash house** is the central base camp. Racers return there to refuel, check time, re-orient, and decide whether to continue the current route or revise. Elite racers treat each hash-house visit as a decision point, not just a rest stop: they assess their capacity against remaining time and course, then commit or pivot.\n\nThe lab's Pilot Check is the hash house visit. The parallels are direct:\n\n- **Refuel** → capacity read (Cognitive / Emotional / Physical sliders).\n- **Re-orient** → Gauge dispatch (cleared or grounded) + diagnosis of which dimension is red.\n- **Decide whether to continue** → Full Turn vs. Partial Turn vs. Recovery insertion.\n\nThis framing tightens an instrument that already exists — it doesn't add a new one. The Gauge is the continuous instrument (between every phase); the Pilot Check is the explicit pre-leg hash-house visit (before a Full Turn starts).\n\nPractical implication: the Pilot Check form can be framed to the author as 'you're at the hash house — what's your read?' rather than 'complete this checklist.' The framing change may improve compliance on sessions where the operator is inclined to skip the check. The hash-house visit is non-optional in rogaining; that normative weight transfers.\n\nThe Debrief's 'Capacity + next' field closes the loop: post-leg gauge read = leaving the hash house for the next leg.\n\nCross-ref: chunk-gauge-heartbeat (The Gauge) — the heartbeat is the continuous rhythm; the hash house is the explicit check-in point within that rhythm."
+        },
+        {
           "id": "chunk-gauge-heartbeat",
           "title": "The heartbeat — capacity ↔ restoration as meta-rhythm",
           "summary": "The continuous Gauge-read-and-dispatch cycle is the framework's beating rhythm. Without it, the framework is just phases without honoring capacity.",
@@ -4370,7 +4402,7 @@
       "type": "aux / persistent",
       "accent": "dark",
       "description": "Your seat. Where the Frame card sits today, where lab notes get written. Also the home for cross-cutting lab work — agent composition, process docs, session integration.",
-      "items": ["LAB-022","LAB-023","LAB-024","LAB-029"],
+      "items": ["LAB-022","LAB-023","LAB-024","LAB-029","LAB-034","LAB-035","LAB-037","LAB-039","LAB-040","LAB-041"],
       "sources": [
         { "label": "PROCESS.md (how the agents compose, lab-to-book flow)", "href": "PROCESS.md" },
         { "label": "DECISIONS.md (synthesized decisions log)", "href": "DECISIONS.md" }
@@ -4399,6 +4431,42 @@
         }
       ],
       "chunks": [
+        {
+          "id": "chunk-snap-circuit-leg-view",
+          "title": "Snap Circuit board — Leg view (v0.1)",
+          "summary": "The Leg rendered as a five-zone vertical circuit board. Frame=power source, Comprehend=amplifier, Sync=filter, Produce=live signal, Debrief=output stage. Signal flows top-to-bottom with wire segments. Read-only v0.1; click-throughs deferred.",
+          "body": "Phase 5 of the rogaine-spine arc ships a Snap Circuit board as the Leg view (new toolbar tab: LEG). Five vertical zones named after electronics components:\n\n- Frame = power source (the turn begins here; scope and intent)\n- Comprehend = amplifier (context loaded and boosted)\n- Sync = filter (noise removed; roster and alignment)\n- Produce = live signal (work output; the active phase)\n- Debrief = output stage (result measured, captured, fed forward)\n\nWire segments connect the zones top-to-bottom. Zone display shows the sub-record's status (pending / active / done) plus key metadata when populated. The circuit metaphor does a different cognitive job than the Hex Map: Hex Map is terrain (where am I in the week?); Snap Circuit is wiring (how does this leg flow?). The two metaphors compose — one for the Course/week scale, one for the Leg/turn scale.\n\nv0.1 is read-only. Clicking a zone does nothing. Phase 5 fix commit (11c6cd1) hoists fmtComprehendWhen, swaps the groundedness glyph from ⏚ to ≈, and hardens click handlers. Click-through wiring (zone → form/drawer) deferred to LAB-037.\n\nDesign lineage: WS004 ('Beyond the Symbolic: Humanizing AI Tools'), Bruner's iconic/enactive distinction. Snap Circuits is Alan Kay's 'constructing a diagram is much less difficult than reading one' made physical."
+        },
+        {
+          "id": "chunk-hex-map-course-view-v01",
+          "title": "Hex Map — Course/Map view (v0.1)",
+          "summary": "Hex Map as the Course/week visualization. Each hex is a lab area; biome accent = area color; fog = status; P0 glow; frontier halo. Read-only v0.1 spec.",
+          "body": "Step 0b of the rogaine-spine arc ships a read-only Hex Map as the Course/Map view (visible on the Course toolbar tab, below the planning form). Spec:\n\n- Each hexagon represents one lab area.\n- **Biome** → area accent color (blue for Frame, amber for Comprehend/Sync/Produce, green for Recovery, etc.).\n- **Fog of war** → hex darkens for areas with no active work (status-driven).\n- **P0 glow** → bright pulse ring on hexes whose items include a P0.\n- **Frontier halo** → ring highlight on hexes that are on the current Course's frontier (reachable this week).\n\nThe Hex Map gives terrain-level orientation at the week/Course scale: where is the work concentrated, what's in fog, what's glowing with urgency. This is the Course-level bird's eye. The Snap Circuit board (chunk-snap-circuit-leg-view) is the Leg-level wiring diagram. The two visualizations compose and don't overlap.\n\nv0.1 is read-only. v0.2 candidates: click-to-add-to-frontier, hover details panel, semantic adjacency (items near related items, not just area-grouped). Queued as LAB-041."
+        },
+        {
+          "id": "chunk-course-tier-spec",
+          "title": "Course tier — object shape and data conventions",
+          "summary": "The Course object's shape, ISO-week ID convention, frontier-not-itinerary call, and changes_to_course as the Debrief→Course coupling point.",
+          "body": "The Course is the top tier of the three-tier data model (Map → Course → Leg). One Course per ISO week.\n\n**ID convention:** `YYYY-WNN` (e.g., `2026-W19`). Derived from the Monday of the week — unambiguous, ISO 8601 compliant, human-readable.\n\n**Shape (v0.1):**\n```\n{\n  id: 'YYYY-WNN',\n  label: string,          // author-named course title\n  frontier: string[],     // item IDs reachable this week\n  p0: string[],           // P0 subset of frontier\n  terrain: string,        // optional free-text description\n  legs: Leg[],            // array of Leg records for this week\n  status: 'planning' | 'active' | 'complete'\n}\n```\n\n**Frontier-not-itinerary:** a Course names what is *reachable* this week, not which leg hits which item. The distinction preserves rogaine selectivity — the racer (worker) chooses the route in real time based on conditions. Per-leg Frame picks from the frontier at turn-start; Debrief feeds back into the course via `changes_to_course`.\n\n**changes_to_course:** the Debrief→Course coupling. Phase 4 adds a `changes_to_course` field on the Leg's debrief sub-record: `{ course_held: 'yes' | 'no' | 'partial', summary: string }`. When the debrief reveals the course needs revision, the author captures the what and why here. UI to mutate the frontier directly from Debrief is deferred (LAB-038).\n\n**Comprehend write-back:** Phase 3 adds an on-demand Comprehend section on the Course view — textarea + log — persisted to `course.comprehend[]`. Keeps the re-immersion record attached to the week, not orphaned in a separate tool."
+        },
+        {
+          "id": "chunk-7-leg-courses-naming",
+          "title": "\"7 leg courses\" — canonical unit name",
+          "summary": "A Course is a 7-leg arc over one ISO week. Naming locked to the book title The 7 Turn Work Week. Short, citable naming chunk.",
+          "body": "The Course is a **7 leg course** — one Full Turn per leg, seven legs per week. The naming is not incidental:\n\n- **Turn** = one work unit (Frame → Comprehend → Sync → Produce → Debrief).\n- **Leg** = one Turn-length segment of a larger course (rogaine vocabulary).\n- **Course** = the 7-leg arc for the ISO week.\n- **7 Turn Work Week** = the book title. The three-tier model (Course → Leg → Phase) embeds the book's central claim in the data architecture.\n\nThis is a naming chunk, not a design spec. When citing the model in chapter or presentation material: \"A week is a 7 leg course. Each leg is one Full Turn. The week's Course names the terrain — what's reachable — before any leg is run.\"\n\nLocked 2026-05-04 on the branch `danversfleury/lab-course-tier`."
+        },
+        {
+          "id": "chunk-frontier-vs-itinerary",
+          "title": "Frontier-not-itinerary — the week-scale design call",
+          "summary": "A Course names what is reachable this week, not what gets done in which leg. Preserves rogaine selectivity at week scale.",
+          "body": "The decisive design call in the rogaine-spine arc: a Course is a **frontier**, not an itinerary.\n\n**Itinerary:** leg 1 does items A+B, leg 2 does C+D, etc. Planned in advance. Violates the rogaine condition — the racer doesn't plan checkpoints in order; they choose dynamically based on terrain and capacity.\n\n**Frontier:** the Course names items that are *reachable* this week (flagged in `course.frontier[]`). Which leg hits which item is a per-leg Frame decision, made at turn-start when the author knows their current capacity and what's changed since the last leg.\n\nThis preserves the rogaine's key quality: the racer retains real selectivity at route-planning time. Cognitive-work translation: the worker can respond to what's actually true today (capacity, blockers, dependencies) rather than executing a plan that was optimized for last Monday's conditions.\n\nThe design call also solves a planning failure mode: the itinerary version creates guilt debt ('I said I'd do C in leg 3 and I didn't'). The frontier version creates feedback ('leg 3 chose C over D because of X — does the frontier need updating?'). Debrief captures the feedback; `changes_to_course` records whether the course held.\n\nQuenton's formulation: 'The Course names the terrain. The racer picks the route.'"
+        },
+        {
+          "id": "chunk-bruner-snap-design-language",
+          "title": "Bruner / Snap Circuits — the lab's iconic+enactive design language",
+          "summary": "The lab pushes toward iconic and enactive representation (Bruner) away from pure symbolic. Grounded in WS004, Kay's diagram construction claim, and the Snap Circuits analogy for AI agent composition.",
+          "body": "Jerome Bruner identified three modes of representation:\n- **Enactive** — knowledge through action and manipulation.\n- **Iconic** — knowledge through image and diagram.\n- **Symbolic** — knowledge through language and notation.\n\nThe lab, as currently built, is heavily symbolic: text fields, JSON, written labels. Quenton's design directive (surfaced in the rogaine-spine arc) is to push hard toward iconic and enactive.\n\nAllan Kay: *\"constructing a diagram is much less difficult than reading one.\"* The corollary for the lab: a zone you can interact with (even just click) teaches the structure faster than a label that describes it.\n\nThe Snap Circuits analogy originates in WS004 ('Beyond the Symbolic: Humanizing AI Tools'): Snap Circuits are the enactive/iconic equivalent of what Claude Projects do symbolically. A child snapping a power source to an amplifier to a speaker *is performing the architecture* — not just reading about it. The Leg view's five-zone circuit board applies this to the turn structure: Frame snaps to Comprehend snaps to Sync snaps to Produce snaps to Debrief. The wires are visible; the signal flow is readable.\n\nThe Hex Map applies the same principle at Course scale: terrain, biomes, fog, glow. You read the week's state by reading the map — you don't consult a status table.\n\nThis design language drives every subsequent visual decision in the lab. When a new view is proposed, the question is: what is the iconic/enactive equivalent of what we're currently expressing symbolically?"
+        },
         {
           "id": "chunk-priority-spec-v0.1",
           "title": "Priority spec — turn-based P0 with hard cap at 3 (v0.1)",
@@ -4564,7 +4632,8 @@
         "LAB-009","LAB-010","LAB-011","LAB-012","LAB-013","LAB-014","LAB-015","LAB-016",
         "LAB-017","LAB-018","LAB-019","LAB-020","LAB-021","LAB-022","LAB-023","LAB-024",
         "LAB-025","LAB-026","LAB-027","LAB-028","LAB-029",
-        "LAB-030","LAB-031","LAB-032","LAB-033"
+        "LAB-030","LAB-031","LAB-032","LAB-033",
+        "LAB-034","LAB-035","LAB-036","LAB-037","LAB-038","LAB-039","LAB-040","LAB-041"
       ],
       "artifacts": [],
       "notes": []
@@ -4879,6 +4948,78 @@
       "area": "trim-bench",
       "brief": "Apply the Bootstrap-a-Workshop play to Trim Bench. Lower priority — Trim is meta-ambient (lives inside other phases) and may not need a full workshop right away.",
       "full": "Trim is selection discipline within phases. It may be sufficient to surface as principles + chunks rather than a full workshop with prototype. Open question to settle when this comes up: does Trim need its own prototype, or is it expressed entirely through how other workshops handle their fields (e.g., Frame's 'Not Doing' column already operationalizes Trim)? Answer probably emerges from running the existing workshops for a few weeks."
+    },
+    "LAB-034": {
+      "id": "LAB-034",
+      "title": "Course Coach agent (poker-coach for legs)",
+      "status": "backlog",
+      "priority": "P2",
+      "area": "director-desk",
+      "brief": "Reads legs[] like poker hand histories. Surfaces patterns across past Frame+Debrief pairs. Suggests better moves for the next leg's Frame.",
+      "full": "The Course Coach reads the current Course's legs[] array — specifically the Frame sub-record (what was planned) and the Debrief sub-record (what happened, course_held, changes_to_course) — and treats them like poker hand histories. Patterns across multiple legs reveal: consistent over-scoping, frontier items that keep getting skipped, capacity mis-reads that recur on the same day-of-week, etc. Output is a suggestion for the next leg's Frame: adjust scope, recalibrate capacity, revise frontier. Whether this is a sub-agent (invoked from the Course view) or a top-level agent (like Quenton or Larry) is a design call deferred to Quenton. Priority is P2 — needs at least 4-5 completed legs before patterns are detectable. Needs legs[] to accumulate depth before it's useful."
+    },
+    "LAB-035": {
+      "id": "LAB-035",
+      "title": "Sync station form",
+      "status": "backlog",
+      "priority": "P2",
+      "area": "director-desk",
+      "brief": "The sync sub-record on the leg has a slot but no form. Phase 5 stub renders deferred state. Needs roster picker, course-state alignment ritual, and output capture.",
+      "full": "The Leg data model includes a sync sub-record slot (added in the Phase 1-2 build). Phase 5's Snap Circuit board renders the Sync zone in a deferred / stub state. What's needed: (1) a roster picker — humans and AI agents who need to be aligned before Produce; (2) a course-state alignment ritual — structured check that everyone has the same understanding of the current frontier and P0s; (3) output capture persisted to the leg as {at: timestamp, summary: string, roster: string[]}. The Sync form is conditional (skip for solo turns) and probably lives as a drawer opened from the Sync zone click-through (LAB-037). P2 — Sync is conditional and less urgent than Frame+Debrief forms."
+    },
+    "LAB-036": {
+      "id": "LAB-036",
+      "title": "Frame Approach iconic skin (mode/leaning/AI/done flavor)",
+      "status": "backlog",
+      "priority": "P1",
+      "area": "frame-workshop",
+      "brief": "Replace per-Done Approach text fields with iconic pickers: mode (3 buttons), leaning_on (chips from prior Sources), AI/people (avatars), Done flavor (3 icons).",
+      "full": "Quenton's step 7 from the rogaine-spine build order. The Approach batch in Frame (How I'll work) currently uses free-text fields. The iconic-skin replacement: (1) Mode — 3 buttons (solo / pair / collaborative); (2) Leaning on — chip picker surfacing items from prior Sources and recent Comprehend logs, so the author selects rather than types; (3) AI / people — avatar chips for the specific agents and humans in the turn; (4) Done flavor — 3 icons representing the type of output (artifact / decision / exploration). This is the biggest iconic-language payoff in the lab after Hex Map and Snap Circuit — it makes the Approach selection enactive rather than symbolic. Grounded in Bruner (chunk-bruner-snap-design-language). P1 — higher priority than Sync or click-throughs."
+    },
+    "LAB-037": {
+      "id": "LAB-037",
+      "title": "Leg view click-throughs (zone → form)",
+      "status": "backlog",
+      "priority": "P2",
+      "area": "director-desk",
+      "brief": "Phase 5 ships read-only Snap Circuit zones. Wire each zone to open the underlying form/drawer on click.",
+      "full": "Phase 5 (commit 11c6cd1) hardens click handlers but defers actual click-through wiring. Target mapping: Frame zone → Frame Workshop drawer; Comprehend zone → Course view Comprehend section; Sync zone → Sync form drawer (LAB-035); Produce zone → Produce Bay (if a Produce form exists); Debrief zone → Debrief Booth drawer. The click-through pattern makes the Snap Circuit board interactive — it becomes the navigation surface for the leg, not just a status read. P2 — the board is useful read-only; click-throughs are quality of life."
+    },
+    "LAB-038": {
+      "id": "LAB-038",
+      "title": "Frontier add/remove UI on Debrief",
+      "status": "backlog",
+      "priority": "P2",
+      "area": "debrief-booth",
+      "brief": "Phase 4 records changes_to_course qualitatively. Add UI to actually mutate the Course frontier on save: which items get added or removed for next-leg planning.",
+      "full": "Phase 4 (commit f4a0a06) adds the Debrief rogaine shape including changes_to_course: {course_held: 'yes'|'no'|'partial', summary: string}. This captures the qualitative record of whether the course was revised. What's missing: a UI that lets the author actually mutate course.frontier[] at save time — add items that should be reachable next leg, remove items that are done or deferred. The current flow requires the author to then manually edit the Course planning form to reflect the debrief's conclusions. The writeback UI closes that loop. Design question: does this UI live inside the Debrief form (at save time) or as a follow-on step in the Course view? P2."
+    },
+    "LAB-039": {
+      "id": "LAB-039",
+      "title": "Auto-archive stale undebriefed legs",
+      "status": "backlog",
+      "priority": "P2",
+      "area": "director-desk",
+      "brief": "Phase 2 documents intentional orphan behavior: prior-day legs that were never debriefed stay in-progress. Add auto-close-on-next-day-open or a stale-legs surfacing UI.",
+      "full": "Phase 2 (commits 2c4c8ce and 49b78c5) explicitly documents the orphan-leg behavior: if a leg was opened on a prior day but never debriefed, it remains in-progress status. The phase 2 fix commit (49b78c5) adds a console warning for orphaned legs. Two resolution paths: (1) auto-archive on next-day-open — when the Course view loads and detects a prior-day leg with no debrief, flag it and offer a quick-close; (2) stale-legs surfacing UI — a 'pending debriefs' section in the Course view or Director's Desk drawer showing orphaned legs with age. Option 1 is lower friction; option 2 surfaces historical data. Suggest option 2 for the author to decide. P2."
+    },
+    "LAB-040": {
+      "id": "LAB-040",
+      "title": "Course planning surface on Director's Desk drawer",
+      "status": "backlog",
+      "priority": "P3",
+      "area": "director-desk",
+      "brief": "Course planning form lives as a top-level toolbar tab. Consider also surfacing course state inside Director's Desk's drawer as a cross-cutting strategic surface.",
+      "full": "The Course planning form and Hex Map currently live as a separate toolbar tab (Course / Map). Director's Desk is the strategic home — where cross-cutting work lives. An open design question: should a condensed version of the current Course state (frontier items, active leg, P0s) also appear in the Director's Desk drawer, so the author doesn't need to switch tabs to orient before a Frame? This would make the Desk a true strategic anchor. Open design call — flag for Quenton. P3 (low urgency; the toolbar tab is working)."
+    },
+    "LAB-041": {
+      "id": "LAB-041",
+      "title": "Hex Map v0.2 (interaction + adjacency)",
+      "status": "backlog",
+      "priority": "P2",
+      "area": "director-desk",
+      "brief": "Hex Map v0.1 is read-only. v0.2: click-to-add-to-frontier, hover details panel, semantic adjacency.",
+      "full": "Hex Map v0.1 (commit c554317, Step 0b of the rogaine-spine arc) is read-only — biome/fog/glow/halo are rendered but not interactive. v0.2 targets: (1) click-to-add-to-frontier — clicking a hex opens a picker of that area's items to add to course.frontier[]; (2) hover details panel — hovering a hex shows item count, P0 count, active leg count, most recent Log entry title; (3) semantic adjacency — items from related areas are placed near each other on the map, not just grouped by area. Adjacency is a design call for Quenton (what makes two areas semantically adjacent in this lab?). P2 — the read-only map is valuable; interaction is quality-of-life."
     }
   }
 }

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -518,6 +518,120 @@
     text-align: center;
   }
   .bc-canvas-hint strong { color: var(--accent); }
+  /* Build lens 2-col layout (Move 3c): canvas on the left, tool drawer
+     on the right. Drawer is a scrollable list of items grouped by area
+     (biome). Click an item to take it "in hand" — Move 3d wires the
+     placement mechanic; today the click just acks. */
+  .bc-build-layout {
+    display: grid;
+    grid-template-columns: 1fr 230px;
+    gap: 12px;
+    align-items: start;
+  }
+  @media (max-width: 720px) {
+    .bc-build-layout { grid-template-columns: 1fr; }
+  }
+  .bc-drawer {
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-bd);
+    border-radius: 8px;
+    padding: 10px 12px;
+    max-height: 520px;
+    overflow-y: auto;
+  }
+  .bc-drawer-title {
+    font-family: var(--font-px);
+    font-size: 10px;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    color: var(--accent);
+    margin: 0 0 4px;
+  }
+  .bc-drawer-sub {
+    font-family: var(--font-px);
+    font-size: 9.5px;
+    color: #6f7a90;
+    margin: 0 0 10px;
+    line-height: 1.4;
+  }
+  .bc-drawer-area { margin-bottom: 10px; }
+  .bc-drawer-area-name {
+    font-family: var(--font-px);
+    font-size: 9px;
+    font-weight: bold;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    color: var(--accent-dim);
+    padding: 4px 0;
+    border-bottom: 1px dotted var(--panel-bd);
+    margin-bottom: 4px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .bc-drawer-area-swatch {
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    flex-shrink: 0;
+  }
+  .bc-drawer-area-count {
+    color: #6f7a90;
+    font-weight: normal;
+    margin-left: auto;
+    font-size: 9px;
+  }
+  .bc-drawer-item {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    width: 100%;
+    text-align: left;
+    background: transparent;
+    border: 1px solid transparent;
+    padding: 4px 6px;
+    border-radius: 3px;
+    font-family: inherit;
+    font-size: 11.5px;
+    color: var(--fg);
+    cursor: pointer;
+    margin: 1px 0;
+    line-height: 1.35;
+  }
+  .bc-drawer-item:hover {
+    background: rgba(226,160,74,0.08);
+    border-color: var(--accent-dim);
+  }
+  .bc-drawer-item-id {
+    font-family: var(--font-px);
+    font-size: 9.5px;
+    color: var(--accent-dim);
+    flex-shrink: 0;
+    min-width: 24px;
+  }
+  .bc-drawer-item-title {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .bc-drawer-item-pri {
+    font-family: var(--font-px);
+    font-size: 8.5px;
+    padding: 0 3px;
+    border-radius: 2px;
+    flex-shrink: 0;
+  }
+  .bc-drawer-item-pri.P0 { background: #c25450; color: #fff; }
+  .bc-drawer-item-pri.P1 { background: rgba(212,160,48,0.45); color: #fff; }
+  .bc-drawer-item-pri.P2 { background: rgba(94,111,138,0.45); color: #c8c0b4; }
+  .bc-drawer-empty {
+    color: #6f7a90;
+    font-style: italic;
+    font-size: 11px;
+    padding: 8px 6px;
+  }
   /* By-function lens (restored from v0.2): clustered biome regions. */
   .hex-region-bg {
     fill-opacity: 0.06;
@@ -8702,7 +8816,7 @@
     // "A1", "B7", etc — snap-circuit board convention.
     return BC_ROW_LETTERS[row] + (col + 1);
   }
-  function renderCourseLensBuild(slot /*, items, frontierSet, workingSet */) {
+  function renderCourseLensBuild(slot, items /*, frontierSet, workingSet */) {
     const w = BC_LABEL_PAD * 2 + BC_COLS * BC_CELL;
     const h = BC_LABEL_PAD + BC_ROWS * BC_CELL + 8;
 
@@ -8740,26 +8854,82 @@
       cells.push(`</g>`);
     }
 
+    // ── Drawer: items grouped by area (biome) ──
+    // Move 3c renders all items as not-yet-placed; Move 3d wires
+    // course.build_positions and filters the drawer by what's still
+    // un-placed.
+    const placedSet = new Set(); // populated by Move 3d
+    const drawerItems = (items || []).filter(it => !placedSet.has(it.id));
+    const byArea = new Map();
+    drawerItems.forEach(it => {
+      const aId = it.areaId || '__orphan';
+      if (!byArea.has(aId)) {
+        byArea.set(aId, { areaId: aId, areaName: it.areaName || aId, items: [] });
+      }
+      byArea.get(aId).items.push(it);
+    });
+    byArea.forEach(g => {
+      g.items.sort((a, b) => {
+        const pa = priorityRank(a.priority) - priorityRank(b.priority);
+        if (pa !== 0) return pa;
+        const sa = statusRank(a.status) - statusRank(b.status);
+        if (sa !== 0) return sa;
+        return (a.id || '').localeCompare(b.id || '');
+      });
+    });
+    const sortedAreas = Array.from(byArea.values())
+      .sort((a, b) => (a.areaName || '').localeCompare(b.areaName || ''));
+
+    const drawerInner = sortedAreas.length === 0
+      ? '<div class="bc-drawer-empty">All items placed.</div>'
+      : sortedAreas.map(g => {
+          const accent = (AREA_VISUALS[g.areaId] && AREA_VISUALS[g.areaId].accent) || 'dark';
+          const color = HEX_ACCENT_FILL[accent] || HEX_ACCENT_FILL.dark;
+          const itemsHTML = g.items.map(it => {
+            const idShort = (it.id || '').replace(/^LAB-/, '');
+            const pri = it.priority || 'P2';
+            return `<button type="button" class="bc-drawer-item" data-item="${escapeHTML(it.id)}" title="${escapeHTML(it.areaName || '')}: ${escapeHTML(it.title || '')}">
+              <span class="bc-drawer-item-id">${escapeHTML(idShort)}</span>
+              <span class="bc-drawer-item-title">${escapeHTML(it.title || '(no title)')}</span>
+              <span class="bc-drawer-item-pri ${pri}">${pri}</span>
+            </button>`;
+          }).join('');
+          return `<div class="bc-drawer-area">
+            <div class="bc-drawer-area-name">
+              <span class="bc-drawer-area-swatch" style="background:${color}"></span>
+              ${escapeHTML(g.areaName)}
+              <span class="bc-drawer-area-count">${g.items.length}</span>
+            </div>
+            ${itemsHTML}
+          </div>`;
+        }).join('');
+
     slot.innerHTML = `
-      <p class="course-hexmap-sub">Build · empty canvas (snap-circuit board, ${BC_ROWS}×${BC_COLS} = ${BC_ROWS * BC_COLS} cells). Cells are clickable but inert until the tool drawer + click-to-place mechanic land in Moves 3c–3d.</p>
-      <div class="bc-canvas-wrap">
-        <svg class="bc-canvas" viewBox="0 0 ${w} ${h}" preserveAspectRatio="xMidYMid meet" role="grid" aria-label="Build canvas: ${BC_ROWS}×${BC_COLS} grid, currently empty.">
-          ${colLabels.join('')}
-          ${rowLabels.join('')}
-          ${cells.join('')}
-        </svg>
+      <p class="course-hexmap-sub">Build · empty canvas + tool drawer. Click a cell or item to confirm interaction (real click-to-place lands in Move 3d).</p>
+      <div class="bc-build-layout">
+        <div class="bc-canvas-wrap">
+          <svg class="bc-canvas" viewBox="0 0 ${w} ${h}" preserveAspectRatio="xMidYMid meet" role="grid" aria-label="Build canvas: ${BC_ROWS}×${BC_COLS} grid, currently empty.">
+            ${colLabels.join('')}
+            ${rowLabels.join('')}
+            ${cells.join('')}
+          </svg>
+        </div>
+        <div class="bc-drawer" aria-label="Item drawer">
+          <p class="bc-drawer-title">Tool drawer · ${drawerItems.length} items</p>
+          <p class="bc-drawer-sub">Pieces grouped by area. Click an item to take it in hand (Move 3d wires placement).</p>
+          ${drawerInner}
+        </div>
       </div>
-      <p class="bc-canvas-hint">Coming in 3c–3e: <strong>tool drawer</strong> (item palette) · <strong>click-to-place</strong> · <strong>template apply</strong> (frontier as starting position).</p>
+      <p class="bc-canvas-hint">Coming in 3d–3e: <strong>click-to-place</strong> · <strong>template apply</strong> (frontier as starting position).</p>
     `;
 
-    // Inert click handler — acknowledges interactions until 3d wires the
-    // real placement mechanic. Click any cell to confirm grid is alive.
+    // Inert click handlers — acknowledge interactions until 3d wires the
+    // real placement mechanic.
     const svg = slot.querySelector('svg.bc-canvas');
     if (svg) {
       svg.addEventListener('click', (e) => {
         const cell = e.target && e.target.closest ? e.target.closest('.bc-cell') : null;
         if (!cell) return;
-        // Visual ping: flash the cell border briefly.
         const bg = cell.querySelector('.bc-cell-bg');
         if (!bg) return;
         bg.style.transition = 'none';
@@ -8769,6 +8939,22 @@
           bg.style.transition = '';
           bg.style.fill   = '';
           bg.style.stroke = '';
+        }, 180);
+      });
+    }
+    const drawer = slot.querySelector('.bc-drawer');
+    if (drawer) {
+      drawer.addEventListener('click', (e) => {
+        const btn = e.target && e.target.closest ? e.target.closest('.bc-drawer-item') : null;
+        if (!btn) return;
+        // Visual ack: brief border pulse on the clicked item.
+        btn.style.transition = 'none';
+        btn.style.borderColor = 'var(--accent)';
+        btn.style.background  = 'rgba(226,160,74,0.18)';
+        setTimeout(() => {
+          btn.style.transition  = '';
+          btn.style.borderColor = '';
+          btn.style.background  = '';
         }, 180);
       });
     }

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -425,6 +425,27 @@
   @media (prefers-reduced-motion: reduce) {
     .hex-cell.breathing { animation: none; }
   }
+  /* Hex hover tooltip (Move 1): instant HTML tooltip layer. Native SVG
+     <title> tooltips have a ~1 sec delay; this surfaces immediately on
+     mouseenter and follows the cursor. Native <title> stays in the DOM
+     for screen-reader accessibility. */
+  .hex-tooltip {
+    position: fixed;
+    z-index: 100;
+    background: rgba(0,0,0,0.92);
+    color: var(--fg);
+    font-family: var(--font-px);
+    font-size: 11.5px;
+    padding: 6px 10px;
+    border-radius: 4px;
+    border: 1px solid var(--panel-bd);
+    pointer-events: none;
+    max-width: 360px;
+    line-height: 1.45;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.5);
+    white-space: normal;
+  }
+  .hex-tooltip[hidden] { display: none; }
   /* Ring bands — faint concentric circles behind the hex spiral. Help the
      eye see the priority structure (P0 ring, P1 ring, P2 ring) without
      drawing strong borders that compete with the hexes. */
@@ -8600,7 +8621,8 @@
       </div>
     `;
 
-    // Single-pulse-on-select wiring (unchanged from v0.2).
+    // Single-pulse-on-select wiring (unchanged from v0.2) + Move 1 hover
+    // tooltip. Listeners attach fresh after each render (innerHTML wipes them).
     const svg = wrap.querySelector('svg');
     if (svg) {
       svg.addEventListener('click', (e) => {
@@ -8613,6 +8635,46 @@
       svg.addEventListener('animationend', (e) => {
         if (e.target && e.target.classList && e.target.classList.contains('pulse-once')) {
           e.target.classList.remove('pulse-once');
+        }
+      });
+
+      // Move 1: instant HTML tooltip layer. Lazily create a single tooltip
+      // div on the body; reuse across re-renders so we don't leak DOM nodes.
+      let tooltip = document.getElementById('hex-tooltip');
+      if (!tooltip) {
+        tooltip = document.createElement('div');
+        tooltip.id = 'hex-tooltip';
+        tooltip.className = 'hex-tooltip';
+        tooltip.hidden = true;
+        document.body.appendChild(tooltip);
+      }
+      svg.addEventListener('mouseover', (e) => {
+        const tgt = e.target;
+        if (!tgt || !tgt.classList || !tgt.classList.contains('hex-cell')) return;
+        const titleEl = tgt.querySelector('title');
+        if (!titleEl) return;
+        // Use textContent (already escapeHTML-safe; <title> only stores text).
+        tooltip.textContent = titleEl.textContent;
+        tooltip.hidden = false;
+      });
+      svg.addEventListener('mousemove', (e) => {
+        if (tooltip.hidden) return;
+        // Position offset from the cursor; nudge above/left when near the
+        // viewport edges so the tooltip stays fully visible.
+        const pad = 14;
+        const tw = tooltip.offsetWidth || 240;
+        const th = tooltip.offsetHeight || 32;
+        let x = e.clientX + pad;
+        let y = e.clientY + pad;
+        if (x + tw > window.innerWidth - 8)  x = e.clientX - tw - pad;
+        if (y + th > window.innerHeight - 8) y = e.clientY - th - pad;
+        tooltip.style.left = x + 'px';
+        tooltip.style.top  = y + 'px';
+      });
+      svg.addEventListener('mouseout', (e) => {
+        const tgt = e.target;
+        if (tgt && tgt.classList && tgt.classList.contains('hex-cell')) {
+          tooltip.hidden = true;
         }
       });
     }

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -4631,6 +4631,12 @@
       ],
       "chunks": [
         {
+          "id": "chunk-hex-map-v03",
+          "title": "Hex Map v0.3 — concentric rings, Okabe-Ito palette, map legend, genus:species hover",
+          "summary": "Concentric rings carry priority (P0 center → P1 → P2). Okabe-Ito color-blind-safe palette with an explicit map legend (area → color, like a geographic map). Genus:species hover reveals item identity. Red P0 stroke and per-hex LAB-### labels dropped.",
+          "body": "The author dogfooded Hex Map v0.2 and found the red P0 borders distracting — the stroke was fighting the biome color in the same visual layer. The fix: **spatial position carries priority instead of stroke**. Concentric rings encode the three priority tiers: P0 items occupy the center ring, P1 the next ring out, P2 the outermost. You read priority by how close to center a zone sits, not by what color its border is. The red stroke is gone.\n\nThe palette moves to **Okabe-Ito** — the color-blind-safe eight-color scheme standard in scientific publishing. Rather than asking the reader to infer what each color means from context, v0.3 adds an **explicit map legend**: each area is listed with its color swatch, the way a geographic map lists what blue means (water) or what green means (forest). The map tells its own story; the legend locks it.\n\nHover reveals **genus:species identity** — the area name (genus) and the specific item or sub-record (species). This replaces the old approach of baking LAB-### labels directly into the hex face. The hex face carries only its color signal; the hover reveals what lives there. This frees the hex from label clutter and makes the priority-ring encoding readable without text competing for the same space.\n\nTwo commits: `6c40ddb` (concentric rings + Okabe-Ito palette + map legend + genus:species hover) and `664e479` (fixes: drop dead .pulse-once.p0 rule, escape priority/status, document palette collision)."
+        },
+        {
           "id": "chunk-four-channel-hex-encoding",
           "title": "Four-channel Hex Map encoding — hue, luminosity, stroke, motion",
           "summary": "Hex Map v0.2 assigns each cognitive job its own visual primitive: hue=biome, luminosity=relevance, stroke=priority, motion=attention. Stops overloading hue.",

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -400,6 +400,84 @@
     display: inline-block;
   }
 
+  /* ── Comprehend (on-demand re-immersion notes attached to the active leg) ── */
+  .course-comprehend {
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-bd);
+    border-radius: 6px;
+    padding: 14px 16px;
+    max-width: 760px;
+    margin-top: 16px;
+  }
+  .course-comprehend-title {
+    font-family: var(--font-px);
+    font-size: 10px;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    color: var(--accent-dim);
+    margin: 0 0 4px;
+  }
+  .course-comprehend-sub {
+    font-family: var(--font-px);
+    font-size: 10px;
+    color: #6f7a90;
+    margin: 0 0 12px;
+  }
+  .course-comprehend-empty {
+    font-family: var(--font-px);
+    font-size: 11px;
+    color: #6f7a90;
+    font-style: italic;
+    padding: 6px 4px;
+  }
+  .course-comprehend textarea {
+    width: 100%;
+    background: var(--bg);
+    border: 1px solid var(--panel-bd);
+    color: var(--fg);
+    padding: 7px 9px;
+    font-family: inherit;
+    font-size: 13px;
+    line-height: 1.45;
+    border-radius: 4px;
+    resize: vertical;
+    min-height: 56px;
+    box-sizing: border-box;
+  }
+  .course-comprehend textarea:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+  .course-comprehend-actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-top: 8px;
+  }
+  .course-comprehend-log {
+    margin-top: 14px;
+    padding-top: 10px;
+    border-top: 1px solid var(--panel-bd);
+  }
+  .course-comprehend-entry {
+    padding: 6px 8px;
+    border-left: 2px solid var(--panel-bd);
+    margin: 6px 0;
+    font-size: 12.5px;
+    line-height: 1.45;
+    color: var(--fg);
+    background: rgba(255,255,255,0.02);
+  }
+  .course-comprehend-entry .cc-when {
+    display: block;
+    font-family: var(--font-px);
+    font-size: 9.5px;
+    letter-spacing: 1px;
+    color: var(--accent-dim);
+    margin-bottom: 3px;
+  }
+
   /* ── Lab tile (shared across alt views) ──
      Each tile pulls its area icon + accent color from the floor,
      so an item visually carries the room it lives in. */
@@ -3398,12 +3476,14 @@
      A Course is a 7-leg arc (one ISO week). Frontier-not-itinerary: the Course
      names what's *reachable* this week; per-leg Frame picks from the frontier.
      Step 0a: planning form (theme / target_outcome / frontier / bail_conditions).
-     Step 0b: Hex Map renders the Map; frontier picks highlight on it. -->
+     Step 0b: Hex Map renders the Map; frontier picks highlight on it.
+     Phase 3: On-demand Comprehend appended to the active leg's comprehend[]. -->
 <div id="course-view" class="alt-view">
   <h2 class="alt-heading">Course · 7-leg arc</h2>
   <p class="alt-sub">A week's planned arc. Set the theme, name the target, declare what's reachable, and the bail conditions. Per-leg Frame picks from the frontier.</p>
   <div id="course-body"></div>
   <div id="course-hexmap" class="course-hexmap"></div>
+  <div id="course-comprehend" class="course-comprehend"></div>
 </div>
 
 <!-- ── Cmd-K palette ── -->
@@ -7255,6 +7335,7 @@
     renderCourseFrontierChips();
     if (courseFrontierPanelOpen) renderCourseFrontierPanel();
     renderCourseHexMap();
+    renderCourseComprehend();
   }
 
   function renderCourseFrontierChips() {
@@ -7412,6 +7493,50 @@
     `;
   }
 
+  /* ── On-demand Comprehend (Phase 3) ──
+     Single textarea + Capture button. Appends a timestamped note to the
+     active leg's comprehend[]. Renders the most-recent-first log below.
+     If no active leg exists yet, prompts the user to start one via Frame. */
+  function fmtComprehendWhen(iso) {
+    if (!iso) return '·';
+    try {
+      const d = new Date(iso);
+      const date = d.toISOString().slice(0, 10);
+      const time = d.toTimeString().slice(0, 5);
+      return date + ' · ' + time;
+    } catch { return iso; }
+  }
+  function renderCourseComprehend() {
+    const wrap = document.getElementById('course-comprehend');
+    if (!wrap) return;
+    const leg = findActiveLeg();
+    if (!leg) {
+      wrap.innerHTML =
+        '<p class="course-comprehend-title">Comprehend</p>' +
+        '<p class="course-comprehend-sub">Re-immersion notes for the active leg. ' +
+        'Capture what just changed, what to load before continuing, what surprised you.</p>' +
+        '<p class="course-comprehend-empty">No active leg yet. Open Frame Workshop and save a card to start a leg, then Comprehend notes attach to it.</p>';
+      return;
+    }
+    const entries = (leg.comprehend || []).slice().reverse(); // newest first
+    const logHTML = entries.length === 0
+      ? '<p class="course-comprehend-empty">No notes yet for ' + escapeHTML(leg.id) + '.</p>'
+      : entries.map(e => `<div class="course-comprehend-entry">
+          <span class="cc-when">${escapeHTML(fmtComprehendWhen(e && e.at))}</span>
+          ${escapeHTML((e && e.text) || '').replace(/\n/g, '<br>')}
+        </div>`).join('');
+    wrap.innerHTML =
+      '<p class="course-comprehend-title">Comprehend · ' + escapeHTML(leg.id) + '</p>' +
+      '<p class="course-comprehend-sub">Re-immersion notes for the active leg. ' +
+      'Capture what just changed, what to load before continuing, what surprised you.</p>' +
+      '<textarea id="course-comprehend-input" placeholder="What just changed? What do I need to load? What surprised me?"></textarea>' +
+      '<div class="course-comprehend-actions">' +
+        '<button type="button" id="course-comprehend-capture" class="ff-btn primary">Capture note</button>' +
+        '<span class="ff-saved" id="course-comprehend-saved">✓ saved</span>' +
+      '</div>' +
+      '<div class="course-comprehend-log">' + logHTML + '</div>';
+  }
+
   // Delegated handlers for the Course view (inputs + frontier picker + save).
   document.getElementById('course-view').addEventListener('click', (e) => {
     const tgt = e.target;
@@ -7436,6 +7561,19 @@
       c.bail_conditions = bailEl   ? bailEl.value.trim()   : '';
       upsertCourse(c);
       flashSaved('course-saved');
+      return;
+    }
+    if (tgt.id === 'course-comprehend-capture') {
+      const ta = document.getElementById('course-comprehend-input');
+      const text = ta ? ta.value.trim() : '';
+      if (!text) return;
+      const leg = findActiveLeg();
+      if (!leg) return; // form is hidden when no active leg, but guard anyway
+      leg.comprehend = Array.isArray(leg.comprehend) ? leg.comprehend.slice() : [];
+      leg.comprehend.push({ at: new Date().toISOString(), text: text });
+      upsertLeg(leg);
+      flashSaved('course-comprehend-saved');
+      renderCourseComprehend();
       return;
     }
     const removeBtn = tgt.closest('[data-act="frontier-remove"]');

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -431,7 +431,10 @@
      for screen-reader accessibility. */
   .hex-tooltip {
     position: fixed;
-    z-index: 100;
+    /* z-index above #toolbar (200), drawer-overlay (300), drawer (400);
+       below the cmd-K palette (1000). Otherwise the tooltip hides behind
+       the sticky toolbar when hexes near the top of the map are hovered. */
+    z-index: 450;
     background: rgba(0,0,0,0.92);
     color: var(--fg);
     font-family: var(--font-px);
@@ -8558,9 +8561,11 @@
       stateBits.push(escapeHTML(it.priority || ''));
       stateBits.push(escapeHTML(it.status || ''));
       const stateText = stateBits.length > 0 ? ' · ' + stateBits.join(' · ') : '';
-      return `<polygon class="${classes.join(' ')}" data-item="${escapeHTML(it.id)}" points="${points}" fill="${fill}" fill-opacity="${opacity}">
-        <title>${escapeHTML(genus)}: ${escapeHTML(species)}${stateText}</title>
-      </polygon>`;
+      // Move 1: store the tooltip text in aria-label (not <title>) so the
+      // native browser tooltip doesn't fire after 1 sec on top of our
+      // instant HTML tooltip. Screen readers still announce aria-label.
+      const labelText = escapeHTML(genus) + ': ' + escapeHTML(species) + stateText;
+      return `<polygon class="${classes.join(' ')}" data-item="${escapeHTML(it.id)}" points="${points}" fill="${fill}" fill-opacity="${opacity}" role="img" aria-label="${labelText}"></polygon>`;
     });
 
     // ── Ring-band guides (faint dashed circles + ring labels) ──
@@ -8651,10 +8656,13 @@
       svg.addEventListener('mouseover', (e) => {
         const tgt = e.target;
         if (!tgt || !tgt.classList || !tgt.classList.contains('hex-cell')) return;
-        const titleEl = tgt.querySelector('title');
-        if (!titleEl) return;
-        // Use textContent (already escapeHTML-safe; <title> only stores text).
-        tooltip.textContent = titleEl.textContent;
+        // Read from aria-label (was: <title>'s textContent, but that triggered
+        // a duplicate native browser tooltip after 1 sec). aria-label gives
+        // both screen-reader accessibility and our instant tooltip from one
+        // attribute, with no native-browser tooltip layer competing.
+        const label = tgt.getAttribute('aria-label');
+        if (!label) return;
+        tooltip.textContent = label;
         tooltip.hidden = false;
       });
       svg.addEventListener('mousemove', (e) => {

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -783,6 +783,32 @@
     pointer-events: none;
   }
 
+  /* Comprehend Workshop (Move 2). Phases fill in across 2a-2e. */
+  #ws-comprehend-content { display: flex; flex-direction: column; gap: 12px; }
+  .comp-placeholder {
+    background: var(--panel-bg);
+    border: 1px dashed var(--panel-bd);
+    border-radius: 6px;
+    padding: 28px 20px;
+    text-align: center;
+  }
+  .comp-placeholder-title {
+    font-family: var(--font-px);
+    font-size: 12px;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    color: var(--accent);
+    margin: 0 0 8px;
+  }
+  .comp-placeholder-sub {
+    font-family: var(--font-px);
+    font-size: 11px;
+    color: #6f7a90;
+    margin: 4px 0;
+    line-height: 1.5;
+  }
+
   /* Hex hover tooltip (Move 1): instant HTML tooltip layer. Native SVG
      <title> tooltips have a ~1 sec delay; this surfaces immediately on
      mouseenter and follows the cursor. Native <title> stays in the DOM
@@ -4191,18 +4217,20 @@
     </div>
   </div>
 
-  <!-- Band 2: Phase cycle (single visual each) -->
+  <!-- Band 2: Phase cycle (single visual each).
+       Move 2a (v0.4 build): Comprehend leads. Per the C-before-F call —
+       you can't scope what you haven't read in. Frame follows. -->
   <div class="band band-phase">
+    <div class="area area-visual" data-area="comprehend-station" data-accent="amber">
+      <div class="area-scene">🛠️</div>
+      <div class="area-label">Comprehend<span class="lbl-sub">orient first</span></div>
+      <div class="badge-row" id="badges-comprehend-station"></div>
+    </div>
+    <div class="arrow">→</div>
     <div class="area area-visual" data-area="frame-workshop" data-accent="blue">
       <div class="area-scene">🖼️</div>
       <div class="area-label">Frame<span class="lbl-sub">required</span></div>
       <div class="badge-row" id="badges-frame-workshop"></div>
-    </div>
-    <div class="arrow">→</div>
-    <div class="area area-visual" data-area="comprehend-station" data-accent="amber">
-      <div class="area-scene">🛠️</div>
-      <div class="area-label">Comprehend<span class="lbl-sub">conditional</span></div>
-      <div class="badge-row" id="badges-comprehend-station"></div>
     </div>
     <div class="arrow">→</div>
     <div class="area area-visual" data-area="sync-floor" data-accent="amber">
@@ -4638,6 +4666,19 @@
 
       </div>
 
+      <!-- COMPREHEND STATION (Move 2 v0.4 build).
+           Workshop content for the orientation room. Phases land here:
+             2a — placeholder + open-via-workshop wiring (this file).
+             2b — "Where you are" snapshot at the top.
+             2c — Sidebar + main split with deck walks.
+             2d — Product walks with iframe + walk-mode banner.
+             2e — Walk logging + polish folds.
+           Sibling block to ws-debrief-content; openDrawer toggles it. -->
+      <div id="ws-comprehend-content" style="display:none">
+        <div id="comp-snapshot"></div>
+        <div id="comp-walk-studio"></div>
+      </div>
+
     </div>
 
     <!-- Area view (bottom half — floor: four tiles, content swaps below) -->
@@ -4826,9 +4867,10 @@
     {
       "id": "comprehend-station",
       "name": "Comprehend Station",
-      "type": "phase / conditional",
+      "type": "phase / required",
       "accent": "amber",
-      "description": "Where Comprehend practice and chapter live. The phase that loads remaining state from agents and prior work.",
+      "workshop": true,
+      "description": "Where the lab orients you. Re-immerse on prior legs, walk decks, take guided product walks of new features. The phase that loads remaining state from agents and prior work — first step in the cycle (C-before-F).",
       "items": ["LAB-009","LAB-010","LAB-044","LAB-046"],
       "artifacts": [
         { "label": "turn-v0.1-phases-and-leverage.md (Comprehend section)", "href": "turn-v0.1-phases-and-leverage.md" }
@@ -5878,6 +5920,7 @@
     const frameModes = document.querySelectorAll('#workshop-view > .ws-mode');
     const pilotContent = document.getElementById('ws-pilot-content');
     const debriefContent = document.getElementById('ws-debrief-content');
+    const comprehendContent = document.getElementById('ws-comprehend-content');
     if (area.workshop) {
       drawer.classList.add('workshop');
       wsView.classList.add('visible');
@@ -5888,14 +5931,23 @@
         frameModes.forEach(el => el.style.display = 'none');
         if (pilotContent) pilotContent.style.display = 'block';
         if (debriefContent) debriefContent.style.display = 'none';
+        if (comprehendContent) comprehendContent.style.display = 'none';
         initPilotCheckWorkshop();
       } else if (areaId === 'debrief-booth') {
         frameModes.forEach(el => el.style.display = 'none');
         if (pilotContent) pilotContent.style.display = 'none';
         if (debriefContent) debriefContent.style.display = 'block';
+        if (comprehendContent) comprehendContent.style.display = 'none';
         initDebriefWorkshop();
+      } else if (areaId === 'comprehend-station') {
+        frameModes.forEach(el => el.style.display = 'none');
+        if (pilotContent) pilotContent.style.display = 'none';
+        if (debriefContent) debriefContent.style.display = 'none';
+        if (comprehendContent) comprehendContent.style.display = 'block';
+        initComprehendWorkshop();
       } else {
         frameModes.forEach(el => el.style.display = '');
+        if (comprehendContent) comprehendContent.style.display = 'none';
         if (pilotContent) pilotContent.style.display = 'none';
         if (debriefContent) debriefContent.style.display = 'none';
         if (areaId === 'frame-workshop') initFrameWorkshop();
@@ -5907,6 +5959,7 @@
       frameModes.forEach(el => el.style.display = '');
       if (pilotContent) pilotContent.style.display = 'none';
       if (debriefContent) debriefContent.style.display = 'none';
+      if (comprehendContent) comprehendContent.style.display = 'none';
     }
 
     showAreaView(area);
@@ -7837,6 +7890,33 @@
   }
 
   function initDebriefWorkshop() { dbEnterResting(); }
+
+  /* ── Comprehend Workshop (Move 2 v0.4 build) ──
+     The orientation room. Phases land here:
+       2a — placeholder + open-via-workshop wiring (this file).
+       2b — "Where you are" snapshot at the top.
+       2c — Sidebar + main split with deck walks.
+       2d — Product walks with iframe + walk-mode banner.
+       2e — Walk logging + polish folds.
+     Each render rebuilds the workshop content from scratch (matches
+     the renderCourseHexMap pattern; cheap at this scale, no listener
+     leaks). */
+  function initComprehendWorkshop() {
+    renderComprehendWorkshop();
+  }
+  function renderComprehendWorkshop() {
+    const snapshot = document.getElementById('comp-snapshot');
+    const studio = document.getElementById('comp-walk-studio');
+    if (!snapshot || !studio) return;
+    // 2a placeholder. 2b will fill snapshot; 2c-2e will fill studio.
+    snapshot.innerHTML =
+      '<div class="comp-placeholder">' +
+        '<p class="comp-placeholder-title">Comprehend Station</p>' +
+        '<p class="comp-placeholder-sub">Orientation room. The lab\'s "where am I, what just happened" surface.</p>' +
+        '<p class="comp-placeholder-sub">Building across Moves 2a–2e: snapshot · walk studio · iframe walks · walk logging.</p>' +
+      '</div>';
+    studio.innerHTML = '';
+  }
 
   // Wire debrief controls (bound once at load)
   (function wireDebrief() {

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -403,11 +403,6 @@
     100% { filter: brightness(1.0); }
   }
   .hex-cell.pulse-once { animation: hex-pulse-once 600ms ease-out; }
-  .hex-cell.pulse-once.p0 {
-    /* Preserve P0 drop-shadow during the pulse animation by stacking
-       the brightness filter via a second filter layer on the keyframe. */
-    animation: hex-pulse-once 600ms ease-out;
-  }
   /* Ambient breath on the active leg's working set. Slow ±5% opacity
      oscillation so peripheral vision picks up "something's alive over
      there" without the focused eye seeing motion. */
@@ -8337,6 +8332,14 @@
     tan:    '#CC79A7',  // Okabe-Ito reddish purple
     warm:   '#F0E442',  // Okabe-Ito yellow
     dark:   '#888888',  // neutral gray (Okabe-Ito uses black; lighter for our dark bg)
+    // Fallbacks for legacy accent keys not currently used by any area.
+    // PALETTE COLLISION RISK: orange + red both map to vermillion (#D55E00),
+    // and tan + purple both map to reddish purple (#CC79A7). If a future area
+    // uses `red` or `purple` as its accent alongside `orange` or `tan`, the
+    // legend will show duplicate colors. Audit area accents before adding new
+    // ones; if a real conflict appears, remap these to a non-Okabe-Ito hue
+    // (or pick one to retire). No conflict in current data (only blue, amber,
+    // green, dark, tan, warm, orange, teal are in use).
     red:    '#D55E00',  // collapse to vermillion
     purple: '#CC79A7'   // collapse to reddish purple
   };
@@ -8522,8 +8525,11 @@
       const stateBits = [];
       if (isActive)    stateBits.push('in active leg');
       if (inFrontier)  stateBits.push('in frontier');
-      stateBits.push(it.priority);
-      stateBits.push(it.status);
+      // priority/status come from controlled JSON today, but escape anyway for
+      // consistency with genus/species — defends against hand-edited JSON
+      // values containing `<` from silently breaking the SVG title node.
+      stateBits.push(escapeHTML(it.priority || ''));
+      stateBits.push(escapeHTML(it.status || ''));
       const stateText = stateBits.length > 0 ? ' · ' + stateBits.join(' · ') : '';
       return `<polygon class="${classes.join(' ')}" data-item="${escapeHTML(it.id)}" points="${points}" fill="${fill}" fill-opacity="${opacity}">
         <title>${escapeHTML(genus)}: ${escapeHTML(species)}${stateText}</title>

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -425,6 +425,74 @@
   @media (prefers-reduced-motion: reduce) {
     .hex-cell.breathing { animation: none; }
   }
+  /* Course view lens tabs (Move 3a): three lenses on the same data —
+     Build (user-placed canvas, default), By function (biome view, v0.2
+     restored), By priority (concentric rings, v0.3). The user owns one
+     placement; lenses are read-only re-projections. */
+  .course-hexmap-tabs {
+    display: flex;
+    gap: 4px;
+    margin: 6px 0 10px;
+    border-bottom: 1px solid var(--panel-bd);
+  }
+  .ch-tab {
+    background: transparent;
+    border: 1px solid transparent;
+    border-bottom: none;
+    padding: 6px 12px;
+    font-family: var(--font-px);
+    font-size: 10.5px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    color: var(--accent-dim);
+    cursor: pointer;
+    border-radius: 4px 4px 0 0;
+    margin-bottom: -1px;
+  }
+  .ch-tab:hover { color: var(--fg); }
+  .ch-tab.active {
+    color: var(--accent);
+    border-color: var(--panel-bd);
+    border-bottom-color: var(--panel-bg);
+    background: var(--panel-bg);
+  }
+  /* Build canvas placeholder (Move 3a). Fills out across 3b–3e. */
+  .course-build-placeholder {
+    background: var(--panel-bg);
+    border: 1px dashed var(--panel-bd);
+    border-radius: 6px;
+    padding: 32px 24px;
+    text-align: center;
+    color: #6f7a90;
+    font-family: var(--font-px);
+    font-size: 12px;
+    line-height: 1.6;
+  }
+  .course-build-placeholder strong { color: var(--accent); }
+  /* By-function lens (restored from v0.2): clustered biome regions. */
+  .hex-region-bg {
+    fill-opacity: 0.06;
+    stroke-opacity: 0.45;
+    stroke-width: 1;
+  }
+  .hex-region-label {
+    font-family: var(--font-px);
+    font-size: 9.5px;
+    font-weight: bold;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    fill: var(--accent-dim);
+    dominant-baseline: hanging;
+    pointer-events: none;
+  }
+  .hex-region-count {
+    font-family: var(--font-px);
+    font-size: 9px;
+    fill: #6f7a90;
+    dominant-baseline: hanging;
+    pointer-events: none;
+  }
+
   /* Hex hover tooltip (Move 1): instant HTML tooltip layer. Native SVG
      <title> tooltips have a ~1 sec delay; this surfaces immediately on
      mouseenter and follows the cursor. Native <title> stays in the DOM
@@ -8450,6 +8518,25 @@
     return { x, y };
   }
 
+  /* Course view lens dispatcher (Move 3a).
+     Three lenses on the same course/items data — Build (default; user-
+     placed canvas, fills out across Moves 3b-3e), By function (v0.2
+     biome view restored), By priority (v0.3 concentric rings). User
+     placement persists across lens switches; lenses are projections,
+     not workspaces. */
+  const COURSE_HEX_LENS_KEY = 'cognitive-lab-v0.1::course-hex-lens';
+  const COURSE_HEX_LENSES = ['build', 'function', 'priority'];
+  function loadCourseHexLens() {
+    try {
+      const v = localStorage.getItem(COURSE_HEX_LENS_KEY);
+      return COURSE_HEX_LENSES.includes(v) ? v : 'build';
+    } catch { return 'build'; }
+  }
+  function saveCourseHexLens(v) {
+    try { localStorage.setItem(COURSE_HEX_LENS_KEY, v); } catch {}
+  }
+  let courseHexLens = loadCourseHexLens();
+
   function renderCourseHexMap() {
     const wrap = document.getElementById('course-hexmap');
     if (!wrap) return;
@@ -8457,11 +8544,241 @@
     const frontierSet = new Set(c.frontier || []);
     const workingSet = getActiveLegWorkingSet();
     const items = allItemsArray();
-    if (items.length === 0) {
-      wrap.innerHTML = '<p class="course-hexmap-title">Map</p><p class="course-hexmap-sub">No items in the lab yet.</p>';
+    const inFrontierCount = items.filter(it => frontierSet.has(it.id)).length;
+    const activeCount = workingSet.size;
+    // Outer chrome — header + tabs + content slot. Tabs are stable across
+    // lens switches; only the content slot's innerHTML changes.
+    wrap.innerHTML = `
+      <p class="course-hexmap-title">Map · ${items.length} items · ${inFrontierCount} in frontier · ${activeCount} active in current leg</p>
+      <div class="course-hexmap-tabs" role="tablist" aria-label="Course map lens">
+        <button class="ch-tab${courseHexLens === 'build'    ? ' active' : ''}" data-lens="build"    role="tab">▦ Build</button>
+        <button class="ch-tab${courseHexLens === 'function' ? ' active' : ''}" data-lens="function" role="tab">⛰ By function</button>
+        <button class="ch-tab${courseHexLens === 'priority' ? ' active' : ''}" data-lens="priority" role="tab">◎ By priority</button>
+      </div>
+      <div id="course-hexmap-content"></div>
+    `;
+    // Tab click delegation.
+    wrap.querySelectorAll('.ch-tab').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const lens = btn.dataset.lens;
+        if (lens && COURSE_HEX_LENSES.includes(lens) && lens !== courseHexLens) {
+          courseHexLens = lens;
+          saveCourseHexLens(lens);
+          renderCourseHexMap();
+        }
+      });
+    });
+    // Dispatch to lens.
+    const slot = document.getElementById('course-hexmap-content');
+    if (!items.length) {
+      slot.innerHTML = '<p class="course-hexmap-sub">No items in the lab yet.</p>';
       return;
     }
+    if (courseHexLens === 'priority')      renderCourseLensByPriority(slot, items, frontierSet, workingSet);
+    else if (courseHexLens === 'function') renderCourseLensByFunction(slot, items, frontierSet, workingSet);
+    else                                    renderCourseLensBuild(slot, items, frontierSet, workingSet);
+    // Wire shared SVG listeners (click + tooltip) on whatever SVG ended up
+    // in the slot. Lenses without an SVG (Build placeholder today) skip.
+    wireHexSVGListeners(slot);
+  }
 
+  /* Shared listener wiring used by every lens that renders an SVG with
+     .hex-cell polygons. Click → single-pulse animation. Mouseover →
+     instant HTML tooltip from the polygon's aria-label. */
+  function wireHexSVGListeners(container) {
+    const svg = container.querySelector('svg');
+    if (!svg) return;
+    svg.addEventListener('click', (e) => {
+      const tgt = e.target;
+      if (!tgt || !tgt.classList || !tgt.classList.contains('hex-cell')) return;
+      tgt.classList.remove('pulse-once');
+      void tgt.getBoundingClientRect();
+      tgt.classList.add('pulse-once');
+    });
+    svg.addEventListener('animationend', (e) => {
+      if (e.target && e.target.classList && e.target.classList.contains('pulse-once')) {
+        e.target.classList.remove('pulse-once');
+      }
+    });
+    let tooltip = document.getElementById('hex-tooltip');
+    if (!tooltip) {
+      tooltip = document.createElement('div');
+      tooltip.id = 'hex-tooltip';
+      tooltip.className = 'hex-tooltip';
+      tooltip.hidden = true;
+      document.body.appendChild(tooltip);
+    }
+    svg.addEventListener('mouseover', (e) => {
+      const tgt = e.target;
+      if (!tgt || !tgt.classList || !tgt.classList.contains('hex-cell')) return;
+      const label = tgt.getAttribute('aria-label');
+      if (!label) return;
+      tooltip.textContent = label;
+      tooltip.hidden = false;
+    });
+    svg.addEventListener('mousemove', (e) => {
+      if (tooltip.hidden) return;
+      const pad = 14;
+      const tw = tooltip.offsetWidth || 240;
+      const th = tooltip.offsetHeight || 32;
+      let x = e.clientX + pad;
+      let y = e.clientY + pad;
+      if (x + tw > window.innerWidth - 8)  x = e.clientX - tw - pad;
+      if (y + th > window.innerHeight - 8) y = e.clientY - th - pad;
+      tooltip.style.left = x + 'px';
+      tooltip.style.top  = y + 'px';
+    });
+    svg.addEventListener('mouseout', (e) => {
+      const tgt = e.target;
+      if (tgt && tgt.classList && tgt.classList.contains('hex-cell')) {
+        tooltip.hidden = true;
+      }
+    });
+  }
+
+  /* Build lens (Move 3a stub).
+     Fills out in Move 3b (empty canvas with grid), 3c (tool drawer),
+     3d (click-to-place + persistence), 3e (template apply). */
+  function renderCourseLensBuild(slot /*, items, frontierSet, workingSet */) {
+    slot.innerHTML = `
+      <div class="course-build-placeholder">
+        <p>The <strong>Build canvas</strong> ships across Moves 3b–3e:</p>
+        <p>3b · empty grid (snap-circuit board) → 3c · tool drawer (item palette)<br>
+           3d · click-to-place + persistence → 3e · template apply (current frontier as starting position)</p>
+        <p style="margin-top: 14px;">For now, switch to <strong>By priority</strong> or <strong>By function</strong>.</p>
+      </div>
+    `;
+  }
+
+  /* By-function lens — restored from v0.2.
+     Items grouped into labeled biome regions (one cluster per area).
+     Within a cluster, P0 first, then status rank. Across clusters,
+     biggest-first so dominant biomes anchor the top-left. */
+  function renderCourseLensByFunction(slot, items, frontierSet, workingSet) {
+    const byArea = new Map();
+    items.forEach(it => {
+      const aId = it.areaId || '__orphan';
+      if (!byArea.has(aId)) byArea.set(aId, { areaId: aId, areaName: it.areaName || aId, items: [] });
+      byArea.get(aId).items.push(it);
+    });
+    byArea.forEach(r => {
+      r.items.sort((a, b) => {
+        const pa = priorityRank(a.priority) - priorityRank(b.priority);
+        if (pa !== 0) return pa;
+        const sa = statusRank(a.status) - statusRank(b.status);
+        if (sa !== 0) return sa;
+        return (a.id || '').localeCompare(b.id || '');
+      });
+    });
+    const regions = Array.from(byArea.values()).sort((a, b) => {
+      if (b.items.length !== a.items.length) return b.items.length - a.items.length;
+      return (a.areaName || '').localeCompare(b.areaName || '');
+    });
+    const S = 20;
+    const STEP_X = 1.5 * S;
+    const STEP_Y = Math.sqrt(3) * S;
+    const OFFSET_Y = STEP_Y / 2;
+    const HEX_PAD = 8;
+    const LABEL_H = 14;
+    const REGION_GAP = 12;
+    const CANVAS_W = 740;
+    regions.forEach(r => {
+      const n = r.items.length;
+      const cols = Math.min(3, n);
+      const rows = Math.ceil(n / cols);
+      r.cols = cols;
+      r.rows = rows;
+      r.w = HEX_PAD * 2 + 2 * S + (cols - 1) * STEP_X;
+      const oddOffset = cols > 1 ? OFFSET_Y : 0;
+      r.h = HEX_PAD * 2 + LABEL_H + STEP_Y + (rows - 1) * STEP_Y + oddOffset;
+    });
+    let cursorX = 0, cursorY = 0, rowMaxH = 0, totalH = 0, totalW = 0;
+    regions.forEach(r => {
+      if (cursorX + r.w > CANVAS_W && cursorX > 0) {
+        cursorX = 0;
+        cursorY += rowMaxH + REGION_GAP;
+        rowMaxH = 0;
+      }
+      r.x = cursorX;
+      r.y = cursorY;
+      cursorX += r.w + REGION_GAP;
+      if (r.h > rowMaxH) rowMaxH = r.h;
+      if (cursorY + r.h > totalH) totalH = cursorY + r.h;
+      if (r.x + r.w > totalW) totalW = r.x + r.w;
+    });
+    const finalW = Math.max(totalW + REGION_GAP, CANVAS_W);
+    const finalH = totalH + REGION_GAP;
+    const regionGroups = regions.map(r => {
+      const accent = (AREA_VISUALS[r.areaId] && AREA_VISUALS[r.areaId].accent) || 'dark';
+      const tint = HEX_ACCENT_FILL[accent] || HEX_ACCENT_FILL.dark;
+      const hexes = r.items.map((it, i) => {
+        const col = i % r.cols;
+        const row = Math.floor(i / r.cols);
+        const cx = HEX_PAD + S + col * STEP_X;
+        const cy = HEX_PAD + LABEL_H + (STEP_Y / 2) + row * STEP_Y + (col % 2 ? OFFSET_Y : 0);
+        const itemAccent = (AREA_VISUALS[it.areaId] && AREA_VISUALS[it.areaId].accent) || 'dark';
+        const fill = HEX_ACCENT_FILL[itemAccent] || HEX_ACCENT_FILL.dark;
+        const opacity = hexLuminosityFor(it, frontierSet);
+        const isActive = workingSet.has(it.id);
+        const classes = ['hex-cell'];
+        if (isActive) {
+          classes.push('active');
+          classes.push('breathing');
+        }
+        const points = hexPolygonPoints(cx, cy, S);
+        const genus = it.areaName || '(orphan)';
+        const species = it.title || '(no title)';
+        const inFrontier = frontierSet.has(it.id);
+        const stateBits = [];
+        if (isActive)    stateBits.push('in active leg');
+        if (inFrontier)  stateBits.push('in frontier');
+        stateBits.push(escapeHTML(it.priority || ''));
+        stateBits.push(escapeHTML(it.status || ''));
+        const labelText = escapeHTML(genus) + ': ' + escapeHTML(species) + ' · ' + stateBits.join(' · ');
+        return `<polygon class="${classes.join(' ')}" data-item="${escapeHTML(it.id)}" points="${points}" fill="${fill}" fill-opacity="${opacity}" role="img" aria-label="${labelText}"></polygon>`;
+      }).join('\n');
+      const bg = `<rect class="hex-region-bg" x="0" y="0" width="${r.w}" height="${r.h}" rx="8" ry="8" fill="${tint}" stroke="${tint}" />`;
+      const labelY = HEX_PAD - 2;
+      const label = `<text class="hex-region-label" x="${HEX_PAD}" y="${labelY}">${escapeHTML(r.areaName)}</text>` +
+                    `<text class="hex-region-count" x="${(r.w - HEX_PAD).toFixed(2)}" y="${labelY}" text-anchor="end">${r.items.length}</text>`;
+      return `<g transform="translate(${r.x.toFixed(2)},${r.y.toFixed(2)})">${bg}${label}${hexes}</g>`;
+    }).join('\n');
+    // Area legend (same as priority lens — same data, same encoding).
+    const areaSet = new Map();
+    items.forEach(it => {
+      const k = it.areaId || '__orphan';
+      if (!areaSet.has(k)) {
+        const accent = (AREA_VISUALS[it.areaId] && AREA_VISUALS[it.areaId].accent) || 'dark';
+        areaSet.set(k, {
+          name: it.areaName || k,
+          color: HEX_ACCENT_FILL[accent] || HEX_ACCENT_FILL.dark,
+          count: 0
+        });
+      }
+      areaSet.get(k).count++;
+    });
+    const areasForLegend = Array.from(areaSet.values()).sort((a, b) => a.name.localeCompare(b.name));
+    const legendHTML = areasForLegend.map(a =>
+      `<span class="lg-item"><span class="lg-swatch" style="background:${a.color}"></span>${escapeHTML(a.name)}<span style="color:var(--accent-dim);margin-left:2px;">·${a.count}</span></span>`
+    ).join('');
+    slot.innerHTML = `
+      <p class="course-hexmap-sub">By function · items grouped into biome regions (one cluster per area). Same encoding as Priority lens; different layout.</p>
+      <svg viewBox="0 0 ${finalW.toFixed(2)} ${finalH.toFixed(2)}" preserveAspectRatio="xMidYMid meet" role="img" aria-label="Lab map by function: ${items.length} items grouped into ${regions.length} biome regions.">
+        ${regionGroups}
+      </svg>
+      <div class="course-hexmap-legend">${legendHTML}</div>
+      <div class="course-hexmap-key">
+        <span class="lg-item"><span class="lg-swatch dim"></span>archived</span>
+        <span class="lg-item"><span class="lg-swatch avail"></span>available</span>
+        <span class="lg-item"><span class="lg-swatch front"></span>in frontier</span>
+        <span class="lg-item"><span class="lg-swatch act"></span>active (breathes)</span>
+      </div>
+    `;
+  }
+
+  /* By-priority lens — concentric rings (v0.3 layout).
+     Body lifted from the prior renderCourseHexMap; now a sibling lens. */
+  function renderCourseLensByPriority(slot, items, frontierSet, workingSet) {
     // ── Sort items into priority tiers, then by area within each tier ──
     // Within a tier, same-area items pack adjacently in the spiral.
     // Within an area+tier, status-rank (in-progress first) so the most-
@@ -8608,12 +8925,9 @@
       `<span class="lg-item"><span class="lg-swatch" style="background:${a.color}"></span>${escapeHTML(a.name)}<span style="color:var(--accent-dim);margin-left:2px;">·${a.count}</span></span>`
     ).join('');
 
-    const inFrontierCount = items.filter(it => frontierSet.has(it.id)).length;
-    const activeCount = workingSet.size;
-    wrap.innerHTML = `
-      <p class="course-hexmap-title">Map · ${items.length} items · ${inFrontierCount} in frontier · ${activeCount} active in current leg</p>
-      <p class="course-hexmap-sub">v0.3: rings = priority (P0 center → P1 → P2). Color = area (see legend). Brightness = relevance (archived dim → in-frontier bright → active brightest). The current leg's working items breathe slowly. Hover any hex for the area + item title.</p>
-      <svg viewBox="0 0 ${CANVAS_W.toFixed(2)} ${CANVAS_H.toFixed(2)}" preserveAspectRatio="xMidYMid meet" role="img" aria-label="Lab map: ${items.length} items in concentric rings (P0 center, P1 mid, P2 outer). Color carries area. ${inFrontierCount} in frontier; ${activeCount} active in current leg.">
+    slot.innerHTML = `
+      <p class="course-hexmap-sub">By priority · concentric rings (P0 center → P1 → P2). Color = area. Brightness = relevance.</p>
+      <svg viewBox="0 0 ${CANVAS_W.toFixed(2)} ${CANVAS_H.toFixed(2)}" preserveAspectRatio="xMidYMid meet" role="img" aria-label="Lab map by priority: ${items.length} items in concentric rings (P0 center, P1 mid, P2 outer). Color carries area.">
         ${bands.join('\n')}
         ${cells.join('\n')}
       </svg>
@@ -8625,67 +8939,6 @@
         <span class="lg-item"><span class="lg-swatch act"></span>active (breathes)</span>
       </div>
     `;
-
-    // Single-pulse-on-select wiring (unchanged from v0.2) + Move 1 hover
-    // tooltip. Listeners attach fresh after each render (innerHTML wipes them).
-    const svg = wrap.querySelector('svg');
-    if (svg) {
-      svg.addEventListener('click', (e) => {
-        const tgt = e.target;
-        if (!tgt || !tgt.classList || !tgt.classList.contains('hex-cell')) return;
-        tgt.classList.remove('pulse-once');
-        void tgt.getBoundingClientRect();
-        tgt.classList.add('pulse-once');
-      });
-      svg.addEventListener('animationend', (e) => {
-        if (e.target && e.target.classList && e.target.classList.contains('pulse-once')) {
-          e.target.classList.remove('pulse-once');
-        }
-      });
-
-      // Move 1: instant HTML tooltip layer. Lazily create a single tooltip
-      // div on the body; reuse across re-renders so we don't leak DOM nodes.
-      let tooltip = document.getElementById('hex-tooltip');
-      if (!tooltip) {
-        tooltip = document.createElement('div');
-        tooltip.id = 'hex-tooltip';
-        tooltip.className = 'hex-tooltip';
-        tooltip.hidden = true;
-        document.body.appendChild(tooltip);
-      }
-      svg.addEventListener('mouseover', (e) => {
-        const tgt = e.target;
-        if (!tgt || !tgt.classList || !tgt.classList.contains('hex-cell')) return;
-        // Read from aria-label (was: <title>'s textContent, but that triggered
-        // a duplicate native browser tooltip after 1 sec). aria-label gives
-        // both screen-reader accessibility and our instant tooltip from one
-        // attribute, with no native-browser tooltip layer competing.
-        const label = tgt.getAttribute('aria-label');
-        if (!label) return;
-        tooltip.textContent = label;
-        tooltip.hidden = false;
-      });
-      svg.addEventListener('mousemove', (e) => {
-        if (tooltip.hidden) return;
-        // Position offset from the cursor; nudge above/left when near the
-        // viewport edges so the tooltip stays fully visible.
-        const pad = 14;
-        const tw = tooltip.offsetWidth || 240;
-        const th = tooltip.offsetHeight || 32;
-        let x = e.clientX + pad;
-        let y = e.clientY + pad;
-        if (x + tw > window.innerWidth - 8)  x = e.clientX - tw - pad;
-        if (y + th > window.innerHeight - 8) y = e.clientY - th - pad;
-        tooltip.style.left = x + 'px';
-        tooltip.style.top  = y + 'px';
-      });
-      svg.addEventListener('mouseout', (e) => {
-        const tgt = e.target;
-        if (tgt && tgt.classList && tgt.classList.contains('hex-cell')) {
-          tooltip.hidden = true;
-        }
-      });
-    }
   }
 
   /* Format helper used by both the Comprehend section and the Leg view's

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -808,6 +808,119 @@
     margin: 4px 0;
     line-height: 1.5;
   }
+  /* "Where you are" orientation snapshot (Move 2b). Collapsible at the
+     top of the Comprehend workshop. Compact 4-item read of the lab's
+     current state — designed for re-immerse-in-3-seconds. */
+  .comp-snapshot {
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-bd);
+    border-radius: 6px;
+    overflow: hidden;
+  }
+  .comp-snapshot-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 14px;
+    background: rgba(226,160,74,0.06);
+    border-bottom: 1px solid var(--panel-bd);
+    font-family: var(--font-px);
+    font-size: 10.5px;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    color: var(--accent);
+    cursor: pointer;
+    user-select: none;
+  }
+  .comp-snapshot-header:hover { background: rgba(226,160,74,0.10); }
+  .comp-snapshot-header .comp-snap-toggle {
+    margin-left: auto;
+    color: var(--accent-dim);
+    font-size: 9px;
+    transition: transform 150ms;
+  }
+  .comp-snapshot.collapsed .comp-snap-toggle { transform: rotate(-90deg); }
+  .comp-snapshot.collapsed .comp-snapshot-body { display: none; }
+  .comp-snapshot-body {
+    padding: 12px 14px;
+    display: grid;
+    gap: 10px;
+  }
+  .comp-snap-row {
+    display: grid;
+    grid-template-columns: 110px 1fr;
+    gap: 10px;
+    align-items: baseline;
+  }
+  .comp-snap-label {
+    font-family: var(--font-px);
+    font-size: 9.5px;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--accent-dim);
+  }
+  .comp-snap-val { font-size: 12.5px; color: var(--fg); line-height: 1.45; }
+  .comp-snap-val .comp-snap-id {
+    font-family: var(--font-px);
+    font-size: 11px;
+    color: var(--accent);
+    margin-right: 6px;
+  }
+  .comp-snap-val .comp-snap-status {
+    font-family: var(--font-px);
+    font-size: 9.5px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--accent-dim);
+    padding: 1px 5px;
+    border: 1px solid var(--panel-bd);
+    border-radius: 3px;
+    margin-left: 6px;
+  }
+  .comp-snap-val .comp-snap-empty { color: #6f7a90; font-style: italic; }
+  .comp-snap-recent {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .comp-snap-recent li {
+    font-size: 11.5px;
+    line-height: 1.4;
+    padding: 4px 6px;
+    background: rgba(255,255,255,0.02);
+    border-left: 2px solid var(--panel-bd);
+    cursor: pointer;
+  }
+  .comp-snap-recent li:hover { background: rgba(255,255,255,0.05); }
+  .comp-snap-recent li.cc-note      { border-left-color: rgba(212,160,48,0.55); }
+  .comp-snap-recent li.cc-synthesis { border-left-color: rgba(92,176,154,0.55); }
+  .comp-snap-recent li.cc-deck      { border-left-color: rgba(74,123,212,0.55); }
+  .comp-snap-recent li.cc-walk      { border-left-color: rgba(204,121,167,0.55); }
+  .comp-snap-recent .comp-snap-when {
+    font-family: var(--font-px);
+    font-size: 9.5px;
+    color: var(--accent-dim);
+    margin-right: 6px;
+  }
+  /* Polish: snapshot drilldown (Move 2e fold-in v0.2) — clicking an
+     entry toggles the full body inline. */
+  .comp-snap-recent li.expanded .comp-snap-body {
+    display: block;
+    margin-top: 4px;
+    padding: 4px 6px;
+    background: rgba(255,255,255,0.04);
+    border-radius: 2px;
+    font-size: 11px;
+    color: var(--fg);
+    white-space: pre-wrap;
+    line-height: 1.5;
+  }
+  .comp-snap-recent .comp-snap-body { display: none; }
 
   /* Hex hover tooltip (Move 1): instant HTML tooltip layer. Native SVG
      <title> tooltips have a ~1 sec delay; this surfaces immediately on
@@ -7893,14 +8006,50 @@
 
   /* ── Comprehend Workshop (Move 2 v0.4 build) ──
      The orientation room. Phases land here:
-       2a — placeholder + open-via-workshop wiring (this file).
-       2b — "Where you are" snapshot at the top.
+       2a — placeholder + open-via-workshop wiring.
+       2b — "Where you are" snapshot at the top (this file).
        2c — Sidebar + main split with deck walks.
        2d — Product walks with iframe + walk-mode banner.
        2e — Walk logging + polish folds.
      Each render rebuilds the workshop content from scratch (matches
      the renderCourseHexMap pattern; cheap at this scale, no listener
      leaks). */
+
+  // Compact relative-time formatter for the snapshot. Designed for
+  // re-immerse-glance reads; not for precise reporting. Returns null
+  // for missing input so callers can skip the row.
+  function fmtRelativeTime(iso) {
+    if (!iso) return null;
+    const then = new Date(iso).getTime();
+    if (!isFinite(then)) return null;
+    const now = Date.now();
+    const diff = now - then;
+    if (diff < 0) return 'just now';
+    const sec = Math.floor(diff / 1000);
+    if (sec < 60)        return sec + 's ago';
+    const min = Math.floor(sec / 60);
+    if (min < 60)        return min + 'm ago';
+    const hr = Math.floor(min / 60);
+    if (hr < 24)         return hr + 'h ago';
+    const day = Math.floor(hr / 24);
+    if (day < 7)         return day + 'd ago';
+    const wk = Math.floor(day / 7);
+    if (wk < 5)          return wk + 'w ago';
+    return new Date(iso).toISOString().slice(0, 10);
+  }
+
+  // Snapshot collapse state — sessionStorage so a single dogfood
+  // session preserves the user's preference but a new browser session
+  // starts fresh (snapshot expanded by default — that's the orient case).
+  const COMP_SNAP_COLLAPSED_KEY = 'cognitive-lab-v0.1::comp-snap-collapsed';
+  function isCompSnapCollapsed() {
+    try { return sessionStorage.getItem(COMP_SNAP_COLLAPSED_KEY) === '1'; }
+    catch { return false; }
+  }
+  function setCompSnapCollapsed(v) {
+    try { sessionStorage.setItem(COMP_SNAP_COLLAPSED_KEY, v ? '1' : '0'); } catch {}
+  }
+
   function initComprehendWorkshop() {
     renderComprehendWorkshop();
   }
@@ -7908,13 +8057,117 @@
     const snapshot = document.getElementById('comp-snapshot');
     const studio = document.getElementById('comp-walk-studio');
     if (!snapshot || !studio) return;
-    // 2a placeholder. 2b will fill snapshot; 2c-2e will fill studio.
+
+    // ── "Where you are" snapshot (Move 2b) ──
+    // Four rows: leg + course / recent comprehend / time since / last debrief.
+    const leg = (typeof findActiveLeg === 'function') ? findActiveLeg() : null;
+    const course = (typeof findActiveCourse === 'function') ? findActiveCourse() : null;
+    const collapsed = isCompSnapCollapsed();
+
+    const legRow = leg
+      ? `<div class="comp-snap-row">
+          <span class="comp-snap-label">Active leg</span>
+          <span class="comp-snap-val">
+            <span class="comp-snap-id">${escapeHTML(leg.id)}</span>
+            <span>leg ${leg.leg_number || '?'} of ${COURSE_LEG_COUNT}</span>
+            <span class="comp-snap-status">${escapeHTML(leg.status || 'unknown')}</span>
+          </span>
+        </div>`
+      : `<div class="comp-snap-row">
+          <span class="comp-snap-label">Active leg</span>
+          <span class="comp-snap-val"><span class="comp-snap-empty">No active leg yet — open Frame Workshop and save a card to start one.</span></span>
+        </div>`;
+
+    const courseRow = course
+      ? `<div class="comp-snap-row">
+          <span class="comp-snap-label">Course</span>
+          <span class="comp-snap-val">
+            <span class="comp-snap-id">${escapeHTML(course.id)}</span>
+            <span>${escapeHTML(course.theme || '(no theme yet)')}</span>
+          </span>
+        </div>`
+      : '';
+
+    // Recent comprehend entries: last 3, newest first. Each row
+    // expandable (drilldown polish from Move 2e fold-in v0.2).
+    const entries = (leg && Array.isArray(leg.comprehend))
+      ? leg.comprehend.slice(-3).reverse()
+      : [];
+    const recentRow = leg
+      ? `<div class="comp-snap-row">
+          <span class="comp-snap-label">Last 3 acts</span>
+          <span class="comp-snap-val">${
+            entries.length === 0
+              ? '<span class="comp-snap-empty">No comprehend activity on this leg yet.</span>'
+              : `<ul class="comp-snap-recent">${entries.map((e, i) => {
+                  const p = comprehendEntryParts(e);
+                  return `<li class="cc-${p.kind}" data-idx="${i}" role="button" tabindex="0">
+                    <span class="comp-snap-when">${escapeHTML(fmtComprehendWhen(e && e.at))}</span>
+                    <span class="cc-kind cc-kind-${p.kind}">${escapeHTML(p.label)}</span>
+                    ${p.bodyHTML}
+                    <div class="comp-snap-body">${p.bodyHTML}</div>
+                  </li>`;
+                }).join('')}</ul>`
+          }</span>
+        </div>`
+      : '';
+
+    const lastTouchedAt = leg ? (leg.updatedAt || leg.createdAt) : null;
+    const sinceRel = fmtRelativeTime(lastTouchedAt);
+    const sinceRow = sinceRel
+      ? `<div class="comp-snap-row">
+          <span class="comp-snap-label">Last touched</span>
+          <span class="comp-snap-val">${escapeHTML(sinceRel)}</span>
+        </div>`
+      : '';
+
+    // Last Debrief summary if present. Skip the row entirely when no
+    // debrief — per Quenton, "no debrief yet" is noise.
+    const debriefCard = leg ? findDebriefCardForLeg(leg) : null;
+    const debriefRow = debriefCard
+      ? `<div class="comp-snap-row">
+          <span class="comp-snap-label">Last debrief</span>
+          <span class="comp-snap-val">${escapeHTML((debriefCard.caught || '').slice(0, 220) || '(no caught text)')}</span>
+        </div>`
+      : '';
+
+    snapshot.className = 'comp-snapshot' + (collapsed ? ' collapsed' : '');
     snapshot.innerHTML =
-      '<div class="comp-placeholder">' +
-        '<p class="comp-placeholder-title">Comprehend Station</p>' +
-        '<p class="comp-placeholder-sub">Orientation room. The lab\'s "where am I, what just happened" surface.</p>' +
-        '<p class="comp-placeholder-sub">Building across Moves 2a–2e: snapshot · walk studio · iframe walks · walk logging.</p>' +
-      '</div>';
+      `<div class="comp-snapshot-header" data-act="snap-toggle">
+        ▸ Where you are
+        <span class="comp-snap-toggle">▼</span>
+      </div>` +
+      `<div class="comp-snapshot-body">
+        ${legRow}
+        ${courseRow}
+        ${sinceRow}
+        ${recentRow}
+        ${debriefRow}
+      </div>`;
+
+    // Header toggles collapse state.
+    const header = snapshot.querySelector('[data-act="snap-toggle"]');
+    if (header) {
+      header.addEventListener('click', () => {
+        const next = !snapshot.classList.contains('collapsed');
+        setCompSnapCollapsed(next);
+        snapshot.classList.toggle('collapsed', next);
+      });
+    }
+    // Recent-entry drilldown (polish fold).
+    snapshot.querySelectorAll('.comp-snap-recent li').forEach(li => {
+      li.addEventListener('click', () => {
+        li.classList.toggle('expanded');
+      });
+      li.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          li.classList.toggle('expanded');
+        }
+      });
+    });
+
+    // 2c-2e fill in the studio. Empty for now.
     studio.innerHTML = '';
   }
 

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -128,6 +128,215 @@
     margin: 0 0 14px 0;
   }
 
+  /* ── Course view (the 7-leg arc planning surface) ── */
+  .course-card {
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-bd);
+    border-radius: 6px;
+    padding: 16px 18px;
+    max-width: 760px;
+    margin: 0 0 16px;
+  }
+  .course-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    border-bottom: 1px solid var(--panel-bd);
+    padding-bottom: 10px;
+    margin-bottom: 14px;
+  }
+  .course-id {
+    font-family: var(--font-px);
+    font-size: 12px;
+    font-weight: bold;
+    letter-spacing: 1.5px;
+    color: var(--accent);
+  }
+  .course-status {
+    font-family: var(--font-px);
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--accent-dim);
+    padding: 2px 6px;
+    border: 1px solid var(--panel-bd);
+    border-radius: 3px;
+  }
+  .course-field { margin-bottom: 14px; }
+  .course-field label {
+    display: block;
+    font-family: var(--font-px);
+    font-size: 10.5px;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--accent-dim);
+    margin-bottom: 5px;
+  }
+  .course-field .course-hint {
+    font-family: inherit;
+    font-weight: normal;
+    text-transform: none;
+    letter-spacing: 0;
+    font-size: 10.5px;
+    color: #6f7a90;
+    margin-left: 6px;
+  }
+  .course-field input[type="text"],
+  .course-field textarea {
+    width: 100%;
+    background: var(--bg);
+    border: 1px solid var(--panel-bd);
+    color: var(--fg);
+    padding: 7px 9px;
+    font-family: inherit;
+    font-size: 13px;
+    line-height: 1.45;
+    border-radius: 4px;
+    box-sizing: border-box;
+  }
+  .course-field textarea {
+    resize: vertical;
+    min-height: 56px;
+  }
+  .course-field input[type="text"]:focus,
+  .course-field textarea:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+  .course-frontier-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    min-height: 28px;
+    padding: 5px;
+    background: var(--bg);
+    border: 1px dashed var(--panel-bd);
+    border-radius: 4px;
+    margin-bottom: 6px;
+  }
+  .course-frontier-chips:empty::before {
+    content: 'No frontier items yet — pick from the lab below.';
+    font-size: 11.5px;
+    color: #6f7a90;
+    font-style: italic;
+    padding: 0 4px;
+  }
+  .course-frontier-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 6px 3px 8px;
+    background: rgba(74,123,212,0.14);
+    border: 1px solid rgba(74,123,212,0.45);
+    border-radius: 12px;
+    font-size: 11.5px;
+    color: var(--fg);
+  }
+  .course-frontier-chip .cfc-id {
+    font-family: var(--font-px);
+    font-size: 10px;
+    letter-spacing: 0.5px;
+    color: #6f9ee0;
+    font-weight: bold;
+  }
+  .course-frontier-chip .cfc-x {
+    margin-left: 2px;
+    color: #97a3ba;
+    font-size: 14px;
+    line-height: 1;
+    padding: 0 2px;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+  }
+  .course-frontier-chip .cfc-x:hover { color: #ff7a7a; }
+  .course-frontier-toggle {
+    background: transparent;
+    color: var(--accent-dim);
+    border: 1px solid var(--panel-bd);
+    border-radius: 3px;
+    padding: 4px 8px;
+    font-family: var(--font-px);
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    cursor: pointer;
+  }
+  .course-frontier-toggle:hover { color: var(--fg); }
+  .course-frontier-toggle.open { color: var(--accent); border-color: var(--accent); }
+  .course-frontier-panel {
+    margin-top: 8px;
+    padding: 10px;
+    background: var(--bg);
+    border: 1px solid var(--panel-bd);
+    border-radius: 4px;
+    max-height: 320px;
+    overflow-y: auto;
+  }
+  .course-frontier-section {
+    font-family: var(--font-px);
+    font-size: 9.5px;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    color: var(--accent-dim);
+    margin: 10px 0 5px 0;
+    padding-bottom: 3px;
+    border-bottom: 1px dotted var(--panel-bd);
+  }
+  .course-frontier-section:first-child { margin-top: 0; }
+  .course-frontier-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 6px;
+    border-radius: 3px;
+    cursor: pointer;
+    font-size: 12px;
+  }
+  .course-frontier-row:hover { background: rgba(226,160,74,0.06); }
+  .course-frontier-row.selected { background: rgba(74,123,212,0.10); }
+  .course-frontier-row .cfr-pri {
+    font-family: var(--font-px);
+    font-size: 9px;
+    font-weight: bold;
+    padding: 1px 4px;
+    border-radius: 2px;
+    color: #fff;
+  }
+  .course-frontier-row .cfr-pri.P0 { background: #c25450; }
+  .course-frontier-row .cfr-pri.P1 { background: #c98a3a; }
+  .course-frontier-row .cfr-pri.P2 { background: #5e6f8a; }
+  .course-frontier-row .cfr-id {
+    font-family: var(--font-px);
+    font-size: 10px;
+    color: var(--accent-dim);
+    min-width: 60px;
+  }
+  .course-frontier-row .cfr-title {
+    flex: 1;
+    color: var(--fg);
+  }
+  .course-frontier-row .cfr-stat {
+    font-size: 10px;
+    color: var(--accent-dim);
+  }
+  .course-actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-top: 16px;
+    padding-top: 12px;
+    border-top: 1px solid var(--panel-bd);
+  }
+  .course-meta {
+    margin-top: 10px;
+    font-family: var(--font-px);
+    font-size: 10px;
+    color: var(--accent-dim);
+  }
+
   /* ── Lab tile (shared across alt views) ──
      Each tile pulls its area icon + accent color from the floor,
      so an item visually carries the room it lives in. */
@@ -2915,6 +3124,7 @@
   <h1>🧪 COGNITIVE LAB v0.1</h1>
   <div id="view-toggle" role="tablist" aria-label="Lab view">
     <button class="vt-btn active" data-view="floor"     role="tab">Floor</button>
+    <button class="vt-btn"        data-view="course"    role="tab">Course</button>
     <button class="vt-btn"        data-view="priority"  role="tab">Priority</button>
     <button class="vt-btn"        data-view="timeline"  role="tab">Timeline</button>
     <button class="vt-btn"        data-view="by-status" role="tab">By Status</button>
@@ -3050,6 +3260,16 @@
   <h2 class="alt-heading">By-status view</h2>
   <p class="alt-sub">Kanban-style board. Click any card to open it in the floor drawer.</p>
   <div class="bs-board" id="bs-board"></div>
+</div>
+
+<!-- ── Course view ──
+     A Course is a 7-leg arc (one ISO week). Frontier-not-itinerary: the Course
+     names what's *reachable* this week; per-leg Frame picks from the frontier.
+     Step 0a: planning form stub (theme / target_outcome / frontier / bail_conditions). -->
+<div id="course-view" class="alt-view">
+  <h2 class="alt-heading">Course · 7-leg arc</h2>
+  <p class="alt-sub">A week's planned arc. Set the theme, name the target, declare what's reachable, and the bail conditions. Per-leg Frame picks from the frontier.</p>
+  <div id="course-body"></div>
 </div>
 
 <!-- ── Cmd-K palette ── -->
@@ -4349,12 +4569,14 @@
   const SERVER_SAVE_PATHS = {
     'frame-cards':   '/api/save/frame-cards',
     'debrief-cards': '/api/save/debrief-cards',
-    'pilot-checks':  '/api/save/pilot-checks'
+    'pilot-checks':  '/api/save/pilot-checks',
+    'courses':       '/api/save/courses'
   };
   const SERVER_LOAD_PATHS = {
     'frame-cards':   '/exports/frame-cards.json',
     'debrief-cards': '/exports/debrief-cards.json',
-    'pilot-checks':  '/exports/pilot-checks.json'
+    'pilot-checks':  '/exports/pilot-checks.json',
+    'courses':       '/exports/courses.json'
   };
   function postSave(type, arr) {
     const url = SERVER_SAVE_PATHS[type];
@@ -4382,13 +4604,81 @@
     const pairs = [
       ['frame-cards',   FRAME_KEY],
       ['debrief-cards', DEBRIEF_KEY],
-      ['pilot-checks',  PC_KEY]
+      ['pilot-checks',  PC_KEY],
+      ['courses',       COURSE_KEY]
     ];
     await Promise.all(pairs.map(async ([type, key]) => {
       const data = await loadFromServer(type);
       if (data === null) return; // no file yet → keep localStorage as-is
       try { localStorage.setItem(key, JSON.stringify(data)); } catch {}
     }));
+  }
+
+  /* ── Course tier (7-leg arc; ISO-week-stamped) ──
+     A Course is one week's planned arc. Sub-objects:
+       theme            one-line: what this week is *for*
+       target_outcome   what the map looks like different by leg 7
+       frontier         array of LAB item IDs currently in scope
+       bail_conditions  text: when do we abandon this Course?
+       legs[]           leg objects (filled progressively; shape stubbed in step 1)
+       status           planning · in-progress · debriefed · archived
+     ID convention: ISO-week-stamped (COURSE-2026-W18 not -2026-05-03).
+     Frontier-not-itinerary: Course names what's reachable this week, not which
+     leg hits which item. Frame at each leg picks from the frontier. */
+  const COURSE_KEY = 'cognitive-lab-v0.1::courses';
+  const COURSE_LEG_COUNT = 7; // matches book title (The 7 Turn Work Week)
+
+  function isoWeekId(date) {
+    // ISO-8601 week-numbering: weeks start Monday; week 1 contains the first Thursday.
+    const d = date ? new Date(date.getTime()) : new Date();
+    d.setUTCHours(0, 0, 0, 0);
+    const dayNum = d.getUTCDay() || 7; // Sunday → 7
+    d.setUTCDate(d.getUTCDate() + 4 - dayNum); // jump to Thursday of this ISO week
+    const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+    const weekNum = Math.ceil(((d - yearStart) / 86400000 + 1) / 7);
+    return 'COURSE-' + d.getUTCFullYear() + '-W' + String(weekNum).padStart(2, '0');
+  }
+
+  function loadCourses() {
+    try { return JSON.parse(localStorage.getItem(COURSE_KEY) || '[]'); }
+    catch { return []; }
+  }
+  function saveCourses(arr) {
+    try { localStorage.setItem(COURSE_KEY, JSON.stringify(arr)); } catch {}
+    postSave('courses', arr);
+  }
+
+  function findCourseById(id) {
+    return loadCourses().find(c => c && c.id === id) || null;
+  }
+  function findActiveCourse() {
+    // The active course is the one stamped to the current ISO week, if any.
+    return findCourseById(isoWeekId());
+  }
+  function newCourseDraft(opts) {
+    // Returns a fresh Course object stamped to the given (or current) week.
+    const id = (opts && opts.id) || isoWeekId(opts && opts.date);
+    const now = new Date().toISOString();
+    return {
+      id: id,
+      theme: '',
+      target_outcome: '',
+      frontier: [],            // array of LAB item IDs in scope this week
+      bail_conditions: '',
+      legs: [],                // shape defined by Leg wrapper (step 1)
+      status: 'planning',      // planning · in-progress · debriefed · archived
+      createdAt: now,
+      updatedAt: now
+    };
+  }
+  function upsertCourse(course) {
+    const arr = loadCourses();
+    const idx = arr.findIndex(c => c && c.id === course.id);
+    course.updatedAt = new Date().toISOString();
+    if (idx >= 0) arr[idx] = course;
+    else arr.push(course);
+    saveCourses(arr);
+    return course;
   }
 
   /* ── Frame Workshop: storage helpers ── */
@@ -4559,8 +4849,9 @@
     if (Array.isArray(value)) return value.length > 0;
     return !!(value && (typeof value === 'string') && value.trim().length > 0);
   }
-  function flashSaved() {
-    const el = document.getElementById('ff-saved');
+  function flashSaved(id) {
+    const el = document.getElementById(id || 'ff-saved');
+    if (!el) return;
     el.classList.add('show');
     setTimeout(() => el.classList.remove('show'), 1800);
   }
@@ -6054,7 +6345,7 @@
      ────────────────────────────────────────────────────────────── */
 
   const VIEW_KEY = STORAGE_KEY + '::active-view';
-  const VIEWS = ['floor', 'priority', 'timeline', 'by-status'];
+  const VIEWS = ['floor', 'course', 'priority', 'timeline', 'by-status'];
   let activeView = 'floor';
 
   function loadActiveView() {
@@ -6117,6 +6408,7 @@
 
     const isAlt = name !== 'floor';
     document.body.classList.toggle('alt-view-active', isAlt);
+    document.getElementById('course-view').classList.toggle('visible', name === 'course');
     document.getElementById('priority-view').classList.toggle('visible', name === 'priority');
     document.getElementById('timeline-view').classList.toggle('visible', name === 'timeline');
     document.getElementById('by-status-view').classList.toggle('visible', name === 'by-status');
@@ -6125,6 +6417,7 @@
   }
 
   function renderActiveAltView() {
+    if (activeView === 'course')     renderCourseView();
     if (activeView === 'priority')   renderPriorityView();
     if (activeView === 'timeline')   renderTimelineView();
     if (activeView === 'by-status')  renderByStatusView();
@@ -6543,6 +6836,160 @@
       <span class="pss-area">${escapeHTML(it.areaName)}</span>
     </div>`;
   }
+
+  /* ── Course view (planning surface for the 7-leg arc) ──
+     Step 0a stub: theme + target_outcome + frontier (multi-pick over LAB items)
+     + bail_conditions. Auto-loads the active week's course (or drafts one).
+     Frontier-not-itinerary: per-leg Frame picks from this list during the week. */
+  let courseFrontierPanelOpen = false;
+  let courseDraft = null; // in-memory edit buffer; flushed on save
+
+  function getOrInitCourseDraft() {
+    if (courseDraft) return courseDraft;
+    const existing = findActiveCourse();
+    courseDraft = existing ? JSON.parse(JSON.stringify(existing)) : newCourseDraft();
+    return courseDraft;
+  }
+
+  function renderCourseView() {
+    const c = getOrInitCourseDraft();
+    const body = document.getElementById('course-body');
+    if (!body) return;
+    const created = c.createdAt ? c.createdAt.slice(0, 10) : '—';
+    const updated = c.updatedAt ? c.updatedAt.slice(0, 10) : '—';
+    const legCount = (c.legs || []).length;
+    body.innerHTML = `
+      <div class="course-card">
+        <div class="course-header">
+          <span class="course-id">${escapeHTML(c.id)}</span>
+          <span class="course-status">${escapeHTML(c.status || 'planning')}</span>
+        </div>
+        <div class="course-field">
+          <label for="course-theme">Theme <span class="course-hint">one line — what this week is for</span></label>
+          <input id="course-theme" type="text" value="${escapeHTML(c.theme || '')}" placeholder="e.g., Land the rogaine spine in the lab" />
+        </div>
+        <div class="course-field">
+          <label for="course-target">Target outcome <span class="course-hint">what the map looks like different by leg 7</span></label>
+          <textarea id="course-target" placeholder="e.g., Course tier shipped, Hex Map v0.1 read-only, on-demand Comprehend prototype dogfooded once">${escapeHTML(c.target_outcome || '')}</textarea>
+        </div>
+        <div class="course-field">
+          <label>Frontier <span class="course-hint">items reachable this week — pick from the lab</span></label>
+          <div id="course-frontier-chips" class="course-frontier-chips"></div>
+          <button type="button" id="course-frontier-toggle" class="course-frontier-toggle${courseFrontierPanelOpen ? ' open' : ''}">${courseFrontierPanelOpen ? 'Close' : 'Browse items'}</button>
+          <div id="course-frontier-panel" class="course-frontier-panel" ${courseFrontierPanelOpen ? '' : 'hidden'}></div>
+        </div>
+        <div class="course-field">
+          <label for="course-bail">Bail conditions <span class="course-hint">when do we abandon this Course?</span></label>
+          <textarea id="course-bail" placeholder="e.g., If Hex Map proves unreadable after one dogfood, fall back to a Kanban-style Course view.">${escapeHTML(c.bail_conditions || '')}</textarea>
+        </div>
+        <div class="course-actions">
+          <button type="button" id="course-save" class="ff-btn primary">Save Course</button>
+          <span class="ff-saved" id="course-saved">✓ saved</span>
+        </div>
+        <div class="course-meta">
+          Legs: ${legCount} of ${COURSE_LEG_COUNT} · Created ${escapeHTML(created)} · Updated ${escapeHTML(updated)}
+        </div>
+      </div>
+    `;
+    renderCourseFrontierChips();
+    if (courseFrontierPanelOpen) renderCourseFrontierPanel();
+  }
+
+  function renderCourseFrontierChips() {
+    const c = getOrInitCourseDraft();
+    const el = document.getElementById('course-frontier-chips');
+    if (!el) return;
+    const items = allItemsArray();
+    const itemById = new Map(items.map(it => [it.id, it]));
+    el.innerHTML = (c.frontier || []).map(id => {
+      const it = itemById.get(id);
+      const title = it ? it.title : '(missing item)';
+      return `<span class="course-frontier-chip">
+        <span class="cfc-id">${escapeHTML(id)}</span>
+        <span class="cfc-title">${escapeHTML(title)}</span>
+        <button type="button" class="cfc-x" data-act="frontier-remove" data-item="${escapeHTML(id)}" aria-label="Remove ${escapeHTML(title)}">×</button>
+      </span>`;
+    }).join('');
+  }
+
+  function renderCourseFrontierPanel() {
+    const c = getOrInitCourseDraft();
+    const panel = document.getElementById('course-frontier-panel');
+    if (!panel) return;
+    const items = allItemsArray();
+    const selected = new Set(c.frontier || []);
+    // Group by priority. Within a priority, sort: in-progress > drafted > backlog > live > archived.
+    const tiers = { 'P0': [], 'P1': [], 'P2': [] };
+    items.forEach(it => { if (tiers[it.priority]) tiers[it.priority].push(it); });
+    Object.keys(tiers).forEach(p => {
+      tiers[p].sort((a, b) => statusRank(a.status) - statusRank(b.status));
+    });
+    let html = '';
+    ['P0', 'P1', 'P2'].forEach(p => {
+      if (tiers[p].length === 0) return;
+      html += `<div class="course-frontier-section">${p} · ${escapeHTML(PRI_LABEL[p] || '')}</div>`;
+      html += tiers[p].map(it => {
+        const sel = selected.has(it.id) ? ' selected' : '';
+        const statLabel = STATUS_LABEL[it.status] || it.status;
+        return `<div class="course-frontier-row${sel}" data-act="frontier-toggle" data-item="${escapeHTML(it.id)}">
+          <span class="cfr-pri ${it.priority}">${it.priority}</span>
+          <span class="cfr-id">${escapeHTML(it.id)}</span>
+          <span class="cfr-title">${escapeHTML(it.title)}</span>
+          <span class="cfr-stat">${escapeHTML(statLabel)}</span>
+        </div>`;
+      }).join('');
+    });
+    if (html === '') html = '<div class="ff-pp-empty">No items in the lab yet.</div>';
+    panel.innerHTML = html;
+  }
+
+  // Delegated handlers for the Course view (inputs + frontier picker + save).
+  document.getElementById('course-view').addEventListener('click', (e) => {
+    const tgt = e.target;
+    if (tgt.id === 'course-frontier-toggle') {
+      courseFrontierPanelOpen = !courseFrontierPanelOpen;
+      const panel = document.getElementById('course-frontier-panel');
+      tgt.classList.toggle('open', courseFrontierPanelOpen);
+      tgt.textContent = courseFrontierPanelOpen ? 'Close' : 'Browse items';
+      if (panel) {
+        panel.hidden = !courseFrontierPanelOpen;
+        if (courseFrontierPanelOpen) renderCourseFrontierPanel();
+      }
+      return;
+    }
+    if (tgt.id === 'course-save') {
+      const c = getOrInitCourseDraft();
+      const themeEl  = document.getElementById('course-theme');
+      const targetEl = document.getElementById('course-target');
+      const bailEl   = document.getElementById('course-bail');
+      c.theme           = themeEl  ? themeEl.value.trim()  : '';
+      c.target_outcome  = targetEl ? targetEl.value.trim() : '';
+      c.bail_conditions = bailEl   ? bailEl.value.trim()   : '';
+      upsertCourse(c);
+      flashSaved('course-saved');
+      return;
+    }
+    const removeBtn = tgt.closest('[data-act="frontier-remove"]');
+    if (removeBtn) {
+      const id = removeBtn.dataset.item;
+      const c = getOrInitCourseDraft();
+      c.frontier = (c.frontier || []).filter(x => x !== id);
+      renderCourseFrontierChips();
+      if (courseFrontierPanelOpen) renderCourseFrontierPanel();
+      return;
+    }
+    const toggleRow = tgt.closest('[data-act="frontier-toggle"]');
+    if (toggleRow) {
+      const id = toggleRow.dataset.item;
+      const c = getOrInitCourseDraft();
+      const set = new Set(c.frontier || []);
+      if (set.has(id)) set.delete(id); else set.add(id);
+      c.frontier = Array.from(set);
+      renderCourseFrontierChips();
+      renderCourseFrontierPanel();
+      return;
+    }
+  });
 
   function renderPriorityView() {
     const items = allItemsArray();

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -4983,7 +4983,7 @@
       "type": "aux / persistent",
       "accent": "dark",
       "description": "Your seat. Where the Frame card sits today, where lab notes get written. Also the home for cross-cutting lab work — agent composition, process docs, session integration.",
-      "items": ["LAB-022","LAB-023","LAB-024","LAB-029","LAB-034","LAB-035","LAB-037","LAB-039","LAB-040","LAB-041","LAB-043","LAB-045"],
+      "items": ["LAB-022","LAB-023","LAB-024","LAB-029","LAB-034","LAB-035","LAB-037","LAB-039","LAB-040","LAB-041","LAB-043","LAB-045","LAB-047","LAB-048","LAB-049","LAB-050","LAB-051"],
       "sources": [
         { "label": "PROCESS.md (how the agents compose, lab-to-book flow)", "href": "PROCESS.md" },
         { "label": "DECISIONS.md (synthesized decisions log)", "href": "DECISIONS.md" }
@@ -5012,6 +5012,30 @@
         }
       ],
       "chunks": [
+        {
+          "id": "chunk-build-canvas-v0.1",
+          "title": "Build canvas v0.1 — snap-circuit grid, tool drawer, click-to-place, template apply",
+          "summary": "Snap-circuit-style 7×10 grid + tool drawer + click-to-place + template apply. Author owns the placement; lab persists via course.build_positions.",
+          "body": "Move 3 of the v0.4 arc ships the Build canvas as the default lens on the Course view. The canvas is a 7×10 grid (rows A–G × cols 1–10, 70 cells) rendered as an ARIA grid > row > gridcell. Each cell is a snap point.\n\nThe **tool drawer** sits in a 2-col layout beside the grid. Items are grouped by area, sorted by priority within area. A priority allowlist (P0/P1/P2) guards against XSS on hand-edited JSON values.\n\n**Click-to-place flow:** clicking a drawer item puts it in-hand (`bcInHand` state). Clicking a grid cell snaps it. If the cell is already occupied, the pieces swap. An action chip appears on placed pieces with three options: Pick up · Remove · Cancel.\n\n**Persistence:** placements are stored in `course.build_positions` — a dict of `{item_id → {row, col}}`. The board survives page reload and lens switches.\n\n**Template apply** (Move 3e): 'Apply template' button places frontier items in priority + area order, row-major across the grid. 'Clear board' resets to empty. Inline status message surfaces when zero items are placed.\n\n**Cumulative sweep fix:** a double-render on lens-switch-while-chip-open was caught and fixed by clearing `bcActionItemId` at the top of render and bailing early when the chip was stale.\n\nCommits on branch `danversfleury/lab-course-tier`: Moves 3a–3e + cumulative sweep."
+        },
+        {
+          "id": "chunk-snap-circuit-builds-book",
+          "title": "Snap-circuits-with-build-book reframe — give them a board, a parts bin, and a builds book",
+          "summary": "The realization that drove v0.4: snap circuits ship with a build book. Stop generating maps for the user; give them a board, a parts bin, and a builds-book (= release plans / templates).",
+          "body": "The architectural pivot behind Move 3: the author's realization mid-design that the lab should stop generating maps *for* the user and instead give the user the tools to build their own.\n\nSnap Circuits — the physical toy — ships with a **build book**: a catalog of circuits you can assemble. The build book doesn't tell you what your circuit looks like. It shows you canonical circuits (templates) and lets you build your own from the same parts.\n\nTranslated to the lab: the Hex Map (auto-generated from lab data) was showing the user a diagram. The Build canvas gives them a **board** (the 7×10 grid), a **parts bin** (the tool drawer, all items available this Course), and a **builds book** (templates = releases in planning status, e.g. 'Apply template' → frontier items placed in priority order).\n\nAllan Kay's claim — redirected at the user, not just our design choices: *'It's easier to build a diagram than read a diagram.'* The user building their own placement learns the structure. The user reading an auto-generated map consumes it.\n\nThis reframe makes the Build canvas the primary surface (default lens) and repositions the Hex Map lenses (By function / By priority) as read-only re-projections of the same data — reference views, not the authoring surface."
+        },
+        {
+          "id": "chunk-lens-architecture",
+          "title": "Lens architecture — one canvas, three read-only re-projections",
+          "summary": "One canvas, multiple lenses (Build / By function / By priority). User owns one placement; lenses are read-only re-projections. The v0.2 biome view returns as a lens, not the default.",
+          "body": "Move 3a introduces a lens dispatcher on the Course view. Three tabs:\n\n- **Build** (default) — the author-owned snap-circuit grid. Placements persist in `course.build_positions`.\n- **By function** — the v0.2 biome Hex Map (areas as biome-tinted regions, hexes sorted by area). Restored as a reference lens.\n- **By priority** — the v0.3 concentric-rings Hex Map (P0 center → P1 → P2). Reference lens.\n\nThe active lens persists in `courseHexLens` (localStorage) so it survives reload. Lens switches clear any open action chip (`bcActionItemId`) and re-render without state bleed.\n\n`wireHexSVGListeners` was consolidated in this move — prior to 3a it was being called redundantly on every lens switch, causing double event-listener registration. The consolidation is the fix.\n\n**Design principle:** the user owns exactly one placement (the Build canvas). The two Hex Map lenses are read-only re-projections of the same underlying lab data — they don't have their own state. This keeps the authoring surface unambiguous: if you want to rearrange, go to Build."
+        },
+        {
+          "id": "chunk-instant-hex-tooltip",
+          "title": "HTML tooltip layer — instant hover over SVG hex cells",
+          "summary": "HTML tooltip layer over the Hex Map's SVG. aria-label replaces <title> to suppress the duplicate native browser tooltip. Pattern reusable for any future SVG with hex-cell polygons.",
+          "body": "Move 1 fixes the 1-second hover delay on the Hex Map. SVG `<title>` elements are browser-native tooltips — they inherit the OS/browser tooltip delay (typically 500ms–1s), which makes quick hex-scanning feel sluggish.\n\n**The fix:** an HTML tooltip layer (`<div class=\"hex-tooltip\">`) positioned absolutely above the SVG, z-index 450 (above the toolbar). On `mousemove` over a polygon, the tooltip's content and position update immediately via JS; no browser delay.\n\n**`aria-label` replaces `<title>`:** if you keep `<title>` inside the polygon *and* show the HTML tooltip, the browser shows both — a double tooltip. Swapping `<title>` for `aria-label` on each polygon preserves the accessibility label (screen readers read `aria-label`) while suppressing the native browser tooltip.\n\n**Reuse pattern:** any future SVG with polygons that need instant hover identity (hex cells, circuit nodes, map regions) should use this same pattern: aria-label on the polygon, HTML tooltip layer driven by mousemove.\n\nCommits `a5de21f` (tooltip layer, z-index 450, aria-label swap) and followup fix commit on branch `danversfleury/lab-course-tier`."
+        },
         {
           "id": "chunk-hex-map-v03",
           "title": "Hex Map v0.3 — concentric rings, Okabe-Ito palette, map legend, genus:species hover",
@@ -5245,7 +5269,8 @@
         "LAB-025","LAB-026","LAB-027","LAB-028","LAB-029",
         "LAB-030","LAB-031","LAB-032","LAB-033",
         "LAB-034","LAB-035","LAB-036","LAB-037","LAB-038","LAB-039","LAB-040","LAB-041",
-        "LAB-042","LAB-043","LAB-044","LAB-045","LAB-046"
+        "LAB-042","LAB-043","LAB-044","LAB-045","LAB-046",
+        "LAB-047","LAB-048","LAB-049","LAB-050","LAB-051"
       ],
       "artifacts": [],
       "notes": []
@@ -5687,6 +5712,51 @@
       "area": "comprehend-station",
       "brief": "Phase 1.5 deferred: at what density/count does Comprehend register as sufficient? Don't pre-design — that's the Course Coach's job (LAB-034). Captured so it's not forgotten.",
       "full": "Phase 1.5 deliberately deferred the question of sufficiency: when has a leg's Comprehend phase loaded enough context to proceed to Produce? This is not a question Larry or the lab UI should answer alone — it's Course Coach territory (LAB-034). The Course Coach reads leg histories and can detect patterns like 'legs where Comprehend had < 2 entries correlated with mid-leg re-immersion interruptions.' Pre-designing a sufficiency threshold now would be premature — it would encode a guess before the data exists to inform it. Capture the question here so it's not forgotten when LAB-034 becomes active. P3."
+    },
+    "LAB-047": {
+      "id": "LAB-047",
+      "title": "Release as 4th tier (Map → Release → Course → Leg)",
+      "status": "backlog",
+      "priority": "P2",
+      "area": "director-desk",
+      "brief": "Per Quenton's v0.4 design dialog Move 4 — formalize Release as a data object once Move 3 has lived data. Priority and points live on the release-membership, not on items.",
+      "full": "Per Quenton's v0.4 design dialog (Move 4): formalize Release as a fourth tier above Course. The current three-tier model is Map → Course → Leg. Release slots in as Map → Release → Course → Leg.\n\nKey design calls (Quenton):\n- Priority and points live on the **release-membership**, not on the item itself. The same item can be P0 in one release and P2 in another.\n- Templates = releases in `planning` status. The Build canvas's 'Apply template' button is already pointing at this — it applies a release plan to the board.\n- Don't formalize Release as a data object until Move 3 has lived data. Build the canvas first; let the author's placement behavior surface what a release actually is before encoding it.\n\nP2 — blocked on Move 3 lived use."
+    },
+    "LAB-048": {
+      "id": "LAB-048",
+      "title": "Comprehend boot gate (Comprehend before Frame)",
+      "status": "backlog",
+      "priority": "P2",
+      "area": "director-desk",
+      "brief": "Per Quenton's v0.4 design dialog: the leg cycle reorders to C→F·S·P·D. Comprehend becomes a boot strip that gates Frame entry.",
+      "full": "Per Quenton's v0.4 design dialog: the leg cycle reorders from F·C·S·P·D to **C→F·S·P·D**. Comprehend moves first as a 'boot strip' that gates Frame entry.\n\nWhat the boot strip pulls: last leg's Debrief + frontier delta + recent Comprehend log. The author loads context before committing to a Frame — they know what changed since last leg before they scope the current one.\n\nAuthor decision (2026-05-04): rejected the boot-strip surface treatment for now. Comprehend stays as a home-page area, positioned first — the principle (Comprehend before Frame) is honored by layout positioning, not a hard gate. The C-before-F principle stands; the gate mechanism is deferred.\n\nP2 (later) — the principle is active; the mechanism is the build work."
+    },
+    "LAB-049": {
+      "id": "LAB-049",
+      "title": "Build canvas: drag-and-drop affordance (v0.5+)",
+      "status": "backlog",
+      "priority": "P3",
+      "area": "director-desk",
+      "brief": "v0.4 ships click-to-place per Quenton's design call. If lived use shows DnD would be meaningfully better, this is the upgrade path.",
+      "full": "v0.4 ships click-to-place as the placement interaction. Quenton's design call: don't build drag-and-drop until click-to-place has been dogfooded and we know whether DnD would actually improve the experience. Click-to-place is simpler, works on mobile, and has lower implementation cost.\n\nIf after lived use the author finds that rearranging pieces on the board is frequent and click-to-place (click item → click destination) feels slow, DnD is the upgrade path. Track that signal in Debrief entries.\n\nNot a blocker. P3."
+    },
+    "LAB-050": {
+      "id": "LAB-050",
+      "title": "Build canvas: connect placed pieces (chain edges)",
+      "status": "backlog",
+      "priority": "P2",
+      "area": "director-desk",
+      "brief": "v0.4 deferred edges between connected pieces. Couples to LAB-045 (prereqs[] data model). When LAB-045 lands, surface prereq edges on the Build canvas as drawn lines.",
+      "full": "v0.4 deliberately deferred edges between connected pieces on the Build canvas. The decision: don't draw edges between cells until the prereqs[] data model exists (LAB-045).\n\nWhen LAB-045 lands:\n1. Items have `prereqs: string[]` — IDs of items that must complete before this one can start.\n2. On the Build canvas, if both items in a prereq relationship are placed, draw a line between their cells.\n3. The line should be lightweight — the board should remain readable; edges are secondary information.\n\nThis makes the Build canvas show not just placement but wiring: which pieces connect to which. The snap-circuit metaphor becomes complete — you're not just placing components, you're wiring them.\n\nP2 — blocked on LAB-045 (prereqs[] data model)."
+    },
+    "LAB-051": {
+      "id": "LAB-051",
+      "title": "Map world v0.1 — phase boxes live in the map (long-term)",
+      "status": "backlog",
+      "priority": "P3",
+      "area": "director-desk",
+      "brief": "Author's long-vision: each phase-box eventually lives in 'map world.' Central traversable space; phase-cycler moves through which phase the user is in. Library/research/tools become buildings.",
+      "full": "Author's long-vision for the lab (captured 2026-05-04, not a near-term build item):\n\nEach phase-box (Frame, Comprehend, Sync, Produce, Debrief — outside Recover) eventually lives in 'map world' — a central traversable space. A phase-cycler at the bottom of the screen moves through which phase the user is currently in relative to the map. Moving through phases is literally moving through the map.\n\nLibrary and research tools become buildings in the map world. Resources are rooms you enter, not tabs you click.\n\nThis is a long-vision capture, not a near-term spec. The design questions (what does 'traversable space' mean at a technical level? how does it compose with the existing Hex Map lenses?) are for Quenton when the time comes.\n\nNot v0.4. Not v0.5. Capture for the road map. P3."
     }
   }
 }

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -1188,6 +1188,10 @@
     background: rgba(226,160,74,0.55);
     text-transform: uppercase;
     letter-spacing: 1px;
+    /* Belt-and-suspenders — parent already has pointer-events:none, but
+       being explicit prevents a future refactor from accidentally turning
+       the overlay into a click target. */
+    pointer-events: none;
   }
   .comp-studio-main-empty {
     padding: 40px 24px;
@@ -8459,10 +8463,15 @@
     return s;
   }
   // Build the iframe URL for a product walk. Adds `?walk=1` plus the
-  // walk's target_route (if set).
+  // walk's target_route (if set). target_route is allowlisted to safe
+  // query-string characters so a stray `#` or `..` can't break URL
+  // parsing or escape the iframe destination.
   function walkIframeSrc(walk) {
     let qs = 'walk=1';
-    if (walk.target_route) qs += '&' + walk.target_route;
+    if (walk.target_route) {
+      const safe = walk.target_route.replace(/[^a-zA-Z0-9=&_.%-]/g, '');
+      if (safe) qs += '&' + safe;
+    }
     return 'cognitive-lab-v0.1.html?' + qs;
   }
 
@@ -8683,7 +8692,12 @@
                   : '<button type="button" class="primary" data-act="walk-next">Next →</button>') +
               '</div>' +
             '</div>' +
-            '<iframe class="comp-studio-iframe" src="' + escapeHTML(walkIframeSrc(activeWalk)) + '" title="' + escapeHTML(activeWalk.title) + ' (walk mode)"></iframe>' +
+            // sandbox attribute closes the window.top navigation gap from
+            // the inner same-origin frame. allow-same-origin keeps
+            // localStorage access (the whole point of a state-mutating walk);
+            // allow-scripts keeps the lab interactive; allow-forms keeps
+            // any form submissions inside Frame/Debrief working.
+            '<iframe class="comp-studio-iframe" src="' + escapeHTML(walkIframeSrc(activeWalk)) + '" title="' + escapeHTML(activeWalk.title) + ' (walk mode)" sandbox="allow-scripts allow-same-origin allow-forms"></iframe>' +
           '</div>' +
         '</div>';
     }
@@ -11693,6 +11707,13 @@
     banner.className = 'walk-banner';
     banner.textContent = '⚑ Walk in progress — close from the Comprehend Station to return to the full lab';
     document.body.insertBefore(banner, document.body.firstChild);
+    // Hide the Comprehend Station area from assistive tech as well as
+    // visually — the CSS already opacity-dims it; aria-hidden suppresses
+    // screen-reader announcements of the inert overlay text.
+    document.addEventListener('DOMContentLoaded', () => {
+      const inertArea = document.querySelector('.area[data-area="comprehend-station"]');
+      if (inertArea) inertArea.setAttribute('aria-hidden', 'true');
+    });
   })();
 
   hydrateFromServer().then(() => {

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -472,6 +472,7 @@
   /* Build canvas (Move 3b): snap-circuit-style grid. Empty cells with a
      center "snap point" dot, labeled rows (A–G) and columns (1–10). */
   .bc-canvas-wrap {
+    position: relative;       /* anchor for the floating action chip (Move 3d) */
     background: var(--panel-bg);
     border: 1px solid var(--panel-bd);
     border-radius: 8px;
@@ -674,7 +675,6 @@
   /* Action chip — floats next to a clicked occupied cell. Two actions
      today: Pick up (returns piece to hand for re-placement) and Remove
      (returns piece to drawer). */
-  .bc-canvas-wrap { position: relative; }
   .bc-action-chip {
     position: absolute;
     z-index: 20;
@@ -9132,20 +9132,9 @@
         renderCourseHexMap();
       });
     }
-    // ── Outside-click closes the action chip ──
-    if (bcActionItemId) {
-      // Wait one tick so the chip-opening click doesn't immediately close it.
-      setTimeout(() => {
-        const closer = (e) => {
-          const chip = document.querySelector('.bc-action-chip');
-          if (chip && chip.contains(e.target)) return;
-          bcActionItemId = null;
-          document.removeEventListener('click', closer);
-          renderCourseHexMap();
-        };
-        document.addEventListener('click', closer);
-      }, 0);
-    }
+    // Outside-click closer is registered inside openBuildActionChip (not
+    // here) — that path doesn't trigger a re-render so the closer would
+    // never bind if registered conditionally on bcActionItemId.
   }
 
   /* Build canvas action chip — shown when a placed piece is clicked
@@ -9197,6 +9186,19 @@
     if (chipRect.right > wrapRect.right - 4) {
       chip.style.left = (cellRect.left - wrapRect.left - chipRect.width - 4) + 'px';
     }
+    // Outside-click closer. Closes over the chip element directly so that
+    // chip-button clicks (which bubble to document) are correctly identified
+    // as inside the chip — avoids both the never-registered bug and the
+    // double-render-on-button-click bug grepzilla flagged.
+    setTimeout(() => {
+      const closer = (e) => {
+        if (chip.contains(e.target)) return;
+        bcActionItemId = null;
+        document.removeEventListener('click', closer);
+        renderCourseHexMap();
+      };
+      document.addEventListener('click', closer);
+    }, 0);
   }
 
   /* By-function lens — restored from v0.2.

--- a/cognitive-lab/comprehension-deck-v0.1.html
+++ b/cognitive-lab/comprehension-deck-v0.1.html
@@ -1,0 +1,1014 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Comprehension · The Rogaine Spine · 2026-05-04</title>
+<style>
+  :root {
+    --bg:          #1a1a2e;
+    --fg:          #e8e0d4;
+    --panel-bg:    #16213e;
+    --panel-bd:    #2a3a5c;
+    --accent:      #e2a04a;
+    --accent-dim:  #a87832;
+    --success:     #4daa57;
+    --danger:      #c25450;
+    --font-px:     'Courier New', Courier, monospace;
+    --font-sans:   -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+
+    --frame-c:     #4a7bd4;
+    --comprehend-c:#d4a030;
+    --sync-c:      #2d8a7e;
+    --produce-c:   #e2a04a;
+    --debrief-c:   #4a8a5a;
+  }
+  * { box-sizing: border-box; }
+  html, body {
+    margin: 0;
+    padding: 0;
+    background: var(--bg);
+    color: var(--fg);
+    font-family: var(--font-sans);
+    overflow: hidden;
+  }
+  body {
+    height: 100vh;
+    width: 100vw;
+  }
+  #deck {
+    height: 100vh;
+    width: 100vw;
+    overflow-y: scroll;
+    scroll-snap-type: y mandatory;
+    scroll-behavior: smooth;
+  }
+  #deck::-webkit-scrollbar { display: none; }
+  #deck { -ms-overflow-style: none; scrollbar-width: none; }
+
+  .slide {
+    height: 100vh;
+    width: 100vw;
+    scroll-snap-align: start;
+    scroll-snap-stop: always;
+    padding: 56px 72px 80px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    position: relative;
+  }
+  .slide-tag {
+    font-family: var(--font-px);
+    font-size: 11px;
+    color: var(--accent);
+    letter-spacing: 3px;
+    text-transform: uppercase;
+    margin: 0;
+  }
+  h1 {
+    font-size: 56px;
+    line-height: 1.05;
+    margin: 0;
+    color: var(--fg);
+    font-weight: 700;
+    letter-spacing: -1px;
+  }
+  h2 {
+    font-size: 38px;
+    line-height: 1.1;
+    margin: 0;
+    color: var(--fg);
+    font-weight: 700;
+    letter-spacing: -0.5px;
+  }
+  h3 {
+    font-size: 22px;
+    line-height: 1.25;
+    margin: 0;
+    color: var(--fg);
+    font-weight: 700;
+  }
+  .lede {
+    font-size: 22px;
+    line-height: 1.45;
+    color: var(--fg);
+    max-width: 920px;
+    margin: 0;
+  }
+  .body {
+    font-size: 17px;
+    line-height: 1.55;
+    color: var(--fg);
+    max-width: 920px;
+  }
+  .dim { color: #a8a098; }
+  .accent { color: var(--accent); }
+  .px { font-family: var(--font-px); }
+  .small { font-size: 13px; }
+
+  /* progress + counter */
+  #progress {
+    position: fixed;
+    top: 0; left: 0;
+    height: 3px;
+    background: var(--accent);
+    z-index: 50;
+    transition: width 200ms ease;
+  }
+  #counter {
+    position: fixed;
+    bottom: 18px;
+    right: 24px;
+    font-family: var(--font-px);
+    font-size: 11px;
+    letter-spacing: 1.5px;
+    color: var(--accent-dim);
+    z-index: 50;
+  }
+  #help {
+    position: fixed;
+    bottom: 18px;
+    left: 24px;
+    font-family: var(--font-px);
+    font-size: 10px;
+    letter-spacing: 1px;
+    color: #6f7a90;
+    z-index: 50;
+  }
+  #help kbd {
+    background: rgba(255,255,255,0.06);
+    border: 1px solid var(--panel-bd);
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 10px;
+    margin: 0 2px;
+  }
+
+  /* — slide-specific layouts — */
+  .cover {
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    gap: 24px;
+  }
+  .cover h1 { font-size: 88px; letter-spacing: -2px; }
+  .cover .sub {
+    font-family: var(--font-px);
+    font-size: 14px;
+    color: var(--accent);
+    letter-spacing: 5px;
+  }
+
+  /* split layouts */
+  .split {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 56px;
+    flex: 1;
+    align-items: stretch;
+  }
+  .split .col {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+  .split-label {
+    font-family: var(--font-px);
+    font-size: 11px;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    color: var(--accent-dim);
+    margin: 0;
+  }
+  .split-label.before { color: #c25450; }
+  .split-label.after  { color: var(--success); }
+
+  /* "card" boxes */
+  .panel {
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-bd);
+    border-radius: 8px;
+    padding: 18px 22px;
+  }
+  .panel-row {
+    display: flex;
+    gap: 12px;
+    align-items: baseline;
+    margin: 6px 0;
+  }
+  .panel-row .px { color: var(--accent); font-size: 12px; letter-spacing: 1px; }
+
+  /* ASCII-style stack diagram for the data model */
+  .stack {
+    font-family: var(--font-px);
+    font-size: 16px;
+    line-height: 1.35;
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-bd);
+    border-radius: 8px;
+    padding: 22px 26px;
+    color: var(--fg);
+    white-space: pre;
+    overflow-x: auto;
+  }
+  .stack .h { color: var(--accent); font-weight: bold; }
+  .stack .d { color: #6f7a90; }
+  .stack .v { color: var(--success); }
+
+  /* zone strip (snap circuit homage) */
+  .zones {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 12px;
+    margin-top: 8px;
+  }
+  .zone {
+    border: 1px solid var(--panel-bd);
+    border-radius: 8px;
+    padding: 16px 14px;
+    background: var(--panel-bg);
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-height: 220px;
+  }
+  .zone .glyph { font-size: 36px; line-height: 1; }
+  .zone .role  { font-family: var(--font-px); font-size: 10px; letter-spacing: 1.5px; text-transform: uppercase; color: var(--accent-dim); }
+  .zone .name  { font-size: 18px; font-weight: 700; color: var(--fg); }
+  .zone .desc  { font-size: 12.5px; line-height: 1.4; color: #c8c0b4; margin-top: 4px; }
+  .zone[data-z="frame"]      { border-color: rgba(74,123,212,0.6); }
+  .zone[data-z="comprehend"] { border-color: rgba(212,160,48,0.6); }
+  .zone[data-z="sync"]       { border-color: rgba(45,138,126,0.6); }
+  .zone[data-z="produce"]    { border-color: rgba(226,160,74,0.6); }
+  .zone[data-z="debrief"]    { border-color: rgba(74,138,90,0.6); }
+  .zone[data-z="frame"]      .glyph { color: var(--frame-c); }
+  .zone[data-z="comprehend"] .glyph { color: var(--comprehend-c); }
+  .zone[data-z="sync"]       .glyph { color: var(--sync-c); }
+  .zone[data-z="produce"]    .glyph { color: var(--produce-c); }
+  .zone[data-z="debrief"]    .glyph { color: var(--debrief-c); }
+
+  /* hex-band swatch (illustrative, not real hex math) */
+  .hex-band {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    padding: 18px;
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-bd);
+    border-radius: 8px;
+    justify-content: center;
+  }
+  .hex-cell {
+    width: 36px;
+    height: 32px;
+    background: #4a7bd4;
+    clip-path: polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%);
+    opacity: 0.55;
+    transition: opacity 200ms;
+  }
+  .hex-cell.amber  { background: #d4a030; }
+  .hex-cell.green  { background: #4a8a5a; }
+  .hex-cell.warm   { background: #a88a5a; }
+  .hex-cell.teal   { background: #2d8a7e; }
+  .hex-cell.dark   { background: #555; }
+  .hex-cell.dim    { opacity: 0.25; }
+  .hex-cell.bright { opacity: 1.0; box-shadow: 0 0 6px rgba(226,160,74,0.6); }
+  .hex-cell.frontier { box-shadow: 0 0 6px rgba(92,176,154,0.85), inset 0 0 0 2px #5cb09a; opacity: 1.0; }
+
+  /* led bar */
+  .led-bar {
+    display: inline-flex;
+    gap: 4px;
+    padding: 6px 10px;
+    background: rgba(0,0,0,0.25);
+    border-radius: 4px;
+  }
+  .led {
+    width: 22px; height: 9px;
+    border-radius: 1.5px;
+    background: rgba(255,255,255,0.05);
+    border: 1px solid rgba(255,255,255,0.15);
+  }
+  .led.done    { background: rgba(74,138,90,0.55); border-color: rgba(74,138,90,0.7); }
+  .led.current { background: var(--accent); border-color: var(--accent); box-shadow: 0 0 4px rgba(226,160,74,0.7); }
+
+  /* flow / pipeline */
+  .flow {
+    display: flex;
+    align-items: stretch;
+    gap: 12px;
+    margin-top: 12px;
+  }
+  .flow-step {
+    flex: 1;
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-bd);
+    border-radius: 8px;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 0;
+  }
+  .flow-step .num {
+    font-family: var(--font-px);
+    font-size: 10px;
+    letter-spacing: 2px;
+    color: var(--accent);
+  }
+  .flow-step .nm { font-size: 16px; font-weight: 700; }
+  .flow-step .ds { font-size: 12.5px; color: #c8c0b4; line-height: 1.45; }
+  .flow-arrow {
+    align-self: center;
+    color: var(--accent-dim);
+    font-size: 22px;
+    flex-shrink: 0;
+  }
+
+  /* lab item table */
+  .lab-list {
+    display: grid;
+    grid-template-columns: 92px 1fr 80px;
+    gap: 4px 18px;
+    font-size: 14.5px;
+    line-height: 1.5;
+  }
+  .lab-list .id { font-family: var(--font-px); color: var(--accent); }
+  .lab-list .pri {
+    font-family: var(--font-px); font-size: 11px;
+    color: var(--accent-dim); text-align: right; letter-spacing: 1px;
+  }
+
+  /* tag chips */
+  .tag {
+    display: inline-block;
+    padding: 2px 7px;
+    border-radius: 10px;
+    font-family: var(--font-px);
+    font-size: 10px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    background: rgba(226,160,74,0.12);
+    color: var(--accent);
+    border: 1px solid rgba(226,160,74,0.4);
+    margin-right: 6px;
+  }
+  .tag.danger { background: rgba(194,84,80,0.12); color: var(--danger); border-color: rgba(194,84,80,0.4); }
+  .tag.success { background: rgba(74,170,87,0.12); color: var(--success); border-color: rgba(74,170,87,0.4); }
+
+  /* "screenshot" sketches */
+  .sketch {
+    background: #0e1326;
+    border: 1px solid var(--panel-bd);
+    border-radius: 8px;
+    padding: 18px 22px;
+    font-family: var(--font-px);
+    font-size: 12.5px;
+    line-height: 1.6;
+    color: var(--fg);
+  }
+  .sketch .label { color: var(--accent-dim); letter-spacing: 1.5px; font-size: 10px; text-transform: uppercase; }
+
+  /* link button on cover */
+  .open-lab {
+    display: inline-block;
+    margin-top: 28px;
+    padding: 12px 22px;
+    border: 2px solid var(--accent);
+    border-radius: 4px;
+    color: var(--accent);
+    text-decoration: none;
+    font-family: var(--font-px);
+    letter-spacing: 2px;
+    font-size: 13px;
+  }
+  .open-lab:hover { background: rgba(226,160,74,0.1); }
+
+  /* utility */
+  ul.tight { margin: 0; padding-left: 22px; line-height: 1.55; }
+  ul.tight li { margin: 6px 0; }
+  .hr { height: 1px; background: var(--panel-bd); margin: 8px 0; border: none; }
+  .quote {
+    font-style: italic;
+    color: #c8c0b4;
+    border-left: 3px solid var(--accent);
+    padding: 6px 16px;
+    margin: 8px 0;
+    line-height: 1.5;
+  }
+  .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+  .grid-3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+</style>
+</head>
+<body>
+
+<div id="progress"></div>
+<div id="counter">01 / 16</div>
+<div id="help">
+  <kbd>←</kbd><kbd>→</kbd> navigate · <kbd>Space</kbd> next · <kbd>Esc</kbd> top
+</div>
+
+<div id="deck">
+
+  <!-- 1 — COVER -->
+  <section class="slide cover">
+    <p class="sub">comprehension · 2026-05-04</p>
+    <h1>The Rogaine Spine</h1>
+    <p class="lede" style="text-align:center; max-width: 680px;">
+      What landed in the lab tonight, why it's shaped this way,
+      and how the pieces add up to one moving thing.
+    </p>
+    <a class="open-lab" href="cognitive-lab-v0.1.html">→ open the lab</a>
+  </section>
+
+  <!-- 2 — THE REALIZATION -->
+  <section class="slide">
+    <p class="slide-tag">01 · the realization</p>
+    <h2>Stations were forms.<br>They should be lenses on the same thing.</h2>
+
+    <div class="split">
+      <div class="col">
+        <p class="split-label before">— before</p>
+        <div class="panel">
+          <h3 style="color:#c25450;">Five disconnected forms</h3>
+          <p class="body">Frame, Comprehend, Sync, Produce, Debrief — each had (or would have had) its own form, its own state, its own JSON.</p>
+          <p class="body">Debrief reconstructed Frame from memory. Comprehend had no home. Sync was vapor.</p>
+          <p class="body" style="color:#c25450; font-style:italic;">"Wall of text" loop: more fields, more forms, less coherence.</p>
+        </div>
+      </div>
+      <div class="col">
+        <p class="split-label after">— after</p>
+        <div class="panel">
+          <h3 style="color:var(--success);">One unit, five lenses</h3>
+          <p class="body">There's a <strong>unit of work</strong> flowing through the whole turn. The station isn't the thing — it's a different way of looking at the thing.</p>
+          <p class="body">Frame doesn't <em>file</em> a card. Frame <em>sets the course</em>. Every station downstream renders the same course.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 3 — THE METAPHOR -->
+  <section class="slide">
+    <p class="slide-tag">02 · the metaphor</p>
+    <h2>Rogaine: an Australian orienteering sport.<br><span class="dim">Time-boxed score-collection on a map you can't clean.</span></h2>
+
+    <div class="grid-2" style="margin-top: 6px;">
+      <div class="panel">
+        <h3>The shape</h3>
+        <ul class="tight body">
+          <li><strong>Hard time budget</strong> · 24h is canonical · 30 min late = DNF</li>
+          <li><strong>Map of valued checkpoints</strong> · 10–100 points each · pick your own route</li>
+          <li><strong>Pre-event planning window</strong> · 2–4 hours with the map · plan under pressure</li>
+          <li><strong>Hash house</strong> · central rest point · refuel, re-orient, decide</li>
+        </ul>
+      </div>
+      <div class="panel">
+        <h3>The lesson</h3>
+        <p class="body"><span class="accent">"The course is set so the winning team visits <em>most but not all</em>."</span></p>
+        <p class="body small">— IRF Rule C2</p>
+        <hr class="hr">
+        <p class="body">The signature failure isn't under-ambition.<br>It's <strong>"just one more control"</strong> — chasing past the bail-out, hitting the late-penalty cliff.</p>
+        <p class="body" style="color:var(--accent);">Elite skill: <strong>demote the plan when the plan is no longer correct.</strong></p>
+      </div>
+    </div>
+  </section>
+
+  <!-- 4 — THE UNIT -->
+  <section class="slide">
+    <p class="slide-tag">03 · the unit of play</p>
+    <h2>A turn is a <span class="accent">leg.</span><br>A week is a <span class="accent">7 leg course.</span></h2>
+
+    <p class="lede" style="margin-top: 4px;">
+      Locked to the book title — <em>The 7 Turn Work Week</em> — so the data structure earns its name.
+    </p>
+
+    <div class="grid-3" style="margin-top: 16px;">
+      <div class="panel">
+        <p class="px small accent">map</p>
+        <h3>Lifetime backlog</h3>
+        <p class="body">Every LAB item across all areas. Persists.</p>
+      </div>
+      <div class="panel">
+        <p class="px small accent">course</p>
+        <h3>One ISO week</h3>
+        <p class="body">Theme · target outcome · frontier of reachable items · bail conditions · 7 leg slots.</p>
+        <p class="body small dim"><code>COURSE-2026-W18</code></p>
+      </div>
+      <div class="panel">
+        <p class="px small accent">leg</p>
+        <h3>One Full Turn</h3>
+        <p class="body">Wraps Frame · Comprehend · Sync · Produce · Debrief. One slot of the course.</p>
+        <p class="body small dim"><code>LEG-2026-05-04-A</code></p>
+      </div>
+    </div>
+  </section>
+
+  <!-- 5 — FRONTIER NOT ITINERARY -->
+  <section class="slide">
+    <p class="slide-tag">04 · the design call</p>
+    <h2>Frontier, not itinerary.</h2>
+
+    <div class="split">
+      <div class="col">
+        <div class="panel">
+          <h3 class="dim">If a Course pre-assigned items to legs…</h3>
+          <ul class="tight body">
+            <li>Determinism. Easy to chart.</li>
+            <li>Loses the "you choose your route" quality.</li>
+            <li>Re-litigated every time the day changes.</li>
+            <li>Becomes a Gantt chart in disguise.</li>
+          </ul>
+        </div>
+      </div>
+      <div class="col">
+        <div class="panel" style="border-color: var(--accent);">
+          <h3 class="accent">Course names what's <em>reachable</em> this week.</h3>
+          <ul class="tight body">
+            <li>Per-leg Frame picks from the frontier.</li>
+            <li>Surprises and emergence land naturally.</li>
+            <li>"Demote the plan" is a normal move, not a failure.</li>
+            <li>The week has shape; the day has freedom.</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <p class="body dim" style="margin-top: 12px;">
+      <strong>Author's framing:</strong> "Chart your course per turn."
+    </p>
+  </section>
+
+  <!-- 6 — THREE TIERS DATA MODEL -->
+  <section class="slide">
+    <p class="slide-tag">05 · the data model</p>
+    <h2>Three tiers. Schema-flat. Frontier-not-itinerary.</h2>
+
+    <div class="stack" style="margin-top: 6px;">
+<span class="h">Map</span>  <span class="d">— lifetime backlog (existing items + areas)</span>
+ └── <span class="h">Course</span>  <span class="d">— a 7-leg arc, ISO-week-stamped (COURSE-2026-W18)</span>
+      ├── <span class="v">theme</span>            <span class="d">one line: what this week is for</span>
+      ├── <span class="v">target_outcome</span>   <span class="d">how the map looks different by leg 7</span>
+      ├── <span class="v">frontier[]</span>       <span class="d">LAB item IDs reachable this week</span>
+      ├── <span class="v">bail_conditions</span>  <span class="d">when do we abandon this Course?</span>
+      ├── <span class="v">legs[]</span>           <span class="d">leg slots, filled progressively</span>
+      └── <span class="v">status</span>           <span class="d">planning · in-progress · debriefed · archived</span>
+
+      <span class="h">Leg</span>  <span class="d">— one Full Turn (LEG-2026-05-04-A)</span>
+       ├── <span class="v">course_ref</span>        <span class="d">parent course id</span>
+       ├── <span class="v">leg_number</span>        <span class="d">1..7</span>
+       ├── <span class="v">frame_card_id</span>     <span class="d">→ existing Frame card schema</span>
+       ├── <span class="v">comprehend[]</span>      <span class="d">timestamped on-demand notes</span>
+       ├── <span class="v">sync</span>              <span class="d">deferred placeholder</span>
+       ├── <span class="v">produce</span>           <span class="d">{ selected[], bonuses[], notes[] }</span>
+       ├── <span class="v">debrief_card_id</span>   <span class="d">→ existing Debrief card schema</span>
+       └── <span class="v">changes_to_course</span> <span class="d">writeback to course.frontier on debrief</span>
+    </div>
+  </section>
+
+  <!-- 7 — TWO VISUALIZATION METAPHORS -->
+  <section class="slide">
+    <p class="slide-tag">06 · two metaphors, two tiers</p>
+    <h2>Different cognitive jobs.<br>Different metaphors.</h2>
+
+    <div class="split">
+      <div class="col">
+        <div class="panel" style="border-color: rgba(74,123,212,0.45);">
+          <p class="px small" style="color:#6f9ee0;">course / map tier</p>
+          <h3>Hex Map · terrain</h3>
+          <p class="body">Items as hexes. Area accent = biome. Status = fog. P0 = red glow. Frontier = teal halo.</p>
+          <p class="body small dim">"Where am I in the bigger picture? What's reachable? What's been explored?"</p>
+          <div class="hex-band" style="margin-top: 10px;">
+            <div class="hex-cell"></div>
+            <div class="hex-cell amber"></div>
+            <div class="hex-cell amber bright"></div>
+            <div class="hex-cell green"></div>
+            <div class="hex-cell warm"></div>
+            <div class="hex-cell"></div>
+            <div class="hex-cell teal frontier"></div>
+            <div class="hex-cell dark dim"></div>
+            <div class="hex-cell amber frontier"></div>
+            <div class="hex-cell"></div>
+            <div class="hex-cell green dim"></div>
+            <div class="hex-cell warm"></div>
+            <div class="hex-cell amber"></div>
+            <div class="hex-cell teal"></div>
+            <div class="hex-cell dark"></div>
+            <div class="hex-cell green frontier"></div>
+          </div>
+        </div>
+      </div>
+      <div class="col">
+        <div class="panel" style="border-color: rgba(74,138,90,0.45);">
+          <p class="px small" style="color:#5cb09a;">leg tier</p>
+          <h3>Snap Circuit · wiring</h3>
+          <p class="body">Five components in signal-flow order. Each lights as data lands.</p>
+          <p class="body small dim">"What am I building this leg? Do I have all the components wired right?"</p>
+          <div style="display:flex; flex-direction: column; gap: 4px; margin-top: 10px; font-family: var(--font-px); font-size: 12px;">
+            <div style="display:flex; gap:8px; align-items:center;"><span style="font-size:18px;color:var(--frame-c);">🔋</span><span>Frame · power source</span></div>
+            <div style="text-align:center; color:var(--accent-dim);">▼</div>
+            <div style="display:flex; gap:8px; align-items:center;"><span style="font-size:18px;color:var(--comprehend-c);">⚡</span><span>Comprehend · amplifier</span></div>
+            <div style="text-align:center; color:var(--accent-dim);">▼</div>
+            <div style="display:flex; gap:8px; align-items:center;"><span style="font-size:18px;color:var(--sync-c);">≈</span><span>Sync · filter</span></div>
+            <div style="text-align:center; color:var(--accent-dim);">▼</div>
+            <div style="display:flex; gap:8px; align-items:center;"><span style="font-size:18px;color:var(--produce-c);">〰</span><span>Produce · live signal</span></div>
+            <div style="text-align:center; color:var(--accent-dim);">▼</div>
+            <div style="display:flex; gap:8px; align-items:center;"><span style="font-size:18px;color:var(--debrief-c);">🔊</span><span>Debrief · output stage</span></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 8 — BRUNER / SNAP CIRCUITS -->
+  <section class="slide">
+    <p class="slide-tag">07 · the design language</p>
+    <h2>Bruner + Kay + Snap Circuits<br><span class="dim" style="font-size:24px;">drives every visual choice from here.</span></h2>
+
+    <div class="grid-3" style="margin-top: 4px;">
+      <div class="panel">
+        <p class="px small accent">enactive</p>
+        <h3>know where you are · manipulate</h3>
+        <p class="body small">Picking, dragging, snapping things into place. Direct, tactile.</p>
+      </div>
+      <div class="panel">
+        <p class="px small accent">iconic</p>
+        <h3>recognize · compare · configure</h3>
+        <p class="body small">Glanceable visual states. Color, position, glow. Read in a beat.</p>
+      </div>
+      <div class="panel">
+        <p class="px small accent">symbolic</p>
+        <h3>long chains of reasoning · abstract</h3>
+        <p class="body small">Where the lab lived (text, JSON). Now: only when no other mode will do.</p>
+      </div>
+    </div>
+
+    <div class="quote" style="margin-top: 16px;">
+      "Constructing a diagram is much less difficult than trying to read one."<br>
+      <span class="small dim">— Alan Kay (per WS004)</span>
+    </div>
+
+    <p class="body" style="margin-top: 4px;">
+      <strong>Aspiration:</strong> the lab should feel like Snap Circuits, not MS-DOS.<br>
+      <span class="dim">Build the board next to the diagram. See the signal flow. Snap, don't type.</span>
+    </p>
+  </section>
+
+  <!-- 9 — COURSE VIEW -->
+  <section class="slide">
+    <p class="slide-tag">08 · what shipped — course view</p>
+    <h2>Course tab. Plan the week, see the map.</h2>
+
+    <div class="split" style="gap: 36px;">
+      <div class="col">
+        <p class="body">A new top-level toolbar tab. One screen for the whole week's setup:</p>
+        <ul class="tight body">
+          <li><strong>Theme</strong> — one line · what this week is for</li>
+          <li><strong>Target outcome</strong> — what looks different by leg 7</li>
+          <li><strong>Frontier picker</strong> — multi-select over all LAB items, P0/P1/P2 grouped</li>
+          <li><strong>Bail conditions</strong> — when we drop the week's plan</li>
+          <li><strong>Hex Map</strong> — frontier picks light up teal as you click</li>
+          <li><strong>On-demand Comprehend</strong> — capture re-immersion notes anytime</li>
+        </ul>
+        <p class="body dim small">Persists to <code>exports/courses.json</code> via the lab server.</p>
+      </div>
+      <div class="col">
+        <div class="sketch">
+          <div class="label">Course · 7-leg arc</div>
+          <div style="margin-top:8px; font-size:14px;">COURSE-2026-W18 · planning</div>
+          <hr class="hr">
+          <div>theme: <span style="color:var(--accent);">land the rogaine spine</span></div>
+          <div>target: <span class="dim">course tier shipped, hex map readable</span></div>
+          <div>frontier: <span class="accent">[ LAB-027 ] [ LAB-032 ] [ LAB-035 ]</span></div>
+          <div>bail: <span class="dim">if hex map proves unreadable</span></div>
+          <hr class="hr">
+          <div class="label" style="margin-top:8px;">Map · 41 items · 3 in frontier</div>
+          <div class="hex-band" style="margin-top:8px;">
+            <div class="hex-cell"></div><div class="hex-cell amber"></div>
+            <div class="hex-cell amber frontier"></div><div class="hex-cell green"></div>
+            <div class="hex-cell warm"></div><div class="hex-cell teal"></div>
+            <div class="hex-cell amber frontier"></div><div class="hex-cell dark dim"></div>
+            <div class="hex-cell green"></div><div class="hex-cell warm"></div>
+            <div class="hex-cell amber frontier"></div><div class="hex-cell"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 10 — COURSE HEADER BAR -->
+  <section class="slide">
+    <p class="slide-tag">09 · what shipped — course header</p>
+    <h2>One glanceable strip. Top of every workshop.</h2>
+
+    <div class="sketch" style="margin-top: 8px;">
+      <div style="display:flex; gap:18px; flex-wrap:wrap; align-items:center; font-family: var(--font-px); font-size: 13px;">
+        <span style="color:var(--accent); font-weight:bold;">LEG-2026-05-04-A</span>
+        <span class="led-bar">
+          <span class="led done"></span>
+          <span class="led done"></span>
+          <span class="led current"></span>
+          <span class="led"></span>
+          <span class="led"></span>
+          <span class="led"></span>
+          <span class="led"></span>
+        </span>
+        <span><span class="dim">MUSTS</span> <strong>2/3</strong></span>
+        <span><span class="dim">BONUS</span> <strong>1</strong></span>
+        <span><span class="dim">MAP</span> <strong>3/41 in scope</strong></span>
+        <span style="margin-left:auto; padding: 2px 8px; border:1px solid var(--panel-bd); border-radius:3px; text-transform:uppercase; letter-spacing:1px; font-size: 10px;">in-progress</span>
+      </div>
+    </div>
+
+    <div class="grid-2" style="margin-top: 16px;">
+      <div>
+        <h3 class="accent">What it shows</h3>
+        <ul class="tight body">
+          <li><strong>Leg ID</strong> — which leg is active</li>
+          <li><strong>7-segment LED bar</strong> — book title hook · current lit, prior dim, future ghosted</li>
+          <li><strong>MUSTS x/3</strong> — turns red if you go over cap</li>
+          <li><strong>BONUS x</strong> — Frame card's stretch[]</li>
+          <li><strong>MAP x/y in scope</strong> — frontier vs. total items</li>
+          <li><strong>Status badge</strong> — planning · in-progress · debriefed</li>
+        </ul>
+      </div>
+      <div>
+        <h3 class="accent">When it updates</h3>
+        <ul class="tight body">
+          <li>Every time you open a workshop drawer</li>
+          <li>After you save a Frame card (auto-creates leg if needed)</li>
+          <li>After you save a Debrief card (status flips to <span class="success" style="color:var(--success);">debriefed</span>)</li>
+        </ul>
+        <p class="body dim small" style="margin-top:8px;">Empty state when no leg yet: a clickable nudge to open the Course tab.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- 11 — LEG VIEW (SNAP CIRCUIT) -->
+  <section class="slide">
+    <p class="slide-tag">10 · what shipped — leg view</p>
+    <h2>Leg tab. The Snap Circuit board.</h2>
+
+    <p class="body">Five vertically-stacked component cards. Signal flows top to bottom.</p>
+
+    <div class="zones">
+      <div class="zone" data-z="frame">
+        <span class="glyph">🔋</span>
+        <span class="role">power source</span>
+        <span class="name">Frame</span>
+        <span class="desc">Linked Frame card's musts + bonuses as chips.</span>
+      </div>
+      <div class="zone" data-z="comprehend">
+        <span class="glyph">⚡</span>
+        <span class="role">amplifier</span>
+        <span class="name">Comprehend</span>
+        <span class="desc">Newest 3 notes from the leg's comprehend[].</span>
+      </div>
+      <div class="zone" data-z="sync">
+        <span class="glyph">≈</span>
+        <span class="role">filter</span>
+        <span class="name">Sync</span>
+        <span class="desc">Slot present, form deferred (LAB-035).</span>
+      </div>
+      <div class="zone" data-z="produce">
+        <span class="glyph">〰</span>
+        <span class="role">live signal</span>
+        <span class="name">Produce</span>
+        <span class="desc">Selected · bonuses · notes counters.</span>
+      </div>
+      <div class="zone" data-z="debrief">
+        <span class="glyph">🔊</span>
+        <span class="role">output stage</span>
+        <span class="name">Debrief</span>
+        <span class="desc">Course held? · caught · changes_to_course summary.</span>
+      </div>
+    </div>
+
+    <p class="body dim small" style="margin-top: 8px;">
+      Read-only v0.1. Click-throughs into the underlying forms are queued (LAB-037).
+    </p>
+  </section>
+
+  <!-- 12 — DEBRIEF REVISION -->
+  <section class="slide">
+    <p class="slide-tag">11 · what shipped — debrief rogaine shape</p>
+    <h2>Debrief: from 7 free-text probes<br>→ 6 fields that <span class="accent">write themselves</span>.</h2>
+
+    <div class="split">
+      <div class="col">
+        <p class="split-label before">— before</p>
+        <ul class="tight body">
+          <li>Subject · Framed · Actual · Diverged · Sustain · Improve · Capacity</li>
+          <li>Free text everywhere. Reconstructed Frame from memory.</li>
+          <li>"Where they diverged" was the thing that did the most work — and it was the same field as everything else.</li>
+        </ul>
+      </div>
+      <div class="col">
+        <p class="split-label after">— after (rogaine shape)</p>
+        <ul class="tight body">
+          <li><span class="accent">Score</span> · auto-derived from leg.frame · you verify, don't fill</li>
+          <li><span class="accent">Caught</span> · what you actually came home with</li>
+          <li><span class="accent">Course held?</span> · radio: as set / different / wrong from start</li>
+          <li><span class="accent">What changed it</span> · only meaningful if not "as set"</li>
+          <li><span class="accent">Better moves</span> · the slot for the future Course Coach</li>
+          <li><span class="accent">Capacity + next</span> · bridge to next leg</li>
+        </ul>
+      </div>
+    </div>
+    <p class="body dim small" style="margin-top: 8px;">
+      Save also writes back to <code>leg.changes_to_course</code> and bumps status → <span style="color:var(--success);">debriefed</span>. Old cards stay readable (legacy fields retained on view).
+    </p>
+  </section>
+
+  <!-- 13 — THE SPINE IN ACTION -->
+  <section class="slide">
+    <p class="slide-tag">12 · how it all flows</p>
+    <h2>One spine. Five lenses. Pulled through a turn.</h2>
+
+    <div class="flow">
+      <div class="flow-step" style="border-color: rgba(226,160,74,0.5);">
+        <span class="num">01</span>
+        <span class="nm">Plan</span>
+        <span class="ds">Course tab — set theme, target, frontier. Hex map highlights what's in scope.</span>
+      </div>
+      <span class="flow-arrow">→</span>
+      <div class="flow-step" style="border-color: rgba(74,123,212,0.5);">
+        <span class="num">02</span>
+        <span class="nm">Frame</span>
+        <span class="ds">Open Frame Workshop. Save a card → Leg auto-created → Course Header lights segment 1.</span>
+      </div>
+      <span class="flow-arrow">→</span>
+      <div class="flow-step" style="border-color: rgba(212,160,48,0.5);">
+        <span class="num">03</span>
+        <span class="nm">Comprehend</span>
+        <span class="ds">Mid-leg, drop notes from Course tab. Lands on leg.comprehend[]. Amplifier lights.</span>
+      </div>
+      <span class="flow-arrow">→</span>
+      <div class="flow-step" style="border-color: rgba(226,160,74,0.5);">
+        <span class="num">04</span>
+        <span class="nm">Produce</span>
+        <span class="ds">Work the leg. (Ledger UI: deferred — but the slot is real.)</span>
+      </div>
+      <span class="flow-arrow">→</span>
+      <div class="flow-step" style="border-color: rgba(74,138,90,0.5);">
+        <span class="num">05</span>
+        <span class="nm">Debrief</span>
+        <span class="ds">Save → Score auto · Course held? · changes_to_course writeback · status flips to debriefed.</span>
+      </div>
+    </div>
+
+    <p class="body" style="margin-top: 14px;">
+      <strong>The Leg view</strong> renders all of this as a single circuit board — same data, iconic shape.<br>
+      <strong>The Course Header</strong> rides at the top of every workshop drawer — same data, glanceable strip.
+    </p>
+  </section>
+
+  <!-- 14 — COURSE COACH (FUTURE) -->
+  <section class="slide">
+    <p class="slide-tag">13 · the named future</p>
+    <h2>Course Coach.<br><span class="dim" style="font-size:26px;">Reads legs[] like poker hand histories.</span></h2>
+
+    <div class="grid-2" style="margin-top: 6px;">
+      <div class="panel">
+        <h3>Why it has a slot now</h3>
+        <ul class="tight body">
+          <li>Debrief's <strong>Better moves</strong> field is reserved for it.</li>
+          <li>The Leg wrapper exists so it has something to <em>read</em>.</li>
+          <li>Naming the role keeps the architecture from drifting.</li>
+        </ul>
+      </div>
+      <div class="panel">
+        <h3>What it would do</h3>
+        <ul class="tight body">
+          <li>Cross-leg pattern surfacing (the Push that always overruns, the bonus that never gets touched).</li>
+          <li>Suggest moves for the next leg's Frame.</li>
+          <li>Doesn't decide. Suggests. Author still drives.</li>
+        </ul>
+        <p class="body dim small" style="margin-top:8px;">Filed as <strong>LAB-034</strong>. Not built tonight.</p>
+      </div>
+    </div>
+
+    <div class="quote" style="margin-top: 14px;">
+      "Like online poker coaches — review your hands, name better moves, calibrate over weeks."<br>
+      <span class="small dim">— author, design dialog</span>
+    </div>
+  </section>
+
+  <!-- 15 — DEFERRED LAB ITEMS -->
+  <section class="slide">
+    <p class="slide-tag">14 · what's deferred</p>
+    <h2>Eight LAB items spawned for the morning.</h2>
+
+    <div class="lab-list" style="margin-top: 4px;">
+      <span class="id">LAB-034</span><span>Course Coach agent (poker-coach for legs)</span><span class="pri">P2</span>
+      <span class="id">LAB-035</span><span>Sync station + form (the deferred filter zone)</span><span class="pri">P2</span>
+      <span class="id">LAB-036</span><span>Frame Approach iconic skin (mode/leaning/AI/Done flavor as icons)</span><span class="pri">P1</span>
+      <span class="id">LAB-037</span><span>Leg view click-throughs (zone → underlying form)</span><span class="pri">P2</span>
+      <span class="id">LAB-038</span><span>Frontier add/remove UI on Debrief save</span><span class="pri">P2</span>
+      <span class="id">LAB-039</span><span>Auto-archive stale undebriefed legs</span><span class="pri">P2</span>
+      <span class="id">LAB-040</span><span>Course planning surface inside Director's Desk drawer</span><span class="pri">P3</span>
+      <span class="id">LAB-041</span><span>Hex Map v0.2 (interaction + adjacency)</span><span class="pri">P2</span>
+    </div>
+
+    <p class="body dim small" style="margin-top: 16px;">
+      All visible in the lab — Backlog Wall, Director's Desk items list, frontier picker.
+      Larry filed them with brief + full text + suggested priority.
+    </p>
+  </section>
+
+  <!-- 16 — OPEN QUESTIONS / VETTING -->
+  <section class="slide">
+    <p class="slide-tag">15 · open calls · what to vet</p>
+    <h2>Where to push back before merge.</h2>
+
+    <div class="grid-2">
+      <div class="panel" style="border-color: rgba(212,160,48,0.5);">
+        <h3 class="accent">Architecture</h3>
+        <ul class="tight body">
+          <li>Does the leg-as-wrapper feel right, or should Frame have <em>been</em> the leg?</li>
+          <li>Is "frontier-not-itinerary" still the call after a real week?</li>
+          <li>Two visualization metaphors (hex + circuit) — coherent or fragmented?</li>
+        </ul>
+      </div>
+      <div class="panel" style="border-color: rgba(74,138,90,0.5);">
+        <h3 class="accent">Surface</h3>
+        <ul class="tight body">
+          <li>Course Header on Frame/Pilot/Debrief drawers — fits or crowds?</li>
+          <li>Hex Map at 41 items — readable or cluttered?</li>
+          <li>Snap Circuit board — feels like a board, or five disconnected cards?</li>
+          <li>Does any glyph render badly? (Sync's <code>≈</code> is the new one.)</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="grid-2" style="margin-top: 16px;">
+      <div class="panel" style="border-color: rgba(74,123,212,0.5);">
+        <h3 class="accent">Edges to poke</h3>
+        <ul class="tight body">
+          <li>Open Leg tab before saving any Frame card — empty-state link works?</li>
+          <li>Edit a pre-rogaine Debrief card — legacy fields preserved?</li>
+          <li>DevTools: confirm <code>POST /api/save/legs</code> + <code>POST /api/save/courses</code> fire.</li>
+        </ul>
+      </div>
+      <div class="panel" style="border-color: rgba(226,160,74,0.5);">
+        <h3 class="accent">Decision</h3>
+        <p class="body">If surfaces 1→5 feel like one spine flowing through different lenses → open the PR.</p>
+        <p class="body">If any seam feels broken → push back on Quenton before merge.</p>
+        <p class="body" style="margin-top: 10px;">
+          <a class="open-lab" style="margin-top:0; padding:8px 14px; font-size: 12px;" href="cognitive-lab-v0.1.html">→ open the lab</a>
+        </p>
+      </div>
+    </div>
+  </section>
+
+</div>
+
+<script>
+  const deck = document.getElementById('deck');
+  const slides = Array.from(document.querySelectorAll('.slide'));
+  const counter = document.getElementById('counter');
+  const progress = document.getElementById('progress');
+  const total = slides.length;
+
+  function currentIndex() {
+    const top = deck.scrollTop;
+    return Math.round(top / window.innerHeight);
+  }
+  function goTo(i) {
+    const idx = Math.max(0, Math.min(total - 1, i));
+    deck.scrollTo({ top: idx * window.innerHeight, behavior: 'smooth' });
+  }
+  function update() {
+    const i = currentIndex();
+    counter.textContent = String(i + 1).padStart(2, '0') + ' / ' + String(total).padStart(2, '0');
+    progress.style.width = (((i + 1) / total) * 100) + '%';
+  }
+
+  document.addEventListener('keydown', (e) => {
+    if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
+    const i = currentIndex();
+    if (e.key === 'ArrowRight' || e.key === 'PageDown' || e.key === ' ') {
+      e.preventDefault();
+      goTo(i + 1);
+    } else if (e.key === 'ArrowLeft' || e.key === 'PageUp') {
+      e.preventDefault();
+      goTo(i - 1);
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      goTo(0);
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      goTo(total - 1);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      goTo(0);
+    }
+  });
+
+  deck.addEventListener('scroll', () => {
+    requestAnimationFrame(update);
+  });
+  window.addEventListener('resize', update);
+  update();
+</script>
+
+</body>
+</html>

--- a/cognitive-lab/lab-server.py
+++ b/cognitive-lab/lab-server.py
@@ -8,6 +8,7 @@ Behavior:
   POST /api/save/debrief-cards    body = JSON array, written to exports/debrief-cards.json
   POST /api/save/pilot-checks     body = JSON array, written to exports/pilot-checks.json
   POST /api/save/courses          body = JSON array, written to exports/courses.json
+  POST /api/save/legs             body = JSON array, written to exports/legs.json
 
 Notes:
   - .md/.txt are served as text/plain so links open in a tab instead of downloading.
@@ -36,6 +37,7 @@ ALLOWED_TYPES = {
     "debrief-cards": "debrief-cards.json",
     "pilot-checks":  "pilot-checks.json",
     "courses":       "courses.json",
+    "legs":          "legs.json",
 }
 
 DEFAULT_PORT = 4322

--- a/cognitive-lab/lab-server.py
+++ b/cognitive-lab/lab-server.py
@@ -7,6 +7,7 @@ Behavior:
   POST /api/save/frame-cards      body = JSON array, written to exports/frame-cards.json
   POST /api/save/debrief-cards    body = JSON array, written to exports/debrief-cards.json
   POST /api/save/pilot-checks     body = JSON array, written to exports/pilot-checks.json
+  POST /api/save/courses          body = JSON array, written to exports/courses.json
 
 Notes:
   - .md/.txt are served as text/plain so links open in a tab instead of downloading.
@@ -34,6 +35,7 @@ ALLOWED_TYPES = {
     "frame-cards":   "frame-cards.json",
     "debrief-cards": "debrief-cards.json",
     "pilot-checks":  "pilot-checks.json",
+    "courses":       "courses.json",
 }
 
 DEFAULT_PORT = 4322


### PR DESCRIPTION
## Summary

The lab gains a course-as-spine architecture, a user-authored snap-circuit Build canvas, and a Comprehension Station that lets the lab teach itself via product walks. Driven by four design dialogs with Quenton across the arc; reviewed by grepzilla2 at every sub-phase.

**Major surfaces shipped:**

- **Course tier** (`COURSE-YYYY-Wnn`): theme, target, frontier, bail conditions, legs[], status. Sibling persistence pattern to Frame/Debrief/Pilot.
- **Leg wrapper** (`LEG-YYYY-MM-DD-A`): frame_card_id, comprehend[], sync, produce, debrief_card_id, changes_to_course writeback. One Full Turn nested inside a Course.
- **Course Header** at the top of every workshop drawer: 7-segment LED bar (book title), MUSTS x/3, BONUS x, MAP x/y in scope, status badge.
- **Comprehend Signals** (Phase 1.5): leg.comprehend[] entries auto-log on deck-opens (DECK_FILE_RE matcher) + status cycles to live/archived. Surveillance line: "intentional acts the user would expect to leave a record."
- **Frontier Wiring**: Frame picker scopes to course frontier by default with "Full lab" expand toggle. Off-frontier picks tagged for future Debrief writeback.
- **Hex Map** (3 lenses inside Course view): Build (user-authored canvas) / By function (biome regions) / By priority (concentric rings). Okabe-Ito color-blind palette. 4-state luminosity ramp (archived → available → in-frontier → active). Motion budget (single pulse + ambient breath, honors prefers-reduced-motion).
- **Build canvas** (the snap-circuit board): 7×10 grid, click-to-place from a tool drawer, action chip on placed pieces (Pick up / Remove), Apply Template + Clear board. `course.build_positions` schema persists user placements.
- **Snap Circuit Leg view**: 5 zones (Frame=power · Comprehend=amplifier · Sync=filter · Produce=signal · Debrief=output) with vertical signal flow.
- **Debrief revision** to rogaine shape: Score (auto-derived) · Caught · Course held? radio · What changed it · Better moves · Capacity + next.
- **Comprehend Station** workshop (Move 2): "Where you are" snapshot + Walk Studio. Two decks (turn-v0.1-map, comprehension-deck-v0.1) + one product walk (Build canvas v0.1) shipped. Iframe walk-mode (`?walk=1`) with banner + recursion defense + localStorage isolation.
- **Comprehension deck** (`comprehension-deck-v0.1.html`): 16-slide vertical scroll-snap deck walking the rogaine-spine arc. Filed in the Deck Theater area.
- **Floor reorder**: Comprehend leads Band 2 now (C-before-F). Comprehend Station promoted to `workshop:true`.

**Persistence:** new types `courses` + `legs` added to `lab-server.py` ALLOWED_TYPES. localStorage + fire-and-forget POST + hydrate on load (existing pattern).

**Larry session-close artifacts** captured along the way: 17+ chunks, 3 DECISIONS.md sections, 24 LAB items spawned (LAB-034 through LAB-057) tracking deferred work.

**Files changed:**
- `cognitive-lab/cognitive-lab-v0.1.html` — +4959 / -144 (the lab itself)
- `cognitive-lab/comprehension-deck-v0.1.html` — new file (1014 lines)
- `cognitive-lab/DECISIONS.md` — +214 lines (architectural decisions across the arc)
- `cognitive-lab/lab-server.py` — +4 (new ALLOWED_TYPES entries)
- `.gitignore` — +1 (.claude/ runtime artifacts)

## Test plan

- [ ] Hard-refresh `http://127.0.0.1:4322/cognitive-lab-v0.1.html` to load the new code
- [ ] Floor: Band 2 reads Comprehend → Frame → Sync → Produce → Debrief → Recover
- [ ] Click Comprehend Station: workshop drawer opens with snapshot + Walk Studio
- [ ] Click "Walk: Build canvas v0.1" → iframe loads in walk mode (orange banner top, Comprehend dim+locked inside iframe)
- [ ] Step through the walk; click Done on step 7 → walk-completion logged to leg.comprehend[] (visible in the snapshot's "Last 3 acts" as a `walk` chip)
- [ ] Click "The Rogaine Spine" deck → iframe loads it; auto-logs as `deck` kind
- [ ] Course view: three sub-tabs (Build / By function / By priority); Build is default; placement persists across lens switches
- [ ] Frame Workshop picker: scopes to course frontier by default; "Full lab" toggle works; off-frontier picks get a `↗` chip badge
- [ ] Course Header bar appears at top of Frame, Pilot Check, Debrief drawers
- [ ] Status-cycle any item to live/archived → synthesis entry appears in Comprehend zone of Leg view
- [ ] Hover any hex on the By-priority or By-function lens → instant tooltip with genus:species format

🤖 Generated with [Claude Code](https://claude.com/claude-code)