### PR TITLE
Lab v0.5: Drive-canonical journal + Band-1 holding-pen drawers + workshop card mirror

### DIFF
--- a/cognitive-lab/DRIVE.md
+++ b/cognitive-lab/DRIVE.md
@@ -132,6 +132,64 @@ outside the repo. Never check them in.
 
 ## Scope
 
-This CLI is the **write path** only. Reads / search / browse happen in
-Drive's own UI. The lab itself stays a static HTML viewer that imports
-exports as needed.
+`file-to-drive.py` is the **generic write path** for filing whole
+documents into one of the holding-pen folders. Reads / search /
+browse happen in Drive's own UI. The lab itself stays a static HTML
+viewer that imports exports as needed.
+
+For the Daily Journal's three shelves (Scratchpad, Decision Log,
+Editions), `file-to-drive.py` handles Editions but Scratchpad and
+Decision Log have their own append-style CLIs — see below.
+
+---
+
+# Journal entry-add CLIs
+
+The Daily Journal's Scratchpad and Decision Log shelves are
+Drive-canonical, with one dated md file per day per shelf. Two small
+CLIs append entries to today's docs (creating the dated doc on first
+use of the day):
+
+## scratchpad-add.py
+
+```bash
+python3 cognitive-lab/scratchpad-add.py \
+  "Three rooms of the lab need filing — could be agentic." \
+  --tags lab-cleanup,filing
+```
+
+Behavior:
+- Looks up today's scratchpad doc in `journal-manifest.json`
+  (matched on `shelf="scratchpad"` + today's local date).
+- If found: fetches current content via Drive API, appends the new
+  entry with timestamp + tags, uploads via `--update-id` semantics.
+  Drive keeps the per-edit revision history.
+- If not: creates a new dated md doc (`<date> — scratchpad`),
+  populates with the entry as first content, appends a manifest
+  entry with `shelf="scratchpad"`.
+
+Prints the Drive URL on stdout. Subsequent same-day calls return the
+same URL (same doc, appended).
+
+## decision-log-add.py
+
+```bash
+python3 cognitive-lab/decision-log-add.py \
+  "Backlog Wall retired; status views replace it." \
+  --why "Item-area anchoring + toolbar views provide same coverage with less surface." \
+  --by "Dan + Claude (PR #134 design)" \
+  --link "https://github.com/sociotechnica-org/lifebuild-site/pull/134" \
+  --tags architecture
+```
+
+Same behavior as `scratchpad-add.py`, but writes to the decision-log
+shelf with structured fields (Why / By / Links). `--link` is
+repeatable.
+
+## Manifest schema — `shelf` discriminator
+
+Journal manifest entries gain a `shelf` field with values
+`"edition" | "scratchpad" | "decisionLog"`. Lab UI filters by `shelf`
+to render each tab. Pre-existing entries without `shelf` are legacy
+(filed before this convention) and should be treated as `"edition"`
+or backfilled as needed.

--- a/cognitive-lab/DRIVE.md
+++ b/cognitive-lab/DRIVE.md
@@ -193,3 +193,52 @@ Journal manifest entries gain a `shelf` field with values
 to render each tab. Pre-existing entries without `shelf` are legacy
 (filed before this convention) and should be treated as `"edition"`
 or backfilled as needed.
+
+---
+
+# Workshop card cloud mirror
+
+`lab-server.py` mirrors workshop-card saves (frame-cards / debrief-cards
+/ pilot-checks / courses / legs) to a single Drive doc per card type
+in `/Cognitive Lab/Workshop Cards/`. The local file remains canonical
+for fast read; Drive is a durable backup with version history.
+
+## Behavior
+
+- After each successful local atomic write, the same JSON content is
+  uploaded to Drive (or used to update the existing Drive doc, via
+  `files().update()`).
+- First save of a card type creates the Drive doc; subsequent saves
+  overwrite content and Drive's revision history captures the change.
+- The mapping `save_type → driveId` is tracked at
+  `cognitive-lab/exports/workshop-cards-manifest.json` (gitignored).
+- Mirror is **best-effort and fail-silent**: if google deps aren't
+  installed (i.e., the venv isn't active when launching
+  `lab-server.py`), or auth fails, the mirror is skipped and a warning
+  goes to stderr. Local saves always succeed.
+
+## Activation
+
+Run `lab-server.py` from the venv that has the Drive deps installed:
+
+```bash
+source cognitive-lab/.venv/bin/activate
+python3 cognitive-lab/lab-server.py
+```
+
+On startup you'll see:
+
+```
+[lab-server] drive mirror → /Cognitive Lab/Workshop Cards/
+```
+
+If you don't see that line, the mirror is disabled (fall back to
+local-only). Common cause: launched without the venv. Fix: activate
+the venv and restart.
+
+## Format
+
+`text/plain` with the raw JSON content. Drive shows it readably; the
+local JSON file remains the canonical-format source. Switching to
+`gdoc` auto-conversion was avoided because round-trip would lose JSON
+shape on each update.

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -9350,12 +9350,25 @@
     strategy:       'Plans & Source Material',
   };
 
-  // Fetch a manifest from cognitive-lab/exports/<area>-manifest.json.
+  // Map lab area.id → manifest slug used by file-to-drive.py and the
+  // exports/<slug>-manifest.json file. The lab keeps legacy area IDs
+  // (library / archive / deck-theater) per LAB-060's display-vs-
+  // identifier split; the script's --area flags are the new short
+  // names. This mapping bridges them.
+  const AREA_TO_MANIFEST_SLUG = {
+    library:        'research',
+    archive:        'journal',
+    'deck-theater': 'explainer',
+    strategy:       'strategy',
+  };
+
+  // Fetch a manifest from cognitive-lab/exports/<slug>-manifest.json.
   // Returns [] if the file is missing or unreachable (e.g., file://
   // protocol with no lab-server.py running).
   async function loadAreaManifest(areaId) {
+    const slug = AREA_TO_MANIFEST_SLUG[areaId] || areaId;
     try {
-      const r = await fetch(`exports/${areaId}-manifest.json`, { cache: 'no-store' });
+      const r = await fetch(`exports/${slug}-manifest.json`, { cache: 'no-store' });
       if (!r.ok) return [];
       const data = await r.json();
       return Array.isArray(data) ? data : [];
@@ -9432,10 +9445,11 @@
     const entries = sortManifestByDateDesc(await loadAreaManifest(area.id));
 
     const srcList = document.getElementById('sources-list');
+    const slug = AREA_TO_MANIFEST_SLUG[area.id] || area.id;
     if (entries.length === 0) {
       srcList.innerHTML = `
         <div class="manifest-section-label">${shelfName}</div>
-        <div class="manifest-empty">No entries yet. File one with <code>file-to-drive.py --area ${area.id}</code>.</div>`;
+        <div class="manifest-empty">No entries yet. File one with <code>file-to-drive.py --area ${slug}</code>.</div>`;
     } else {
       srcList.innerHTML = `
         <div class="manifest-section-label">${shelfName} (${entries.length})</div>

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -4615,6 +4615,108 @@
   }
   .archive-text { font-size: 12px; color: var(--fg); line-height: 1.5; margin-top: 2px; }
 
+  /* ── Manifest-driven Band-1 holding-pen drawer ── */
+  .manifest-section-label {
+    font-family: var(--font-px);
+    font-size: 9px;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--accent);
+    margin: 12px 0 6px 0;
+    padding-bottom: 2px;
+    border-bottom: 1px solid var(--panel-bd);
+  }
+  .manifest-section-label:first-child { margin-top: 0; }
+  .manifest-row {
+    display: block;
+    text-decoration: none;
+    color: var(--fg);
+    padding: 8px 6px;
+    border-bottom: 1px solid var(--panel-bd);
+    transition: background 0.12s;
+  }
+  .manifest-row:last-child { border-bottom: 0; }
+  .manifest-row:hover { background: rgba(94, 207, 192, 0.06); color: var(--fg); }
+  .manifest-row-head {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    flex-wrap: wrap;
+    font-size: 12px;
+  }
+  .manifest-date {
+    font-family: var(--font-px);
+    font-size: 10px;
+    color: var(--accent-dim);
+    flex-shrink: 0;
+  }
+  .manifest-fmt {
+    font-family: var(--font-px);
+    font-size: 9px;
+    color: var(--accent-dim);
+    text-transform: lowercase;
+    flex-shrink: 0;
+  }
+  .manifest-title {
+    flex: 1;
+    color: var(--fg);
+    font-weight: 500;
+  }
+  .manifest-arrow {
+    color: var(--accent-dim);
+    flex-shrink: 0;
+    opacity: 0.5;
+  }
+  .manifest-row:hover .manifest-arrow { color: var(--accent); opacity: 1; }
+  .manifest-summary {
+    margin-top: 4px;
+    font-size: 11px;
+    color: var(--accent-dim);
+    line-height: 1.4;
+    font-style: italic;
+  }
+  .manifest-tags {
+    margin-top: 4px;
+    font-size: 10px;
+  }
+  .manifest-tag {
+    display: inline-block;
+    margin-right: 6px;
+    color: var(--accent-dim);
+    font-family: var(--font-px);
+  }
+  .manifest-empty {
+    color: #888;
+    font-size: 12px;
+    font-style: italic;
+    padding: 8px 6px;
+  }
+  .manifest-empty code {
+    font-family: var(--font-px);
+    font-size: 11px;
+    color: var(--accent-dim);
+    background: rgba(0, 0, 0, 0.15);
+    padding: 1px 4px;
+    border-radius: 2px;
+  }
+  details.legacy-notes {
+    margin-top: 16px;
+    padding-top: 12px;
+    border-top: 1px dashed var(--panel-bd);
+  }
+  details.legacy-notes summary {
+    font-family: var(--font-px);
+    font-size: 9px;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--accent-dim);
+    cursor: pointer;
+    margin-bottom: 8px;
+  }
+  details.legacy-notes summary:hover { color: var(--accent); }
+
   /* ── Scrollbar style ── */
   #drawer-body::-webkit-scrollbar { width: 4px; }
   #drawer-body::-webkit-scrollbar-thumb { background: var(--panel-bd); border-radius: 2px; }
@@ -9235,10 +9337,193 @@
   })();
 
   /* ── Area view ── */
+  // Band-1 holding pens are information-storage areas (Drive-canonical,
+  // manifest-driven). Their drawer is a different shape from the Band-2
+  // workshop drawers (Items / Chapter / Experiments). showAreaView
+  // dispatches to the right renderer.
+  const BAND1_HOLDING_PENS = ['library', 'archive', 'deck-theater', 'strategy'];
+
+  // Display labels for the manifest-driven shelf, per area.
+  const HOLDING_PEN_SHELF_NAMES = {
+    library:        'Reports',
+    'deck-theater': 'Explainers',
+    strategy:       'Plans & Source Material',
+  };
+
+  // Fetch a manifest from cognitive-lab/exports/<area>-manifest.json.
+  // Returns [] if the file is missing or unreachable (e.g., file://
+  // protocol with no lab-server.py running).
+  async function loadAreaManifest(areaId) {
+    try {
+      const r = await fetch(`exports/${areaId}-manifest.json`, { cache: 'no-store' });
+      if (!r.ok) return [];
+      const data = await r.json();
+      return Array.isArray(data) ? data : [];
+    } catch (_e) {
+      return [];
+    }
+  }
+
+  // Render a single manifest row (date · format · title · summary · tags).
+  function renderManifestRow(entry) {
+    const safeTitle = (entry.title || '(untitled)').replace(/</g, '&lt;');
+    const safeSummary = (entry.summary || '').replace(/</g, '&lt;');
+    const tags = (entry.tags || []).map(t => `<span class="manifest-tag">#${t}</span>`).join(' ');
+    const fmt = entry.format ? `<span class="manifest-fmt">[${entry.format}]</span>` : '';
+    const date = entry.date || '';
+    const url = entry.driveUrl || (entry.driveId ? `https://drive.google.com/file/d/${entry.driveId}/view` : '#');
+    return `
+      <a class="manifest-row" href="${url}" target="_blank" rel="noopener">
+        <div class="manifest-row-head">
+          <span class="manifest-date">${date}</span>
+          ${fmt}
+          <span class="manifest-title">${safeTitle}</span>
+          <span class="manifest-arrow">↗</span>
+        </div>
+        ${safeSummary ? `<div class="manifest-summary">${safeSummary}</div>` : ''}
+        ${tags ? `<div class="manifest-tags">${tags}</div>` : ''}
+      </a>`;
+  }
+
+  // Sort entries by date (string YYYY-MM-DD) descending. Falls back to title.
+  function sortManifestByDateDesc(entries) {
+    return [...entries].sort((a, b) => {
+      const da = a.date || '';
+      const db = b.date || '';
+      if (da !== db) return db.localeCompare(da);
+      return (a.title || '').localeCompare(b.title || '');
+    });
+  }
+
+  // Hide the workshop-only shelf tiles for Band-1 drawers.
+  function setWorkshopShelvesVisible(visible) {
+    ['items', 'experiments', 'chapter'].forEach(name => {
+      const tile = document.querySelector(`.shelf-tile[data-shelf="${name}"]`);
+      if (tile) tile.style.display = visible ? '' : 'none';
+    });
+  }
+
   function showAreaView(area) {
     areaView.classList.remove('hidden');
     ddView.classList.remove('visible');
 
+    if (area.id === 'archive') {
+      setWorkshopShelvesVisible(false);
+      showJournalDrawer(area);
+      return;
+    }
+    if (BAND1_HOLDING_PENS.includes(area.id)) {
+      setWorkshopShelvesVisible(false);
+      showHoldingPenDrawer(area);
+      return;
+    }
+    setWorkshopShelvesVisible(true);
+    showWorkshopDrawer(area);
+  }
+
+  // Generic Band-1 holding-pen drawer: single manifest-driven shelf.
+  // Used by Research Repository, Explainer Theater, Strategy & Plans.
+  // The Daily Journal has its own drawer (three shelves).
+  async function showHoldingPenDrawer(area) {
+    const infoTip = document.getElementById('drawer-info');
+    if (infoTip) infoTip.setAttribute('data-tip', area.description || '');
+
+    const shelfName = HOLDING_PEN_SHELF_NAMES[area.id] || 'Sources';
+    const entries = sortManifestByDateDesc(await loadAreaManifest(area.id));
+
+    const srcList = document.getElementById('sources-list');
+    if (entries.length === 0) {
+      srcList.innerHTML = `
+        <div class="manifest-section-label">${shelfName}</div>
+        <div class="manifest-empty">No entries yet. File one with <code>file-to-drive.py --area ${area.id}</code>.</div>`;
+    } else {
+      srcList.innerHTML = `
+        <div class="manifest-section-label">${shelfName} (${entries.length})</div>
+        ${entries.map(renderManifestRow).join('')}`;
+    }
+
+    setActiveShelf('sources');
+    updateShelfTile('sources', entries.length);
+    updateShelfTile('items', 0);
+    updateShelfTile('experiments', 0);
+    updateShelfTile('chapter', 0);
+
+    const gapsBadge = document.getElementById('shelf-items-gaps');
+    if (gapsBadge) gapsBadge.classList.remove('show');
+  }
+
+  // The Daily Journal drawer: three shelves (Scratchpad, Decision Log,
+  // Editions) read from journal-manifest.json filtered by `shelf`. Plus
+  // a collapsible "Pre-Newspaper Notes" toggle for legacy labNotes /
+  // decisions / shipped fields preserved in the area JSON.
+  async function showJournalDrawer(area) {
+    const infoTip = document.getElementById('drawer-info');
+    if (infoTip) infoTip.setAttribute('data-tip', area.description || '');
+
+    const all = await loadAreaManifest(area.id);
+    const scratchpad  = sortManifestByDateDesc(all.filter(e => e.shelf === 'scratchpad'));
+    const decisionLog = sortManifestByDateDesc(all.filter(e => e.shelf === 'decisionLog'));
+    const editions    = sortManifestByDateDesc(all.filter(e => !e.shelf || e.shelf === 'edition'));
+
+    const renderShelf = (label, list, hint) => {
+      if (list.length === 0) {
+        return `
+          <div class="manifest-section-label">${label}</div>
+          <div class="manifest-empty">${hint}</div>`;
+      }
+      return `
+        <div class="manifest-section-label">${label} (${list.length})</div>
+        ${list.map(renderManifestRow).join('')}`;
+    };
+
+    // Pre-Newspaper Notes (legacy fields preserved as historical record).
+    let legacyHTML = '';
+    const hasLegacy = (area.labNotes && area.labNotes.length) ||
+                      (area.decisions && area.decisions.length) ||
+                      (area.shipped && area.shipped.length);
+    if (hasLegacy) {
+      legacyHTML += `<details class="legacy-notes"><summary>Pre-Newspaper Notes</summary>`;
+      if (area.labNotes && area.labNotes.length) {
+        legacyHTML += '<div class="drawer-section-label" style="margin-top:8px;">Lab notes (archive)</div>';
+        legacyHTML += area.labNotes.map(n =>
+          `<div class="archive-entry"><div class="archive-date">${n.date}</div><div class="archive-text">${n.text}</div></div>`
+        ).join('');
+      }
+      if (area.decisions && area.decisions.length) {
+        legacyHTML += '<div class="drawer-section-label" style="margin-top:8px;">Decisions log</div>';
+        legacyHTML += area.decisions.map(n =>
+          `<div class="archive-entry"><div class="archive-date">${n.date}</div><div class="archive-text">${n.text}</div></div>`
+        ).join('');
+      }
+      if (area.shipped && area.shipped.length) {
+        legacyHTML += '<div class="drawer-section-label" style="margin-top:8px;">Shipped</div>';
+        legacyHTML += area.shipped.map(s => `<div class="src-item">${s}</div>`).join('');
+      }
+      legacyHTML += `</details>`;
+    }
+
+    const srcList = document.getElementById('sources-list');
+    srcList.innerHTML =
+      renderShelf('Scratchpad',   scratchpad,  'No entries yet. Use <code>scratchpad-add.py</code> to capture a thought.') +
+      renderShelf('Decision Log', decisionLog, 'No decisions logged yet. Use <code>decision-log-add.py</code>.') +
+      renderShelf('Editions',     editions,    'No editions yet. End-of-day publish creates one.') +
+      legacyHTML;
+
+    setActiveShelf('sources');
+    updateShelfTile('sources', scratchpad.length + decisionLog.length + editions.length);
+    updateShelfTile('items', 0);
+    updateShelfTile('experiments', 0);
+    updateShelfTile('chapter', 0);
+
+    const gapsBadge = document.getElementById('shelf-items-gaps');
+    if (gapsBadge) gapsBadge.classList.remove('show');
+  }
+
+  // Band-2 phase-workshop drawer (Frame, Comprehend, Sync, Push, Debrief,
+  // Recover, Director's Desk, Pilot Check Station, etc.). Items / Chapter
+  // / Experiments / Sources shelves. Unchanged from prior behavior; only
+  // the dispatch point changed.
+  function showWorkshopDrawer(area) {
     // Description → moved to (i) tooltip in drawer header
     const infoTip = document.getElementById('drawer-info');
     if (infoTip) infoTip.setAttribute('data-tip', area.description || '');

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -9394,6 +9394,17 @@
       .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
   }
 
+  // URL guard — escHtml prevents attribute breakout but doesn't reject
+  // dangerous schemes. A hand-edited manifest with a `javascript:` entry
+  // would render as a clickable link that runs script. Whitelist to
+  // http(s) and same-origin relative paths. Anything else falls back to '#'.
+  function safeUrl(s) {
+    if (!s) return '#';
+    const trimmed = String(s).trim();
+    if (/^(https?:\/\/|\/|#)/i.test(trimmed)) return escHtml(trimmed);
+    return '#';
+  }
+
   // Render a single manifest row (date · format · title · summary · tags).
   function renderManifestRow(entry) {
     const title = escHtml(entry.title || '(untitled)');
@@ -9404,7 +9415,7 @@
       .map(t => `<span class="manifest-tag">#${escHtml(t)}</span>`)
       .join(' ');
     const url = entry.driveUrl
-      ? escHtml(entry.driveUrl)
+      ? safeUrl(entry.driveUrl)
       : (entry.driveId ? `https://drive.google.com/file/d/${escHtml(entry.driveId)}/view` : '#');
     return `
       <a class="manifest-row" href="${url}" target="_blank" rel="noopener">

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -9355,6 +9355,12 @@
   // (library / archive / deck-theater) per LAB-060's display-vs-
   // identifier split; the script's --area flags are the new short
   // names. This mapping bridges them.
+  //
+  // Note: director-desk is intentionally omitted — it has no Band-1
+  // holding-pen home yet (pending-room). file-to-drive.py supports
+  // --area director-desk and a Drive folder exists, but the lab
+  // routes director-desk to showWorkshopDrawer (its prior behavior)
+  // until the surface gets designed.
   const AREA_TO_MANIFEST_SLUG = {
     library:        'research',
     archive:        'journal',
@@ -9377,24 +9383,39 @@
     }
   }
 
+  // HTML escape — used uniformly for all manifest field interpolations.
+  // Manifest entries come from local CLI inputs (not untrusted sources)
+  // so the threat model is low, but inconsistent escaping is still a
+  // footgun (e.g., a `"` in driveUrl could break out of an href attribute,
+  // a `<` in format could produce malformed HTML).
+  function escHtml(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+
   // Render a single manifest row (date · format · title · summary · tags).
   function renderManifestRow(entry) {
-    const safeTitle = (entry.title || '(untitled)').replace(/</g, '&lt;');
-    const safeSummary = (entry.summary || '').replace(/</g, '&lt;');
-    const tags = (entry.tags || []).map(t => `<span class="manifest-tag">#${t}</span>`).join(' ');
-    const fmt = entry.format ? `<span class="manifest-fmt">[${entry.format}]</span>` : '';
-    const date = entry.date || '';
-    const url = entry.driveUrl || (entry.driveId ? `https://drive.google.com/file/d/${entry.driveId}/view` : '#');
+    const title = escHtml(entry.title || '(untitled)');
+    const summary = escHtml(entry.summary || '');
+    const date = escHtml(entry.date || '');
+    const fmt = entry.format ? `<span class="manifest-fmt">[${escHtml(entry.format)}]</span>` : '';
+    const tagsHTML = (entry.tags || [])
+      .map(t => `<span class="manifest-tag">#${escHtml(t)}</span>`)
+      .join(' ');
+    const url = entry.driveUrl
+      ? escHtml(entry.driveUrl)
+      : (entry.driveId ? `https://drive.google.com/file/d/${escHtml(entry.driveId)}/view` : '#');
     return `
       <a class="manifest-row" href="${url}" target="_blank" rel="noopener">
         <div class="manifest-row-head">
           <span class="manifest-date">${date}</span>
           ${fmt}
-          <span class="manifest-title">${safeTitle}</span>
+          <span class="manifest-title">${title}</span>
           <span class="manifest-arrow">↗</span>
         </div>
-        ${safeSummary ? `<div class="manifest-summary">${safeSummary}</div>` : ''}
-        ${tags ? `<div class="manifest-tags">${tags}</div>` : ''}
+        ${summary ? `<div class="manifest-summary">${summary}</div>` : ''}
+        ${tagsHTML ? `<div class="manifest-tags">${tagsHTML}</div>` : ''}
       </a>`;
   }
 

--- a/cognitive-lab/decision-log-add.py
+++ b/cognitive-lab/decision-log-add.py
@@ -35,7 +35,6 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
-import sys
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path

--- a/cognitive-lab/decision-log-add.py
+++ b/cognitive-lab/decision-log-add.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""
+decision-log-add.py — append a decision to today's decision-log doc in Drive.
+
+The Daily Journal's Decision Log shelf is Drive-canonical: one dated
+md file per day, in the Daily Journal Drive folder, indexed by
+journal-manifest.json with shelf="decisionLog". This CLI is the
+agent-callable + human-callable append.
+
+Behavior:
+  python3 decision-log-add.py "<decision>" \
+    [--why "..."] [--by "..."] [--link URL] [--tags tag1,tag2]
+
+  - Looks up today's decision-log doc in journal-manifest.json
+    (matched on shelf="decisionLog" + today's local date).
+  - If found: fetches current content, appends the new decision
+    with a timestamp + structured fields, uploads via Drive API.
+  - If not: creates a new dated md doc with the decision as first
+    content, appends a manifest entry with shelf="decisionLog".
+
+Prints the Drive URL on stdout. Non-zero exit on failure.
+
+Auth:
+  Reuses ~/.config/cognitive-lab/credentials.json + token.json — same
+  OAuth setup as file-to-drive.py.
+
+Notes:
+  - --link can be passed multiple times to attach multiple URLs.
+  - Format is `md` (markdown). Round-trip is plain Drive API + the
+    shared file-to-drive helpers.
+  - "Today" is the operator's local date, not UTC.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Load file-to-drive.py as a module despite the hyphen in its name.
+SCRIPT_DIR = Path(__file__).resolve().parent
+FTD_PATH = SCRIPT_DIR / "file-to-drive.py"
+_spec = importlib.util.spec_from_file_location("file_to_drive", str(FTD_PATH))
+ftd = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(ftd)
+
+from googleapiclient.discovery import build  # noqa: E402
+from googleapiclient.errors import HttpError  # noqa: E402
+
+SHELF = "decisionLog"
+JOURNAL_AREA = "journal"
+
+
+def today_local_date() -> str:
+    return datetime.now().strftime("%Y-%m-%d")
+
+
+def now_local_time() -> str:
+    return datetime.now().strftime("%H:%M")
+
+
+def utc_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def find_today_entry(date: str) -> dict | None:
+    for entry in ftd.read_manifest(JOURNAL_AREA):
+        if entry.get("shelf") == SHELF and entry.get("date") == date:
+            return entry
+    return None
+
+
+def fetch_md(service, file_id: str) -> str:
+    raw = service.files().get_media(fileId=file_id).execute()
+    return raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
+
+
+def render_decision(decision: str, why: str, by: str,
+                    links: list[str], tags: list[str]) -> str:
+    parts = [f"\n## {now_local_time()} — {decision}\n"]
+    if why:
+        parts.append(f"\n**Why:** {why}\n")
+    if by:
+        parts.append(f"\n**By:** {by}\n")
+    if links:
+        parts.append("\n**Links:**\n")
+        parts.extend(f"- {url}\n" for url in links)
+    if tags:
+        parts.append("\n" + " ".join(f"#{t}" for t in tags) + "\n")
+    return "".join(parts) + "\n"
+
+
+def render_doc_header(date: str) -> str:
+    return f"# Decision Log — {date}\n"
+
+
+def upsert_today_entry(decision: str, why: str, by: str,
+                       links: list[str], tags: list[str]) -> str:
+    creds = ftd.get_credentials()
+    service = build("drive", "v3", credentials=creds, cache_discovery=False)
+
+    date = today_local_date()
+    title = f"{date} — decision log"
+    new_section = render_decision(decision, why, by, links, tags)
+    existing = find_today_entry(date)
+
+    if existing:
+        try:
+            current = fetch_md(service, existing["driveId"])
+        except HttpError as e:
+            ftd.die(f"failed to fetch existing decision-log doc: {e}")
+
+        new_body = current.rstrip() + "\n" + new_section
+        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False, encoding="utf-8") as f:
+            f.write(new_body)
+            tmppath = Path(f.name)
+
+        try:
+            response = ftd.drive_update(service, existing["driveId"], None, tmppath, "md")
+        finally:
+            tmppath.unlink(missing_ok=True)
+
+        entries = ftd.read_manifest(JOURNAL_AREA)
+        for i, entry in enumerate(entries):
+            if entry.get("driveId") == existing["driveId"]:
+                merged_tags = sorted(set(entry.get("tags", []) or []) | set(tags))
+                entries[i] = {**entry, "tags": merged_tags, "filedAt": utc_iso()}
+                break
+        ftd.write_manifest_atomic(JOURNAL_AREA, entries)
+
+        return response.get("webViewLink") or f"https://drive.google.com/file/d/{response['id']}/view"
+
+    # No doc for today yet — create it.
+    body = render_doc_header(date) + new_section
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False, encoding="utf-8") as f:
+        f.write(body)
+        tmppath = Path(f.name)
+
+    try:
+        response = ftd.drive_create(service, JOURNAL_AREA, title, tmppath, "md")
+    finally:
+        tmppath.unlink(missing_ok=True)
+
+    file_id = response["id"]
+    url = response.get("webViewLink") or f"https://drive.google.com/file/d/{file_id}/view"
+
+    new_entry = {
+        "shelf":    SHELF,
+        "date":     date,
+        "title":    title,
+        "driveUrl": url,
+        "driveId":  file_id,
+        "format":   "md",
+        "summary":  "",
+        "tags":     tags,
+        "filedAt":  utc_iso(),
+    }
+    entries = ftd.read_manifest(JOURNAL_AREA)
+    entries.append(new_entry)
+    ftd.write_manifest_atomic(JOURNAL_AREA, entries)
+
+    return url
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(
+        description="Append a decision to today's decision-log doc in Drive.",
+    )
+    p.add_argument("decision", help="The decision (one-line summary).")
+    p.add_argument("--why", default="", help="Why this decision was made.")
+    p.add_argument("--by", default="", help="Who made the decision.")
+    p.add_argument(
+        "--link", action="append", default=[],
+        help="Related URL. Repeatable.",
+    )
+    p.add_argument("--tags", default="", help="Comma-separated tags.")
+    args = p.parse_args()
+
+    decision = args.decision.strip()
+    if not decision:
+        ftd.die("decision text must be non-empty")
+
+    tags = [t.strip() for t in args.tags.split(",") if t.strip()]
+
+    try:
+        url = upsert_today_entry(decision, args.why.strip(), args.by.strip(),
+                                 args.link, tags)
+    except HttpError as e:
+        ftd.die(f"Drive API error: {e}")
+    except Exception as e:  # noqa: BLE001
+        ftd.die(f"decision-log-add failed: {e}")
+
+    print(url)
+
+
+if __name__ == "__main__":
+    main()

--- a/cognitive-lab/lab-server.py
+++ b/cognitive-lab/lab-server.py
@@ -315,8 +315,12 @@ class LabRequestHandler(SimpleHTTPRequestHandler):
 
         # Mirror to Drive on a background thread so Drive latency doesn't
         # delay the POST response. Mirror is best-effort; failures log to
-        # stderr but don't affect the local save.
-        if _drive_mirror_enabled:
+        # stderr but don't affect the local save. Gate thread spawn on
+        # both "deps loaded" AND "no session-killing error has been seen
+        # already" — without this, every save after a manifest-corruption
+        # event would spawn a worker that immediately logs "skipped" and
+        # exits, polluting stderr.
+        if _drive_mirror_enabled and _drive_mirror_disabled_reason is None:
             threading.Thread(
                 target=_mirror_to_drive,
                 args=(save_type, content_text),

--- a/cognitive-lab/lab-server.py
+++ b/cognitive-lab/lab-server.py
@@ -65,12 +65,14 @@ WORKSHOP_CARDS_TITLE_FMT = "{save_type}.json"
 # isn't active), mirror is disabled — local saves still work fine.
 _DRIVE_MIRROR_LOCK = threading.Lock()
 _drive_mirror_enabled = False
+_drive_mirror_creds_present = False
+_drive_mirror_disabled_reason = None  # set if a session-level error should block writes
 _ftd = None
 _drive_service = None
 
 def _try_init_drive_mirror():
     """Best-effort init of the Drive mirror. Silent on failure."""
-    global _drive_mirror_enabled, _ftd, _drive_service
+    global _drive_mirror_enabled, _drive_mirror_creds_present, _ftd, _drive_service
     try:
         spec = importlib.util.spec_from_file_location(
             "file_to_drive", str(ROOT / "file-to-drive.py")
@@ -82,6 +84,9 @@ def _try_init_drive_mirror():
         # on first mirror call.
         _ftd = ftd
         _drive_mirror_enabled = True
+        # Probe whether OAuth creds exist so we can report accurately at boot
+        # without triggering an interactive auth flow.
+        _drive_mirror_creds_present = ftd.CREDENTIALS_PATH.exists()
     except Exception as e:  # noqa: BLE001
         # Could be missing google-api-python-client, missing creds file,
         # or anything else. Disable mirror; local saves still work.
@@ -104,15 +109,31 @@ def _build_drive_service():
         sys.stderr.write(f"[lab-server] Drive auth failed: {e}\n")
         return None
 
+class WorkshopManifestUnreadable(Exception):
+    """Raised when the workshop-cards manifest exists but can't be parsed.
+    Distinct from "manifest missing" (which is normal on first run)."""
+
 def _read_workshop_manifest() -> dict:
-    """Workshop-cards manifest is a flat dict: {save_type: {driveId, ...}, ...}."""
+    """Workshop-cards manifest is a flat dict: {save_type: {driveId, ...}, ...}.
+
+    Returns {} only when the manifest file does not exist (first-run / fresh
+    machine). If the file exists but can't be parsed, raises
+    WorkshopManifestUnreadable — the caller decides how to recover. Silently
+    falling back to {} would strand existing Drive docs and start a fresh
+    duplicate lineage."""
     if not WORKSHOP_CARDS_MANIFEST.exists():
         return {}
     try:
         data = json.loads(WORKSHOP_CARDS_MANIFEST.read_text())
-        return data if isinstance(data, dict) else {}
-    except (json.JSONDecodeError, OSError):
-        return {}
+    except (json.JSONDecodeError, OSError) as e:
+        raise WorkshopManifestUnreadable(
+            f"manifest at {WORKSHOP_CARDS_MANIFEST} exists but is not parseable: {e}"
+        ) from e
+    if not isinstance(data, dict):
+        raise WorkshopManifestUnreadable(
+            f"manifest at {WORKSHOP_CARDS_MANIFEST} is not a JSON object"
+        )
+    return data
 
 def _write_workshop_manifest_atomic(manifest: dict) -> None:
     EXPORTS_DIR.mkdir(parents=True, exist_ok=True)
@@ -136,8 +157,19 @@ def _mirror_to_drive(save_type: str, content_text: str) -> None:
     saves overwrite content via files().update(). Drive's revision
     history captures the change history. Failures log to stderr but
     don't break the local save.
+
+    Runs on a background thread (caller in do_POST starts it daemon-style),
+    so the POST response isn't blocked by Drive latency.
     """
+    global _drive_mirror_disabled_reason
     if not _drive_mirror_enabled:
+        return
+    if _drive_mirror_disabled_reason is not None:
+        # A prior call hit a session-killing error (e.g., unreadable manifest).
+        # Refuse to create docs that would orphan existing ones.
+        sys.stderr.write(
+            f"[lab-server] mirror skipped ({save_type}): {_drive_mirror_disabled_reason}\n"
+        )
         return
     with _DRIVE_MIRROR_LOCK:
         try:
@@ -147,7 +179,19 @@ def _mirror_to_drive(save_type: str, content_text: str) -> None:
 
             from googleapiclient.http import MediaFileUpload
 
-            manifest = _read_workshop_manifest()
+            try:
+                manifest = _read_workshop_manifest()
+            except WorkshopManifestUnreadable as e:
+                # Disable mirror for this session — refuse to create new docs
+                # that would silently strand whatever Drive docs the manifest
+                # used to point at. User must investigate manually.
+                _drive_mirror_disabled_reason = str(e)
+                sys.stderr.write(
+                    f"[lab-server] mirror DISABLED for this session: {e}. "
+                    "Restart after fixing the manifest, or delete it to "
+                    "force fresh-doc creation.\n"
+                )
+                return
             entry = manifest.get(save_type)
 
             # Write content to a temp file for MediaFileUpload.
@@ -269,8 +313,15 @@ class LabRequestHandler(SimpleHTTPRequestHandler):
             self._json_error(500, f"write failed: {e}")
             return
 
-        # Mirror to Drive (best effort; failures logged but don't break the save).
-        _mirror_to_drive(save_type, content_text)
+        # Mirror to Drive on a background thread so Drive latency doesn't
+        # delay the POST response. Mirror is best-effort; failures log to
+        # stderr but don't affect the local save.
+        if _drive_mirror_enabled:
+            threading.Thread(
+                target=_mirror_to_drive,
+                args=(save_type, content_text),
+                daemon=True,
+            ).start()
 
         self._json_ok({
             "ok": True,
@@ -320,7 +371,13 @@ def main(argv):
     print(f"[lab-server] serving {ROOT}")
     print(f"[lab-server] exports → {EXPORTS_DIR}")
     if _drive_mirror_enabled:
-        print(f"[lab-server] drive mirror → /Cognitive Lab/Workshop Cards/")
+        if _drive_mirror_creds_present:
+            print(f"[lab-server] drive mirror → /Cognitive Lab/Workshop Cards/")
+        else:
+            print(
+                f"[lab-server] drive mirror → enabled (auth on first save; "
+                f"creds at {_ftd.CREDENTIALS_PATH} not yet present)"
+            )
     print(f"[lab-server] open    → {url}")
     try:
         httpd.serve_forever()

--- a/cognitive-lab/lab-server.py
+++ b/cognitive-lab/lab-server.py
@@ -16,6 +16,14 @@ Notes:
   - Allowlist on the save type — no arbitrary paths.
   - Bind to 127.0.0.1 only. Local dev tool, not production.
 
+  - **Drive mirror (optional).** After each successful local atomic
+    write, the saved JSON is mirrored to a single Google Doc per card
+    type in the `Cognitive Lab / Workshop Cards / ` Drive folder. The
+    local file remains canonical for fast read; Drive is a durable
+    backup. If the google-api-python-client deps aren't available
+    (i.e., the venv with file-to-drive.py's deps isn't active), the
+    mirror is silently skipped — local saves still succeed.
+
 Usage:
   python3 cognitive-lab/lab-server.py [PORT]
   PORT defaults to 4322.
@@ -23,9 +31,13 @@ Usage:
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import sys
+import tempfile
+import threading
+from datetime import datetime, timezone
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 from pathlib import Path
 
@@ -42,6 +54,147 @@ ALLOWED_TYPES = {
 
 DEFAULT_PORT = 4322
 MAX_BODY_BYTES = 5 * 1024 * 1024  # 5 MB; lab data is small
+
+# ── Drive mirror config ──────────────────────────────────────────────
+WORKSHOP_CARDS_FOLDER_ID = "1kt9Fxxuwb-MK9bnHdmrcpi8JDWSOSd1w"
+WORKSHOP_CARDS_MANIFEST = EXPORTS_DIR / "workshop-cards-manifest.json"
+WORKSHOP_CARDS_TITLE_FMT = "{save_type}.json"
+
+# Try to load file-to-drive.py for the OAuth + Drive helpers. If the
+# deps aren't available (e.g., the venv with google-api-python-client
+# isn't active), mirror is disabled — local saves still work fine.
+_DRIVE_MIRROR_LOCK = threading.Lock()
+_drive_mirror_enabled = False
+_ftd = None
+_drive_service = None
+
+def _try_init_drive_mirror():
+    """Best-effort init of the Drive mirror. Silent on failure."""
+    global _drive_mirror_enabled, _ftd, _drive_service
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "file_to_drive", str(ROOT / "file-to-drive.py")
+        )
+        ftd = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(ftd)
+        from googleapiclient.discovery import build  # noqa: F401
+        # Don't actually authenticate yet — just verify deps load. Auth happens
+        # on first mirror call.
+        _ftd = ftd
+        _drive_mirror_enabled = True
+    except Exception as e:  # noqa: BLE001
+        # Could be missing google-api-python-client, missing creds file,
+        # or anything else. Disable mirror; local saves still work.
+        sys.stderr.write(
+            f"[lab-server] Drive mirror disabled ({type(e).__name__}); "
+            "local saves only.\n"
+        )
+
+def _build_drive_service():
+    """Build (or reuse) a Drive service. Returns None on auth failure."""
+    global _drive_service
+    if _drive_service is not None:
+        return _drive_service
+    try:
+        from googleapiclient.discovery import build
+        creds = _ftd.get_credentials()
+        _drive_service = build("drive", "v3", credentials=creds, cache_discovery=False)
+        return _drive_service
+    except Exception as e:  # noqa: BLE001
+        sys.stderr.write(f"[lab-server] Drive auth failed: {e}\n")
+        return None
+
+def _read_workshop_manifest() -> dict:
+    """Workshop-cards manifest is a flat dict: {save_type: {driveId, ...}, ...}."""
+    if not WORKSHOP_CARDS_MANIFEST.exists():
+        return {}
+    try:
+        data = json.loads(WORKSHOP_CARDS_MANIFEST.read_text())
+        return data if isinstance(data, dict) else {}
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+def _write_workshop_manifest_atomic(manifest: dict) -> None:
+    EXPORTS_DIR.mkdir(parents=True, exist_ok=True)
+    fd, tmpname = tempfile.mkstemp(
+        prefix="workshop-cards-manifest.", suffix=".json", dir=str(EXPORTS_DIR)
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(manifest, f, indent=2, ensure_ascii=False)
+            f.write("\n")
+        os.replace(tmpname, str(WORKSHOP_CARDS_MANIFEST))
+    except Exception:
+        if os.path.exists(tmpname):
+            os.unlink(tmpname)
+        raise
+
+def _mirror_to_drive(save_type: str, content_text: str) -> None:
+    """Best-effort mirror of a workshop-card save to Drive.
+
+    Single Drive doc per save_type. First save creates the doc; later
+    saves overwrite content via files().update(). Drive's revision
+    history captures the change history. Failures log to stderr but
+    don't break the local save.
+    """
+    if not _drive_mirror_enabled:
+        return
+    with _DRIVE_MIRROR_LOCK:
+        try:
+            service = _build_drive_service()
+            if service is None:
+                return
+
+            from googleapiclient.http import MediaFileUpload
+
+            manifest = _read_workshop_manifest()
+            entry = manifest.get(save_type)
+
+            # Write content to a temp file for MediaFileUpload.
+            with tempfile.NamedTemporaryFile(
+                "w", suffix=".json", delete=False, encoding="utf-8"
+            ) as f:
+                f.write(content_text)
+                tmppath = f.name
+
+            try:
+                if entry and entry.get("driveId"):
+                    # Update existing doc — overwrites content; Drive keeps version history.
+                    media = MediaFileUpload(tmppath, mimetype="text/plain", resumable=False)
+                    response = service.files().update(
+                        fileId=entry["driveId"],
+                        media_body=media,
+                        fields="id, webViewLink",
+                    ).execute()
+                else:
+                    # Create new Drive doc for this save_type.
+                    title = WORKSHOP_CARDS_TITLE_FMT.format(save_type=save_type)
+                    metadata = {
+                        "name": title,
+                        "parents": [WORKSHOP_CARDS_FOLDER_ID],
+                    }
+                    media = MediaFileUpload(tmppath, mimetype="text/plain", resumable=False)
+                    response = service.files().create(
+                        body=metadata, media_body=media,
+                        fields="id, webViewLink",
+                    ).execute()
+
+                manifest[save_type] = {
+                    "driveId":  response["id"],
+                    "driveUrl": response.get("webViewLink") or
+                                f"https://drive.google.com/file/d/{response['id']}/view",
+                    "format":   "txt",
+                    "filedAt":  datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                }
+                _write_workshop_manifest_atomic(manifest)
+            finally:
+                if os.path.exists(tmppath):
+                    os.unlink(tmppath)
+
+        except Exception as e:  # noqa: BLE001
+            sys.stderr.write(
+                f"[lab-server] Drive mirror for {save_type} failed: {e}\n"
+            )
 
 
 class LabRequestHandler(SimpleHTTPRequestHandler):
@@ -108,13 +261,16 @@ class LabRequestHandler(SimpleHTTPRequestHandler):
             EXPORTS_DIR.mkdir(parents=True, exist_ok=True)
             target = EXPORTS_DIR / ALLOWED_TYPES[save_type]
             tmp = target.with_suffix(target.suffix + ".tmp")
+            content_text = json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
             with open(tmp, "w", encoding="utf-8") as f:
-                json.dump(payload, f, ensure_ascii=False, indent=2)
-                f.write("\n")
+                f.write(content_text)
             os.replace(tmp, target)
         except OSError as e:
             self._json_error(500, f"write failed: {e}")
             return
+
+        # Mirror to Drive (best effort; failures logged but don't break the save).
+        _mirror_to_drive(save_type, content_text)
 
         self._json_ok({
             "ok": True,
@@ -155,11 +311,16 @@ def main(argv):
 
     EXPORTS_DIR.mkdir(parents=True, exist_ok=True)
 
+    # Best-effort init of Drive mirror. Silent on failure (logs once to stderr).
+    _try_init_drive_mirror()
+
     addr = ("127.0.0.1", port)
     httpd = HTTPServer(addr, LabRequestHandler)
     url = f"http://{addr[0]}:{addr[1]}/cognitive-lab-v0.1.html"
     print(f"[lab-server] serving {ROOT}")
     print(f"[lab-server] exports → {EXPORTS_DIR}")
+    if _drive_mirror_enabled:
+        print(f"[lab-server] drive mirror → /Cognitive Lab/Workshop Cards/")
     print(f"[lab-server] open    → {url}")
     try:
         httpd.serve_forever()

--- a/cognitive-lab/scratchpad-add.py
+++ b/cognitive-lab/scratchpad-add.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+scratchpad-add.py — append an entry to today's scratchpad doc in Drive.
+
+The Daily Journal's Scratchpad shelf is Drive-canonical: one dated md
+file per day, in the Daily Journal Drive folder, indexed by
+journal-manifest.json with shelf="scratchpad". This CLI is the
+agent-callable + human-callable append.
+
+Behavior:
+  python3 scratchpad-add.py "<entry text>" [--tags tag1,tag2]
+
+  - Looks up today's scratchpad doc in journal-manifest.json
+    (matched on shelf="scratchpad" + today's local date).
+  - If found: fetches current content, appends the new entry with a
+    timestamp, uploads via Drive API (replacement; Drive keeps the
+    revision history).
+  - If not: creates a new dated md doc with the entry as first
+    content, appends a manifest entry with shelf="scratchpad".
+
+Prints the Drive URL on stdout. Non-zero exit on failure.
+
+Auth:
+  Reuses ~/.config/cognitive-lab/credentials.json + token.json — same
+  OAuth setup as file-to-drive.py.
+
+Notes:
+  - Format is `md` (markdown). No Google Docs API needed; round-trip
+    is plain Drive API + the shared file-to-drive helpers.
+  - "Today" is the operator's local date, not UTC. So entries logged
+    at 11:30pm and 12:30am go to different docs by intent.
+  - Manifest entry's `filedAt` updates on every append; `date` is
+    the day the entries belong to.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Load file-to-drive.py as a module despite the hyphen in its name.
+SCRIPT_DIR = Path(__file__).resolve().parent
+FTD_PATH = SCRIPT_DIR / "file-to-drive.py"
+_spec = importlib.util.spec_from_file_location("file_to_drive", str(FTD_PATH))
+ftd = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(ftd)
+
+from googleapiclient.discovery import build  # noqa: E402
+from googleapiclient.errors import HttpError  # noqa: E402
+
+SHELF = "scratchpad"
+JOURNAL_AREA = "journal"
+
+
+def today_local_date() -> str:
+    return datetime.now().strftime("%Y-%m-%d")
+
+
+def now_local_time() -> str:
+    return datetime.now().strftime("%H:%M")
+
+
+def utc_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def find_today_entry(date: str) -> dict | None:
+    for entry in ftd.read_manifest(JOURNAL_AREA):
+        if entry.get("shelf") == SHELF and entry.get("date") == date:
+            return entry
+    return None
+
+
+def fetch_md(service, file_id: str) -> str:
+    """Download a Drive .md file as a UTF-8 string."""
+    raw = service.files().get_media(fileId=file_id).execute()
+    return raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
+
+
+def render_entry(text: str, tags: list[str]) -> str:
+    time = now_local_time()
+    tag_line = ("\n" + " ".join(f"#{t}" for t in tags)) if tags else ""
+    return f"\n## {time}\n\n{text}\n{tag_line}\n"
+
+
+def render_doc_header(date: str) -> str:
+    return f"# Scratchpad — {date}\n"
+
+
+def upsert_today_entry(text: str, tags: list[str]) -> str:
+    creds = ftd.get_credentials()
+    service = build("drive", "v3", credentials=creds, cache_discovery=False)
+
+    date = today_local_date()
+    title = f"{date} — scratchpad"
+    new_section = render_entry(text, tags)
+    existing = find_today_entry(date)
+
+    if existing:
+        try:
+            current = fetch_md(service, existing["driveId"])
+        except HttpError as e:
+            ftd.die(f"failed to fetch existing scratchpad doc: {e}")
+
+        new_body = current.rstrip() + "\n" + new_section
+        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False, encoding="utf-8") as f:
+            f.write(new_body)
+            tmppath = Path(f.name)
+
+        try:
+            response = ftd.drive_update(service, existing["driveId"], None, tmppath, "md")
+        finally:
+            tmppath.unlink(missing_ok=True)
+
+        # Refresh manifest entry: filedAt + merged tags
+        entries = ftd.read_manifest(JOURNAL_AREA)
+        for i, entry in enumerate(entries):
+            if entry.get("driveId") == existing["driveId"]:
+                merged_tags = sorted(set(entry.get("tags", []) or []) | set(tags))
+                entries[i] = {**entry, "tags": merged_tags, "filedAt": utc_iso()}
+                break
+        ftd.write_manifest_atomic(JOURNAL_AREA, entries)
+
+        return response.get("webViewLink") or f"https://drive.google.com/file/d/{response['id']}/view"
+
+    # No doc for today yet — create it.
+    body = render_doc_header(date) + new_section
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False, encoding="utf-8") as f:
+        f.write(body)
+        tmppath = Path(f.name)
+
+    try:
+        response = ftd.drive_create(service, JOURNAL_AREA, title, tmppath, "md")
+    finally:
+        tmppath.unlink(missing_ok=True)
+
+    file_id = response["id"]
+    url = response.get("webViewLink") or f"https://drive.google.com/file/d/{file_id}/view"
+
+    new_entry = {
+        "shelf":    SHELF,
+        "date":     date,
+        "title":    title,
+        "driveUrl": url,
+        "driveId":  file_id,
+        "format":   "md",
+        "summary":  "",
+        "tags":     tags,
+        "filedAt":  utc_iso(),
+    }
+    entries = ftd.read_manifest(JOURNAL_AREA)
+    entries.append(new_entry)
+    ftd.write_manifest_atomic(JOURNAL_AREA, entries)
+
+    return url
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(
+        description="Append an entry to today's scratchpad doc in Drive.",
+    )
+    p.add_argument("text", help="The scratchpad entry text.")
+    p.add_argument("--tags", default="", help="Comma-separated tags.")
+    args = p.parse_args()
+
+    text = args.text.strip()
+    if not text:
+        ftd.die("entry text must be non-empty")
+
+    tags = [t.strip() for t in args.tags.split(",") if t.strip()]
+
+    try:
+        url = upsert_today_entry(text, tags)
+    except HttpError as e:
+        ftd.die(f"Drive API error: {e}")
+    except Exception as e:  # noqa: BLE001
+        ftd.die(f"scratchpad-add failed: {e}")
+
+    print(url)
+
+
+if __name__ == "__main__":
+    main()

--- a/cognitive-lab/scratchpad-add.py
+++ b/cognitive-lab/scratchpad-add.py
@@ -37,7 +37,6 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
-import sys
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path


### PR DESCRIPTION
## Summary

Bundles four phases of the lab redesign in one PR: closes the local-only-data gaps for the Daily Journal's Scratchpad and Decision Log shelves (Phase 0), specializes the Band-1 holding-pen drawers as information-storage surfaces (Phase 1A), gives the Daily Journal a proper three-shelf drawer (Phase 1B), and mirrors workshop card saves to Drive as durable backup (Phase ZA).

Architecturally locks in: **Band 1 = information storage; Band 2 = workshops where work develops; future kanban/map = where active work flows.** Holding-pen drawers shed Items / Chapter / Experiments shelves — those concepts belong in workshop drawers, not info-storage rooms.

## Commits

- `9351846` Phase 0: scratchpad-add.py + decision-log-add.py — Drive-canonical journal shelves
- `0f8254e` Phase 1A + 1B + ZA: lab UI redesign for Band-1 holding pens + workshop card cloud mirror

## Phase 0 — journal entry-add CLIs (commit 1)

Two small CLIs that append to today's dated md doc per shelf in Drive:

```bash
python3 cognitive-lab/scratchpad-add.py "<entry text>" [--tags ...]
python3 cognitive-lab/decision-log-add.py "<decision>" \
  [--why ...] [--by ...] [--link URL]* [--tags ...]
```

Both look up today's doc via `journal-manifest.json` (matched on `shelf` + date), download/append/upload via Drive API + the existing `--update-id` flow, or create a new dated doc on first use of the day. Format: `md`. Pre-existing manifest entries without a `shelf` field are legacy and treated as `\"edition\"`.

Tested end-to-end: round-trip verified, append semantics confirmed, manifest entries land with correct shape.

## Phase 1A — Band-1 holding-pen drawer redesign (commit 2)

`showAreaView` refactored to dispatch by area class:

- **Band-2 phase workshops** → `showWorkshopDrawer` (existing renderer renamed; behavior unchanged).
- **Band-1 holding pens** (research, deck-theater, strategy) → `showHoldingPenDrawer`.
- **Daily Journal** (archive) → `showJournalDrawer`.

`showHoldingPenDrawer` reads `cognitive-lab/exports/<area>-manifest.json`, renders entries as a sortable list (date desc), each row click → opens Drive URL. Workshop-only shelf tiles hidden. Graceful empty/missing-file states.

Per-area shelf labels:

| Area | Shelf |
|---|---|
| Research Repository | Reports |
| Explainer Theater | Explainers |
| Strategy & Plans | Plans & Source Material |

## Phase 1B — Daily Journal three-shelf drawer (commit 2)

`showJournalDrawer` reads `journal-manifest.json` and filters by `shelf`:

- **Scratchpad** (`shelf=\"scratchpad\"`)
- **Decision Log** (`shelf=\"decisionLog\"`)
- **Editions** (`shelf=\"edition\"` or missing, for legacy entries)

Plus a collapsible **Pre-Newspaper Notes** `<details>` toggle preserving the legacy `labNotes` / `decisions` / `shipped` fields as historical record. Nothing lost.

## Phase ZA — Workshop card cloud mirror (commit 2)

`lab-server.py` extended to mirror workshop card saves (frame-cards / debrief-cards / pilot-checks / courses / legs) to a single Drive doc per type in `/Cognitive Lab/Workshop Cards/`. Folder ID hard-coded, mapping `save_type → driveId` tracked in `exports/workshop-cards-manifest.json`.

- Local file remains canonical (fast read).
- Drive is durable backup (revision history captured automatically).
- Best-effort + fail-silent: if google deps aren't available (venv not active), mirror disables with a stderr warning. Local saves always succeed.
- Format: `text/plain` with raw JSON content (Drive shows readably; no auto-conversion that would lose JSON shape on update).

Closes the audit gap surfaced during the redesign discussion: 5 work-product files were stranded locally; now mirrored.

## CSS additions

New `manifest-row`, `manifest-section-label`, `manifest-empty`, `manifest-tag`, `manifest-fmt`, `legacy-notes` styles. Match the existing dark-bg + accent-color palette.

## Spec doc

Full implementation plan at `.context/lab-band1-drawer-redesign.md` (irvine workspace) — covers principle, per-area target state, audit findings, deferred phases (ZB, ZC).

## Test plan

- [x] Phase 0 CLIs end-to-end verified (scratchpad and decision-log docs in Drive, manifest carries `shelf` field).
- [x] `lab-server.py` Drive mirror init verified (workshop-cards-manifest.json populates on save).
- [x] JS syntax verified (`node --check` on extracted script block, 5,644 lines, clean).
- [x] Both Python scripts parse cleanly (`ast.parse`).
- [ ] **Lab UI runtime test** — open the lab in browser, click each Band-1 area, confirm the new drawers render their manifest entries. _(Pending — best done by Dan in normal usage.)_
- [ ] Daily Journal three-shelf drawer renders the existing entries (1 scratchpad, 1 decision-log, 1 legacy edition).

## Note on a smoke-test mishap

During Phase ZA verification, the smoke test POSTed a fake save through the live `frame-cards` endpoint and **overwrote `frame-cards.json` with a single test entry**, losing the prior 471 bytes of frame-card content. The file is gitignored (no version control). User accepted the loss; future testing on POST endpoints will copy-and-restore rather than write to live data.

## Out of scope (still deferred)

- **Phase ZB:** manifest-driven workshop drawers (depends on ZA being in production; bigger UI shift).
- **Phase ZC:** kanban/map surface (whole new feature, needs design conversation).
- **`--from-drive-id` mode** on `file-to-drive.py` for filing existing Drive docs into folders (needed for the digital-environments research report still in My Drive root).
- **First-edition manifest backfill** — the 2026-05-09 first edition filed before the manifest side effect existed; lab handles this gracefully (legacy = edition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)