### PR TITLE
Add Director's Desk as a pending-room Drive folder

### DIFF
--- a/cognitive-lab/DRIVE.md
+++ b/cognitive-lab/DRIVE.md
@@ -1,18 +1,19 @@
 # Drive filing — cognitive lab holding pens
 
 `file-to-drive.py` is the agent-callable CLI for filing documents into the
-lab's four Drive folders. It exists because the Claude.ai Drive MCP can
+lab's Drive folders. It exists because the Claude.ai Drive MCP can
 create files at root but cannot write into specific folders, which breaks
 the holding-pen pattern.
 
 Folder targets (already created in Drive):
 
-| `--area`    | Drive folder        |
-| ----------- | ------------------- |
-| `research`  | Research Repository |
-| `journal`   | Daily Journal       |
-| `explainer` | Explainer Theater   |
-| `strategy`  | Strategy & Plans    |
+| `--area`        | Drive folder        |
+| --------------- | ------------------- |
+| `research`      | Research Repository |
+| `journal`       | Daily Journal       |
+| `explainer`     | Explainer Theater   |
+| `strategy`      | Strategy & Plans    |
+| `director-desk` | Director's Desk (pending-room — staged for a future Band-1 surface) |
 
 ## Setup (one-time, ~5 min)
 

--- a/cognitive-lab/file-to-drive.py
+++ b/cognitive-lab/file-to-drive.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python3
 """
 file-to-drive.py — agent-callable CLI for filing documents into the
-Cognitive Lab's four Drive holding-pen folders, and updating their
+Cognitive Lab's Drive holding-pen folders, and updating their
 manifests so the lab can render them.
+
+Areas: research / journal / explainer / strategy (the four Band-1
+holding pens) plus director-desk (pending-room: a Drive folder for
+operational/team-management content staged for the Director's Desk
+surface, which doesn't yet have a Band-1 home or filingGuide).
 
 Behavior:
   python3 file-to-drive.py --area research|journal|explainer
@@ -73,10 +78,11 @@ CREDENTIALS_PATH = CONFIG_DIR / "credentials.json"
 TOKEN_PATH = CONFIG_DIR / "token.json"
 
 AREA_FOLDERS = {
-    "research":  "1PniRQqXbOGSPom17VW2a20dDosSVOLR1",
-    "journal":   "1xtdbKRy1SG42wVegT_uM94MY-LB8IJZW",
-    "explainer": "1_uPvHyY0yAgCZnMyD9bdwyTIBM_Ox7EO",
-    "strategy":  "1YNuePt3ccfIxpZRipwmqnRZcQ5-I83jx",
+    "research":      "1PniRQqXbOGSPom17VW2a20dDosSVOLR1",
+    "journal":       "1xtdbKRy1SG42wVegT_uM94MY-LB8IJZW",
+    "explainer":     "1_uPvHyY0yAgCZnMyD9bdwyTIBM_Ox7EO",
+    "strategy":      "1YNuePt3ccfIxpZRipwmqnRZcQ5-I83jx",
+    "director-desk": "19GlR6pg6hZRTCnhgIz2BEgaOBZxyj7mn",
 }
 
 # format → (upload mime type, convert to Google native type)


### PR DESCRIPTION
## Summary

Stages `/Cognitive Lab/Director's Desk/` as a Drive folder for operational source material (PROCESS.md, DECISIONS.md, SESSION_PROMPTS.md) destined for a Band-1 area that exists in the lab JSON (`data-area=\"director-desk\"`) but doesn't yet have a filingGuide / drawer / room story.

## Why now

These three files are core to how Dan manages the lab's AI team. They live canonically in the lab repo, but they're also the kind of source material that the Director's Desk surface will need to read from once the surface gets built. Without a holding pen, they either (a) get filed somewhere wrong (e.g., Strategy & Plans, which is for roadmaps/architecture) or (b) stay repo-only and we lose the option to surface them via the lab UI.

Lowest-cost option: a Drive folder + one entry in `AREA_FOLDERS`. No Band-1 area, no filingGuide, no DOM work.

## Discipline

Filings under `--area director-desk` should be tagged `pending-room` so they're trivially findable when Director's Desk gets designed.

## Test plan

- [x] Drive folder created and confirmed under `/Cognitive Lab/`
- [x] Script `--help` lists `director-desk` in the `--area` choices
- [ ] First filing under `--area director-desk` lands in the right folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)