### PR TITLE
Fix manifest persistence: track Drive-index manifests, ignore live state

### DIFF
--- a/cognitive-lab/comprehension-deck-v0.1.html
+++ b/cognitive-lab/comprehension-deck-v0.1.html
@@ -397,6 +397,25 @@
   }
   .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
   .grid-3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+
+  @page { size: 13.33in 7.5in; margin: 0; }
+  @media print {
+    html, body, #deck {
+      overflow: visible !important;
+      height: auto !important;
+      width: auto !important;
+    }
+    body { background: var(--bg); }
+    #deck { scroll-snap-type: none !important; }
+    .slide {
+      height: 7.5in !important;
+      width: 13.33in !important;
+      page-break-after: always;
+      break-after: page;
+      scroll-snap-align: unset !important;
+    }
+    .slide:last-child { page-break-after: auto; break-after: auto; }
+  }
 </style>
 </head>
 <body>

--- a/cognitive-lab/comprehension-deck-v0.2.html
+++ b/cognitive-lab/comprehension-deck-v0.2.html
@@ -365,6 +365,25 @@
   }
   .lab-list .id { font-family: var(--font-px); color: var(--accent); }
   .lab-list .pri { font-family: var(--font-px); font-size: 11px; color: var(--accent-dim); text-align: right; letter-spacing: 1px; }
+
+  @page { size: 13.33in 7.5in; margin: 0; }
+  @media print {
+    html, body, #deck {
+      overflow: visible !important;
+      height: auto !important;
+      width: auto !important;
+    }
+    body { background: var(--bg); }
+    #deck { scroll-snap-type: none !important; }
+    .slide {
+      height: 7.5in !important;
+      width: 13.33in !important;
+      page-break-after: always;
+      break-after: page;
+      scroll-snap-align: unset !important;
+    }
+    .slide:last-child { page-break-after: auto; break-after: auto; }
+  }
 </style>
 </head>
 <body>

--- a/cognitive-lab/exports/.gitignore
+++ b/cognitive-lab/exports/.gitignore
@@ -1,1 +1,2 @@
 *.json
+!*-manifest.json

--- a/cognitive-lab/exports/explainer-manifest.json
+++ b/cognitive-lab/exports/explainer-manifest.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "explainer-comprehension-deck-v0.2",
+    "date": "2026-05-04",
+    "title": "comprehension-deck-v0.2.pdf",
+    "driveUrl": "https://drive.google.com/file/d/1xZ6x5bduJWi3S7-HAdjTvcmFIOcVGaMP/view?usp=drivesdk",
+    "driveId": "1xZ6x5bduJWi3S7-HAdjTvcmFIOcVGaMP",
+    "format": "pdf",
+    "summary": "19-slide comprehension deck covering the full end-of-day 2026-05-04 arc: Hex Map v0.2→v0.3, Build canvas v0.1, Comprehend Signals, Frontier wiring, C-before-F reorder, Comprehend Station + Walk Studio. Paired with the 'Comprehend Station tour' product walk. First closed-loop dogfood artifact.",
+    "tags": ["deck", "comprehension", "rogaine-arc", "walk-studio", "internal"],
+    "filedAt": "2026-05-11T00:00:00Z"
+  },
+  {
+    "id": "explainer-comprehension-deck-v0.1",
+    "date": "2026-05-04",
+    "title": "comprehension-deck-v0.1.pdf",
+    "driveUrl": "https://drive.google.com/file/d/1uBiDQvaPe3LoGHpBa7ydgkq557KLNs6W/view?usp=drivesdk",
+    "driveId": "1uBiDQvaPe3LoGHpBa7ydgkq557KLNs6W",
+    "format": "pdf",
+    "summary": "16-slide comprehension deck for the rogaine spine arc (early morning 2026-05-04). Re-immersion artifact after overnight build shipping Course tier, Hex Map, Leg wrapper, Snap Circuit board. Color-matched to the lab; echoes Hex Map and Snap Circuit visuals.",
+    "tags": ["deck", "comprehension", "rogaine-arc", "internal"],
+    "filedAt": "2026-05-11T00:00:00Z"
+  },
+  {
+    "id": "explainer-turn-v0.1-map",
+    "date": "2026-04-30",
+    "title": "turn-v0.1-map.pdf",
+    "driveUrl": "https://drive.google.com/file/d/162RBXIoVIT4yUvnwL1pXSx5zrlYEDyvX/view?usp=drivesdk",
+    "driveId": "162RBXIoVIT4yUvnwL1pXSx5zrlYEDyvX",
+    "format": "pdf",
+    "summary": "The v0.2 turn map — 4-act, 21-slide beginner-facing presentation. Act I: new pace of work. Act II: why batch tools fail. Act III: borrowed wisdom. Act IV: the framework. Core external-facing explainer for The 7 Turn Work Week.",
+    "tags": ["deck", "turn-map", "beginner-facing", "internal"],
+    "filedAt": "2026-05-11T00:00:00Z"
+  }
+]

--- a/cognitive-lab/exports/journal-manifest.json
+++ b/cognitive-lab/exports/journal-manifest.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "journal-edition-2026-05-04",
+    "date": "2026-05-04",
+    "shelf": "edition",
+    "title": "2026-05-04 — Edition",
+    "driveUrl": null,
+    "driveId": null,
+    "format": "md",
+    "summary": "Two Explainer Theater experiment entries: comprehension-deck-v0.1 (rogaine spine re-immersion, early morning) and comprehension-deck-v0.2 + Comprehend Station tour (meta-loop dogfood, end of day). Both from deck-theater.experiments[] in the pre-migration JSON.",
+    "tags": ["explainer", "comprehension-deck", "meta-loop", "rogaine-arc"],
+    "filedAt": "2026-05-11T00:00:00Z",
+    "pendingDriveWrite": true,
+    "pendingNote": "Drive write pending — venv unavailable at filing time. Run: python3 cognitive-lab/file-to-drive.py --area journal --title \"2026-05-04 — Edition\" --content-file /tmp/edition-2026-05-04.md --format md --date 2026-05-04 --summary \"Comprehension deck v0.1 and v0.2 experiment entries from the rogaine arc.\" --tags explainer,comprehension-deck,meta-loop,rogaine-arc"
+  },
+  {
+    "id": "journal-edition-2026-04-30",
+    "date": "2026-04-30",
+    "shelf": "edition",
+    "title": "2026-04-30 — Edition",
+    "driveUrl": null,
+    "driveId": null,
+    "format": "md",
+    "summary": "Two lab notes (Wildcat Frame example; morning gauge worked/recovery turnaround) and five shipped artifacts (v0.2 deck, phases-and-leverage doc, hacks-today doc, cognitive lab plan, capacity-checkin PoC). All from archive.labNotes[] and archive.shipped[] in the pre-migration JSON.",
+    "tags": ["founding-session", "wildcat", "shipped", "gauge"],
+    "filedAt": "2026-05-11T00:00:00Z",
+    "pendingDriveWrite": true,
+    "pendingNote": "Drive write pending — venv unavailable at filing time. Run: python3 cognitive-lab/file-to-drive.py --area journal --title \"2026-04-30 — Edition\" --content-file /tmp/edition-2026-04-30.md --format md --date 2026-04-30 --summary \"Founding-session lab notes + 5 shipped artifacts.\" --tags founding-session,wildcat,shipped,gauge"
+  }
+]

--- a/cognitive-lab/exports/journal-manifest.json
+++ b/cognitive-lab/exports/journal-manifest.json
@@ -4,27 +4,23 @@
     "date": "2026-05-04",
     "shelf": "edition",
     "title": "2026-05-04 — Edition",
-    "driveUrl": null,
-    "driveId": null,
+    "driveUrl": "https://drive.google.com/file/d/1DRY96gERAb_DMkAk-KUfjiH2ZKKIzGP_/view?usp=drivesdk",
+    "driveId": "1DRY96gERAb_DMkAk-KUfjiH2ZKKIzGP_",
     "format": "md",
     "summary": "Two Explainer Theater experiment entries: comprehension-deck-v0.1 (rogaine spine re-immersion, early morning) and comprehension-deck-v0.2 + Comprehend Station tour (meta-loop dogfood, end of day). Both from deck-theater.experiments[] in the pre-migration JSON.",
     "tags": ["explainer", "comprehension-deck", "meta-loop", "rogaine-arc"],
-    "filedAt": "2026-05-11T00:00:00Z",
-    "pendingDriveWrite": true,
-    "pendingNote": "Drive write pending — venv unavailable at filing time. Run: python3 cognitive-lab/file-to-drive.py --area journal --title \"2026-05-04 — Edition\" --content-file /tmp/edition-2026-05-04.md --format md --date 2026-05-04 --summary \"Comprehension deck v0.1 and v0.2 experiment entries from the rogaine arc.\" --tags explainer,comprehension-deck,meta-loop,rogaine-arc"
+    "filedAt": "2026-05-11T00:00:00Z"
   },
   {
     "id": "journal-edition-2026-04-30",
     "date": "2026-04-30",
     "shelf": "edition",
     "title": "2026-04-30 — Edition",
-    "driveUrl": null,
-    "driveId": null,
+    "driveUrl": "https://drive.google.com/file/d/1UgrprzKCkg6DhiJuM8_Lu0_D7C-nEWoK/view?usp=drivesdk",
+    "driveId": "1UgrprzKCkg6DhiJuM8_Lu0_D7C-nEWoK",
     "format": "md",
     "summary": "Two lab notes (Wildcat Frame example; morning gauge worked/recovery turnaround) and five shipped artifacts (v0.2 deck, phases-and-leverage doc, hacks-today doc, cognitive lab plan, capacity-checkin PoC). All from archive.labNotes[] and archive.shipped[] in the pre-migration JSON.",
     "tags": ["founding-session", "wildcat", "shipped", "gauge"],
-    "filedAt": "2026-05-11T00:00:00Z",
-    "pendingDriveWrite": true,
-    "pendingNote": "Drive write pending — venv unavailable at filing time. Run: python3 cognitive-lab/file-to-drive.py --area journal --title \"2026-04-30 — Edition\" --content-file /tmp/edition-2026-04-30.md --format md --date 2026-04-30 --summary \"Founding-session lab notes + 5 shipped artifacts.\" --tags founding-session,wildcat,shipped,gauge"
+    "filedAt": "2026-05-11T00:00:00Z"
   }
 ]

--- a/cognitive-lab/exports/research-manifest.json
+++ b/cognitive-lab/exports/research-manifest.json
@@ -17,6 +17,7 @@
     "filedAt": "2026-05-11T00:00:00Z"
   },
   {
+    "id": "research-recovery-experiences-sonnentag",
     "date": "2026-05-11",
     "title": "Recovery Experiences (Sonnentag & Fritz) — when/dosage/combos",
     "driveUrl": "https://drive.google.com/file/d/1CxAErSeAxgwtCoNnFTfVnkcGGTVK8ERe/view?usp=drivesdk",

--- a/cognitive-lab/exports/research-manifest.json
+++ b/cognitive-lab/exports/research-manifest.json
@@ -1,0 +1,36 @@
+[
+  {
+    "id": "research-core-sources-reading-list",
+    "date": "2026-05-11",
+    "title": "Core Sources — reading list (22 refs)",
+    "driveUrl": "https://drive.google.com/file/d/1KVpCD4eiOCbyjEgDAdDXmarAL10wzz20/view?usp=drivesdk",
+    "driveId": "1KVpCD4eiOCbyjEgDAdDXmarAL10wzz20",
+    "format": "md",
+    "summary": "22 references from library.refs[] formatted as a clean reading list with author, year, and one-line gloss. Covers cognitive load, attention, capacity/recovery, aviation, military/industrial, and goal-setting traditions. Source of truth for the lab's evidence base.",
+    "tags": [
+      "core-sources",
+      "reading-list",
+      "cognitive",
+      "aviation",
+      "industrial"
+    ],
+    "filedAt": "2026-05-11T00:00:00Z"
+  },
+  {
+    "date": "2026-05-11",
+    "title": "Recovery Experiences (Sonnentag & Fritz) — when/dosage/combos",
+    "driveUrl": "https://drive.google.com/file/d/1CxAErSeAxgwtCoNnFTfVnkcGGTVK8ERe/view?usp=drivesdk",
+    "driveId": "1CxAErSeAxgwtCoNnFTfVnkcGGTVK8ERe",
+    "format": "md",
+    "summary": "Practitioner-facing research report on the four Recovery Experiences (Detachment, Relaxation, Mastery, Control): when to deploy each, pairing patterns (D+R reduces strain; M+C builds engagement), dosage/diminishing returns, combo additivity, individual differences, recovery debt across chained days, and sleep's role as floor-reset distinct from the four. Feeds LAB-015 (Recover practice) and LAB-016 (Recover chapter).",
+    "tags": [
+      "recovery",
+      "sonnentag",
+      "research",
+      "recovery-room",
+      "LAB-015",
+      "LAB-016"
+    ],
+    "filedAt": "2026-05-11T15:31:05Z"
+  }
+]

--- a/cognitive-lab/exports/strategy-manifest.json
+++ b/cognitive-lab/exports/strategy-manifest.json
@@ -1,0 +1,90 @@
+[
+  {
+    "id": "strategy-cognitive-lab-plan-v2",
+    "date": "2026-05-01",
+    "title": "cognitive-lab-plan-v2.md",
+    "driveUrl": "https://drive.google.com/file/d/1w6jV0ZqVWCPqOesbfj2OpHbVlaVN7u-9/view?usp=drivesdk",
+    "driveId": "1w6jV0ZqVWCPqOesbfj2OpHbVlaVN7u-9",
+    "format": "md",
+    "summary": "Updated lab project plan written after the spatial-knowledge-UI literature review. Drops v0.2/v0.3 ideas the evidence flags as graveyards; reorders the roadmap around patterns the research supports. Companion to the v0.1-era cognitive-lab-plan.md.",
+    "tags": ["plan", "roadmap", "lab-architecture"],
+    "filedAt": "2026-05-11T00:00:00Z"
+  },
+  {
+    "id": "strategy-cognitive-lab-plan",
+    "date": "2026-04-28",
+    "title": "cognitive-lab-plan.md",
+    "driveUrl": "https://drive.google.com/file/d/1yCM6Z7605zSgRTKyXReZOdeG8-C3RJl9/view?usp=drivesdk",
+    "driveId": "1yCM6Z7605zSgRTKyXReZOdeG8-C3RJl9",
+    "format": "md",
+    "summary": "Original v0.1-era lab project plan: spatial click-to-explore HTML artifact doubling as the lab plan and the hub for cognitive-load management work. Superseded by cognitive-lab-plan-v2.md but preserved as the v0.1-era artifact.",
+    "tags": ["plan", "roadmap", "lab-architecture", "legacy"],
+    "filedAt": "2026-05-11T00:00:00Z"
+  },
+  {
+    "id": "strategy-cognitive-lab-spec",
+    "date": "2026-04-28",
+    "title": "cognitive-lab-spec.md",
+    "driveUrl": "https://drive.google.com/file/d/1H4ObEAb-Pf3ETz4vUfsiVMcEUeE5PJL1/view?usp=drivesdk",
+    "driveId": "1H4ObEAb-Pf3ETz4vUfsiVMcEUeE5PJL1",
+    "format": "md",
+    "summary": "Build spec for cognitive-lab-v0.1.html: pixel-art floor plan, click-to-open drawers, local storage shadow, JSON export. Visual style, panel structure, item taxonomy. The buildable spec underneath the plan.",
+    "tags": ["spec", "lab-architecture", "build"],
+    "filedAt": "2026-05-11T00:00:00Z"
+  },
+  {
+    "id": "strategy-frame-research-and-practice",
+    "date": "2026-05-02",
+    "title": "frame-research-and-practice.md",
+    "driveUrl": "https://drive.google.com/file/d/1SaKz7cYTrZrS0bMJicBtWUdqg2J_7eut/view?usp=drivesdk",
+    "driveId": "1SaKz7cYTrZrS0bMJicBtWUdqg2J_7eut",
+    "format": "md",
+    "summary": "Chunky blocks for the Frame chapter — skeleton for Zelda to weave from. Covers the seven-field form, the research behind each field, the mechanism each field operationalizes, when to use it, a worked example, failure modes, and v0.2 open questions.",
+    "tags": ["framework", "frame-phase", "chapter-source", "7turn"],
+    "filedAt": "2026-05-11T00:00:00Z"
+  },
+  {
+    "id": "strategy-turn-phases-and-leverage",
+    "date": "2026-04-30",
+    "title": "turn-v0.1-phases-and-leverage.md",
+    "driveUrl": "https://drive.google.com/file/d/1JtDNd6OnpfwSq4sJvFIbiUyb6KkLq6aq/view?usp=drivesdk",
+    "driveId": "1JtDNd6OnpfwSq4sJvFIbiUyb6KkLq6aq",
+    "format": "md",
+    "summary": "Phase-by-phase operating manual for the 7-turn cycle. What each phase does, the cognitive science behind it, the edges we have so far, and which phase deserves the most love first. Companion to turn-v0.1-map.md.",
+    "tags": ["framework", "7turn", "operating-manual", "phases"],
+    "filedAt": "2026-05-11T00:00:00Z"
+  },
+  {
+    "id": "strategy-turn-hacks-today",
+    "date": "2026-04-30",
+    "title": "turn-v0.1-hacks-today.md",
+    "driveUrl": "https://drive.google.com/file/d/1pD8tiiiZ3jWxRHr-GyYqQaEeb-xNO3G6/view?usp=drivesdk",
+    "driveId": "1pD8tiiiZ3jWxRHr-GyYqQaEeb-xNO3G6",
+    "format": "md",
+    "summary": "Hack guide for running the 7-turn framework today, before Alexandria/Substrate/Cockpit/Ledger/Playbook exist as live systems. Satisficing-mode primitive tools: files, folders, git, AI windows, voice memos, the capacity check-in PoC, calendar.",
+    "tags": ["framework", "7turn", "operating-manual", "hacks"],
+    "filedAt": "2026-05-11T00:00:00Z"
+  },
+  {
+    "id": "strategy-turn-map",
+    "date": "2026-04-30",
+    "title": "turn-v0.1-map.md",
+    "driveUrl": "https://drive.google.com/file/d/1Qo_NlCJVZ1nfhtUjuu6l6WhM1zPutkx3/view?usp=drivesdk",
+    "driveId": "1Qo_NlCJVZ1nfhtUjuu6l6WhM1zPutkx3",
+    "format": "md",
+    "summary": "The turn map source — ASCII diagram + commentary on the 7-turn cycle (Frame · Comprehend · Sync · Push · Debrief · Recover · Transition). Working map of the cognitive-load framework underlying The 7 Turn Work Week. Playground, not the answer.",
+    "tags": ["framework", "7turn", "map", "source"],
+    "filedAt": "2026-05-11T00:00:00Z"
+  },
+  {
+    "id": "strategy-process",
+    "date": "2026-05-08",
+    "title": "PROCESS.md",
+    "driveUrl": "https://drive.google.com/file/d/1CItcSychGshO_trE9legIrwhgfUoSb1U/view?usp=drivesdk",
+    "driveId": "1CItcSychGshO_trE9legIrwhgfUoSb1U",
+    "format": "md",
+    "summary": "How the lab works as a living system: the six roles (Director + Quenton/Larry/Zelda/ghostwriter/grepzilla2), how the agents compose, how the lab feeds the book, and the rhythm that holds it all together. The lab's operating doc.",
+    "tags": ["process", "roles", "operating-doc"],
+    "filedAt": "2026-05-11T00:00:00Z"
+  }
+]

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,7 @@ import jsxA11y from 'eslint-plugin-jsx-a11y';
 
 export default [
   {
-    ignores: ['dist/**', '.astro/**', 'node_modules/**'],
+    ignores: ['dist/**', '.astro/**', 'node_modules/**', '**/.venv/**'],
   },
   js.configs.recommended,
   ...tseslint.configs.recommended,


### PR DESCRIPTION
## Summary

- `cognitive-lab/exports/.gitignore` previously ignored all `*.json` files, silently erasing the lab's Drive-index manifests across branches and Conductor workspaces. The drawers in Research Repository, Explainer Theater, Strategy & Plans, and Daily Journal would render empty on fresh checkouts even though the Drive content itself persisted in the cloud.
- Split the rule: track `*-manifest.json` (stable indexes pointing at Drive content) while continuing to ignore workshop-card live state (`pilot-checks.json`, `frame-cards.json`, `debrief-cards.json`, `courses.json`, `legs.json`).
- Initial snapshot of the four affected manifests is included so the drawers populate on a fresh checkout.

## Adjacent cleanups bundled

- `comprehension-deck-v0.1.html`, `comprehension-deck-v0.2.html`: add a `@media print` block + 16:9 `@page` size so PDF renders include all slides instead of just the cover. The decks set `overflow:hidden` + `height:100vh` on `html/body`, which clipped print output to the first viewport.
- `eslint.config.js`: ignore `**/.venv/**` so Python virtualenv contents no longer trip ESLint when the cognitive-lab venv is bootstrapped locally.

## Out of scope

- Recovery Room v0.3 workshop build (in-progress on another branch).
- Pre-existing local changes to `DECISIONS.md` and `lab-server.py`.

## Test plan

- [ ] Open the lab from a clean checkout and confirm the Explainer Theater, Research Repository, Strategy & Plans, and Daily Journal drawers populate with their entries.
- [ ] Click an entry in each drawer and confirm the Drive URL opens the file in Drive.
- [ ] Re-render either comprehension deck to PDF and confirm all slides are present.
- [ ] Confirm `pilot-checks.json` and other workshop-card live state still show as ignored by git (run `git check-ignore cognitive-lab/exports/pilot-checks.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)