### PR TITLE
Lab: retire Heartbeat metaphor + Gauge area; central image becomes "the bookended day"

### DIFF
--- a/cognitive-lab/DECISIONS.md
+++ b/cognitive-lab/DECISIONS.md
@@ -255,7 +255,7 @@ Click-to-place over drag-and-drop is a deliberate scope constraint, not a compro
 
 **Reasoning.** Earlier the cache-game was treated as Frame-only. The heartbeat insight (capacity check → restoration plan, in continuous cycle) named the meta-rhythm that makes every phase work. Both images compose: cache-game designs the day; heartbeat keeps you alive playing it.
 
-**Status.** Active. To propagate into chapter material as the framework's central images.
+**Status.** **Superseded 2026-05-11** — the heartbeat metaphor was retired in favor of "the bookended day" as the framework's second central image. See the 2026-05-11 entry at the top of this file.
 
 **References.** Captured in `cognitive-lab/PROCESS.md`. Cache-game origin: Jess's adventure-caching race story.
 
@@ -267,9 +267,9 @@ Click-to-place over drag-and-drop is a deliberate scope constraint, not a compro
 
 **Reasoning.** The PoC has features the Pilot Check doesn't (morning-after test, withdrawal/replenishment bank, color verdict, history). The Pilot Check has features the PoC doesn't (three-dimension breakdown, rule-out threshold, targeted prescription). Each is half-built. Together they're the complete instrument. The author named the convergence; coexistence as separate tools would be the duplication trap.
 
-**Status.** Architecture decided; merger queued as **LAB-025** (Make the Gauge a workshop, embed capacity check-in). Work is post-current-period.
+**Status.** **Superseded 2026-05-11** — the Gauge area was retired entirely; the merger path described here is the path *not* taken. Pilot Check absorbed the capacity-read role; the standalone capacity check-in instrument was retired with the Gauge. LAB-025 (the merger queue item) was deleted in the heartbeat-retirement PR. See the 2026-05-11 entry at the top of this file.
 
-**References.** `cognitive-lab/cognitive-lab-v0.1.html` (item LAB-025), `larry-moleman/PLAYS.md` (Merge-Duplicate-Tools play).
+**References.** Originally tracked as LAB-025 (now deleted). `larry-moleman/PLAYS.md` (Merge-Duplicate-Tools play).
 
 ---
 

--- a/cognitive-lab/DECISIONS.md
+++ b/cognitive-lab/DECISIONS.md
@@ -6,6 +6,18 @@ Entries are reverse-chronological (newest first). Each has: date, decision, reas
 
 ---
 
+## 2026-05-11 · Heartbeat retired; Gauge area deleted; second central image becomes "the bookended day"
+
+**Decision.** The Gauge as a free-standing area and the heartbeat as the framework's second central image are both retired. Capacity management is reframed as an *outside loop* — Pilot Check opens the day, Recovery closes it, the turn cycle runs in the protected middle — rather than as an *inside beat* pulsing between every phase. The framework's two central images are now the cache-game (how the day's game is designed) and the bookended day (how the day is held).
+
+**Reasoning.** Continuous-read capacity instrumentation isn't shippable in the 8-week window; bookended discrete checks (morning Pilot Check + evening Recovery) are sufficient. Keeping the heartbeat as a load-bearing image while the underlying instrument is retired would create vocabulary debt. Cleaner to retire both and re-name the second central image around what's actually implemented.
+
+**Status.** Active. Hourly capacity feedback is parked as a future possibility; if it lands, the heartbeat may return as a name for that specific pattern.
+
+**References.** PR (this branch). `cognitive-lab/archive/heartbeat-retirement-2026-05-11.md` for the archived content. Quenton's design memo lives in the conversation history (Claude session 2026-05-11).
+
+---
+
 ## 2026-05-04 (later) · Move 2 (Comprehension Station arc) — orientation workshop, Walk Studio, C-before-F, iframe pattern, LAB-009 status
 
 **Decision.** Five sub-phases shipped in the Move 2 arc (branch `danversfleury/lab-course-tier`, 11 commits since the v0.4 session-close):

--- a/cognitive-lab/PROCESS.md
+++ b/cognitive-lab/PROCESS.md
@@ -89,15 +89,11 @@ Originated from Jess's adventure-caching race story. Frame is the *game-design* 
 
 Three end-states: collected enough → finish line; tired/hurt with what you got → head home early; time runs out → buzzer. These map to End's three triggers (Done means delivered, capacity floor, bingo time).
 
-### The heartbeat
+### The bookended day
 
-The give-and-take rhythm of capacity check ↔ restoration. The Gauge reads, the result dispatches: cleared (continue) or grounded (insert recovery, re-read). This rhythm runs continuously throughout the day, between every phase.
+The day has two fixed posts: a Pilot Check at the start and a Recovery ritual at the end. Between them the turn cycle runs as many times as capacity allows. The bookends aren't optional and they aren't symmetric — the morning check rules out the dimensions that would make the day unsafe to begin; the evening recovery closes the loops the day opened so they don't bleed into tomorrow. Everything in between (Comprehend → Frame → Sync → Produce → Debrief, with Transition and Trim available throughout) inherits its license to run from the morning check and its right to end from the evening recovery.
 
-Without the heartbeat, the framework is just phases without honoring capacity. With it, every boundary is gated by capacity and every grounded reading dispatches targeted recovery.
-
-The Pilot Check is the explicit pre-flight version of the heartbeat (rule-out across cognitive / emotional / physical, dispatching recovery hours per red dimension). The Gauge is the continuous instrument the heartbeat runs on.
-
-**Together:** The cache-game is *how the day's game is designed* (Frame's metaphor). The heartbeat is *how the day's rhythm cycles* (the Gauge↔Recovery meta-rhythm). They compose; neither alone is the whole framework.
+**Together:** The cache-game is *how the day's game is designed* (Frame's metaphor). The bookended day is *how the day is held* — opened deliberately, closed deliberately, with the cycle living in the protected middle.
 
 ---
 

--- a/cognitive-lab/archive/heartbeat-retirement-2026-05-11.md
+++ b/cognitive-lab/archive/heartbeat-retirement-2026-05-11.md
@@ -1,0 +1,145 @@
+# Heartbeat retirement — 2026-05-11
+
+## Rationale
+
+Heartbeat retired in favor of "the bookended day" as the second central image; the rhythm got absorbed into Pilot Check + Recovery as concrete instruments rather than a metaphor about them.
+
+## Archived content
+
+### Deleted area: the-gauge
+
+```json
+    {
+      "id": "the-gauge",
+      "name": "The Gauge",
+      "type": "gauge / telemetry",
+      "accent": "dark",
+      "description": "The capacity instrument. Read at every boundary. Gates the day's mode. The continuous read-and-dispatch cycle (capacity ↔ restoration) is the framework's heartbeat.",
+      "items": ["LAB-020","LAB-021","LAB-025","LAB-030"],
+      "sources": [
+        { "label": "Capacity Check-In (the live instrument)", "href": "capacity-checkin.html" },
+        { "label": "turn-v0.1-map.html (slides 11 + 17, multi-signal model)", "href": "turn-v0.1-map.html" },
+        { "label": "PROCESS.md (heartbeat as one of two central images)", "href": "PROCESS.md" }
+      ],
+      "experiments": [
+        {
+          "id": "exp-gauge-2026-05-02-heartbeat-named",
+          "title": "Heartbeat named as second central image",
+          "date": "2026-05-02 (afternoon)",
+          "observation": "The give-and-take of capacity check ↔ restoration plan was named as the framework's meta-rhythm. Not just a phase — the rhythm that makes every phase work. Capacity reading dispatches: cleared (continue) or grounded (insert recovery, re-read). The cycle runs continuously, between every phase, across days.",
+          "impact": "Now treated as one of two central images for the framework, alongside the cache-game (Frame's organizing metaphor). The cache-game designs the day; the heartbeat keeps you alive playing it. Captured as a chunk on this area; queued for integration into the deck (LAB-030)."
+        },
+        {
+          "id": "exp-gauge-2026-05-02-merger-architecture",
+          "title": "Capacity check-in + Pilot Check converge into unified Gauge",
+          "date": "2026-05-02 (morning)",
+          "observation": "The capacity check-in PoC and the Pilot Check Station are different views of the same instrument. Each is half-built; together they're the complete instrument. The PoC has felt-sense + bank metaphor + morning-after; the Pilot Check has three-dimension rule-out + targeted prescription. Naming them as separate areas was creating duplication.",
+          "impact": "Architecture decided: merger queued as LAB-025 (Make the Gauge a workshop, embed capacity check-in). Pilot Check Station may dissolve into a use-pattern of the Gauge after the merger."
+        }
+      ],
+      "chunks": [
+        {
+          "id": "chunk-hash-house-gauge-pilot-check",
+          "title": "Hash house = Pilot Check visit (refuel, re-orient, decide)",
+          "summary": "The lab's heartbeat IS the hash house. Pilot Check = hash-house visit: refuel, re-orient, decide whether to continue. A tightening of an existing instrument, not a new one.",
+          "body": "In rogaining, the **hash house** is the central base camp. Racers return there to refuel, check time, re-orient, and decide whether to continue the current route or revise. Elite racers treat each hash-house visit as a decision point, not just a rest stop: they assess their capacity against remaining time and course, then commit or pivot.\n\nThe lab's Pilot Check is the hash house visit. The parallels are direct:\n\n- **Refuel** → capacity read (Cognitive / Emotional / Physical sliders).\n- **Re-orient** → Gauge dispatch (cleared or grounded) + diagnosis of which dimension is red.\n- **Decide whether to continue** → Full Turn vs. Partial Turn vs. Recovery insertion.\n\nThis framing tightens an instrument that already exists — it doesn't add a new one. The Gauge is the continuous instrument (between every phase); the Pilot Check is the explicit pre-leg hash-house visit (before a Full Turn starts).\n\nPractical implication: the Pilot Check form can be framed to the author as 'you're at the hash house — what's your read?' rather than 'complete this checklist.' The framing change may improve compliance on sessions where the operator is inclined to skip the check. The hash-house visit is non-optional in rogaining; that normative weight transfers.\n\nThe Debrief's 'Capacity + next' field closes the loop: post-leg gauge read = leaving the hash house for the next leg.\n\nCross-ref: chunk-gauge-heartbeat (The Gauge) — the heartbeat is the continuous rhythm; the hash house is the explicit check-in point within that rhythm."
+        },
+        {
+          "id": "chunk-gauge-heartbeat",
+          "title": "The heartbeat — capacity ↔ restoration as meta-rhythm",
+          "summary": "The continuous Gauge-read-and-dispatch cycle is the framework's beating rhythm. Without it, the framework is just phases without honoring capacity.",
+          "body": "The framework has two central images. The cache-game (Jess's contribution) names how the day's game gets designed — Frame as the game-design moment. The heartbeat names how the day's rhythm cycles.\n\nThe heartbeat: capacity check → action plan → capacity check → action plan. The Gauge reads, the result dispatches: cleared (continue with the planned phase) or grounded (insert recovery, re-read). The cycle runs continuously throughout the day, between every phase, across days.\n\nWith the heartbeat, every phase boundary is gated by capacity and every grounded reading dispatches a targeted recovery. Without it, the cycle just runs through phases regardless of state — and the framework collapses into ritual.\n\nThe Pilot Check is the explicit pre-flight version of the heartbeat (rule-out across cognitive / emotional / physical, dispatching recovery hours per red dimension). The Gauge is the continuous instrument the heartbeat runs on.\n\nThe two images compose. The cache-game is *how the day's game is designed.* The heartbeat is *how the day's rhythm cycles.* Neither alone is the framework; together they make the practice live."
+        }
+      ],
+      "notes": [
+        "The capacity check-in is the felt-sense layer of the Gauge. It's been doing real recovery-planning work and is the seed the Gauge grows from.",
+        "2026-04-30 — The morning gauge worked (recovery turnaround)."
+      ]
+    }
+```
+
+### Deleted LAB items
+
+```json
+    "LAB-020": {
+      "id": "LAB-020",
+      "title": "Per-turn gauge entries (vs only per-day)",
+      "status": "backlog",
+      "priority": "P1",
+      "area": "the-gauge",
+      "brief": "Upgrade the gauge to record a reading at the start of each turn, not just daily.",
+      "full": "Upgrade the gauge to record a reading at the start of each turn, not just once per day. This feeds the multi-signal model and enables intra-day capacity tracking."
+    },
+    "LAB-021": {
+      "id": "LAB-021",
+      "title": "Capacity check-in v0.2 (turn-aware data model)",
+      "status": "backlog",
+      "priority": "P1",
+      "area": "the-gauge",
+      "brief": "Rebuild the check-in PoC with a turn-aware data model.",
+      "full": "Rebuild the capacity check-in PoC with a turn-aware data model. Each record tagged with turn ID, time-of-day, and which phase triggered the check-in. Enables correlation analysis between gauge readings and turn outcomes."
+    },
+    "LAB-025": {
+      "id": "LAB-025",
+      "title": "Make the Gauge a workshop (embed capacity check-in)",
+      "status": "backlog",
+      "priority": "P1",
+      "area": "the-gauge",
+      "brief": "Promote the Gauge from a regular area to a workshop, with the capacity check-in PoC embedded as the instrument view.",
+      "full": "Same workshop pattern as Frame. Top half of drawer = the live instrument (capacity check-in PoC, embedded as iframe or directly merged), bottom half = the floor view (items, artifacts, notes, recent gauge readings as cards). Eventually adds the multi-signal layers (behavioral, temporal) on top of the felt-sense PoC. Architecturally, makes the PoC's daily ritual a first-class part of the lab rather than a side artifact."
+    },
+    "LAB-030": {
+      "id": "LAB-030",
+      "title": "Integrate the heartbeat into the deck",
+      "status": "backlog",
+      "priority": "P1",
+      "area": "the-gauge",
+      "brief": "Update deck slides to surface the heartbeat as the framework's second central image alongside the cache-game.",
+      "full": "The framework now has two named central images. The cache-game is well-represented in the deck (Frame batches with subtitles tied to the metaphor). The heartbeat (capacity ↔ restoration as continuous meta-rhythm) is not yet in the deck. Update slides 11 and 17–18 (Gauge and multi-signal model) to name the heartbeat explicitly. Possibly add a slide that pairs the two images. Coordinates with chunk-gauge-heartbeat in the-gauge area."
+    }
+```
+
+### Deleted heartbeat prose from LAB_CONTEXT.md
+
+The heartbeat section was in `quenton-quince/LAB_CONTEXT.md` (lines 90–95) and `cognitive-lab/PROCESS.md` (lines 92–100). The `cognitive-lab/LAB_CONTEXT.md` file did not exist at the time of this retirement — the DECISIONS.md entry references the path the brief specified; see PR1 git log for context.
+
+**From `quenton-quince/LAB_CONTEXT.md` (lines 90–95):**
+
+```
+### The heartbeat
+
+The give-and-take rhythm of capacity check ↔ restoration. The Gauge reads, the result dispatches: cleared (continue) or grounded (insert recovery, re-read). This rhythm runs continuously, between phases, across days. Without the heartbeat, the framework is just phases without honoring capacity. With it, every boundary is gated and every grounded reading dispatches targeted recovery.
+
+The Pilot Check is the explicit pre-flight version of the heartbeat (rule-out across cognitive / emotional / physical, dispatching recovery hours per red dimension). The Gauge is the continuous instrument the heartbeat runs on.
+```
+
+### Deleted heartbeat block from PROCESS.md
+
+**From `cognitive-lab/PROCESS.md` (lines 92–100):**
+
+```
+### The heartbeat
+
+The give-and-take rhythm of capacity check ↔ restoration. The Gauge reads, the result dispatches: cleared (continue) or grounded (insert recovery, re-read). This rhythm runs continuously throughout the day, between every phase.
+
+Without the heartbeat, the framework is just phases without honoring capacity. With it, every boundary is gated by capacity and every grounded reading dispatches targeted recovery.
+
+The Pilot Check is the explicit pre-flight version of the heartbeat (rule-out across cognitive / emotional / physical, dispatching recovery hours per red dimension). The Gauge is the continuous instrument the heartbeat runs on.
+
+**Together:** The cache-game is *how the day's game is designed* (Frame's metaphor). The heartbeat is *how the day's rhythm cycles* (the Gauge↔Recovery meta-rhythm). They compose; neither alone is the whole framework.
+```
+
+### Deleted chunk: chunk-gauge-heartbeat
+
+```
+{
+  "id": "chunk-gauge-heartbeat",
+  "title": "The heartbeat — capacity ↔ restoration as meta-rhythm",
+  "summary": "The continuous Gauge-read-and-dispatch cycle is the framework's beating rhythm. Without it, the framework is just phases without honoring capacity.",
+  "body": "The framework has two central images. The cache-game (Jess's contribution) names how the day's game gets designed — Frame as the game-design moment. The heartbeat names how the day's rhythm cycles.\n\nThe heartbeat: capacity check → action plan → capacity check → action plan. The Gauge reads, the result dispatches: cleared (continue with the planned phase) or grounded (insert recovery, re-read). The cycle runs continuously throughout the day, between every phase, across days.\n\nWith the heartbeat, every phase boundary is gated by capacity and every grounded reading dispatches a targeted recovery. Without it, the cycle just runs through phases regardless of state — and the framework collapses into ritual.\n\nThe Pilot Check is the explicit pre-flight version of the heartbeat (rule-out across cognitive / emotional / physical, dispatching recovery hours per red dimension). The Gauge is the continuous instrument the heartbeat runs on.\n\nThe two images compose. The cache-game is *how the day's game is designed.* The heartbeat is *how the day's rhythm cycles.* Neither alone is the framework; together they make the practice live."
+}
+```
+
+## See also
+
+PR1 in `git log`. DECISIONS.md entry 2026-05-11.

--- a/cognitive-lab/cognitive-lab-spec.md
+++ b/cognitive-lab/cognitive-lab-spec.md
@@ -164,7 +164,7 @@ a click target. Click → drawer.
 - Type: gauge / telemetry
 - Color: dark `#2d3142` with orange accent
 - Description: "The capacity instrument. Read at every boundary. Gates the day's mode."
-- Items: LAB-020, LAB-021
+- Items: (none — area retired, see archive/heartbeat-retirement-2026-05-11.md)
 - Artifacts:
   - existing capacity-checkin PoC (note: not in this folder yet — exists in user's other workspace)
   - `.context/turn-v0.1-map.html` (deck slide 11 + slide 17, multi-signal model)
@@ -334,8 +334,6 @@ a click target. Click → drawer.
   Selection heuristics. Fast-no protocols. (Lower priority once Frame works.)
 - **LAB-018** Trim chapter — `backlog` — trim-bench
 - **LAB-019** Run 1 week of formal Frame and capture lab notes — `backlog` — frame-workshop / archive
-- **LAB-020** Per-turn gauge entries (vs only per-day) — `backlog` — the-gauge
-- **LAB-021** Capacity check-in v0.2 (turn-aware data model) — `backlog` — the-gauge
 
 ### P2 — later
 

--- a/cognitive-lab/cognitive-lab-spec.md
+++ b/cognitive-lab/cognitive-lab-spec.md
@@ -160,15 +160,8 @@ a click target. Click → drawer.
 
 ### Center / always-visible
 
-#### `the-gauge` — The Gauge
-- Type: gauge / telemetry
-- Color: dark `#2d3142` with orange accent
-- Description: "The capacity instrument. Read at every boundary. Gates the day's mode."
-- Items: (none — area retired, see archive/heartbeat-retirement-2026-05-11.md)
-- Artifacts:
-  - existing capacity-checkin PoC (note: not in this folder yet — exists in user's other workspace)
-  - `.context/turn-v0.1-map.html` (deck slide 11 + slide 17, multi-signal model)
-- Decoration: monitor / dashboard motif
+#### `the-gauge` — The Gauge (retired 2026-05-11)
+- Status: **area retired**; capacity-read role absorbed into Pilot Check (morning) and Recovery Room (evening). See `archive/heartbeat-retirement-2026-05-11.md` for the deleted area JSON, items, and design rationale.
 
 #### `director-desk` — Director's Desk (you)
 - Type: aux / persistent

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -5104,11 +5104,6 @@
 
   <!-- Band 4: Instruments + Director (bottom) -->
   <div class="band">
-    <div class="area area-visual" data-area="the-gauge" data-accent="dark">
-      <div class="area-scene">🎛️</div>
-      <div class="area-label">The Gauge<span class="lbl-sub">capacity</span></div>
-      <div class="badge-row" id="badges-the-gauge"></div>
-    </div>
     <div class="area area-visual" data-area="pilot-check-station" data-accent="amber">
       <div class="area-scene">✈️</div>
       <div class="area-label">Pilot Check<span class="lbl-sub">multi-signal</span></div>
@@ -5960,53 +5955,6 @@
       "notes": []
     },
     {
-      "id": "the-gauge",
-      "name": "The Gauge",
-      "type": "gauge / telemetry",
-      "accent": "dark",
-      "description": "The capacity instrument. Read at every boundary. Gates the day's mode. The continuous read-and-dispatch cycle (capacity ↔ restoration) is the framework's heartbeat.",
-      "items": ["LAB-020","LAB-021","LAB-025","LAB-030"],
-      "sources": [
-        { "label": "Capacity Check-In (the live instrument)", "href": "capacity-checkin.html" },
-        { "label": "turn-v0.1-map.html (slides 11 + 17, multi-signal model)", "href": "turn-v0.1-map.html" },
-        { "label": "PROCESS.md (heartbeat as one of two central images)", "href": "PROCESS.md" }
-      ],
-      "experiments": [
-        {
-          "id": "exp-gauge-2026-05-02-heartbeat-named",
-          "title": "Heartbeat named as second central image",
-          "date": "2026-05-02 (afternoon)",
-          "observation": "The give-and-take of capacity check ↔ restoration plan was named as the framework's meta-rhythm. Not just a phase — the rhythm that makes every phase work. Capacity reading dispatches: cleared (continue) or grounded (insert recovery, re-read). The cycle runs continuously, between every phase, across days.",
-          "impact": "Now treated as one of two central images for the framework, alongside the cache-game (Frame's organizing metaphor). The cache-game designs the day; the heartbeat keeps you alive playing it. Captured as a chunk on this area; queued for integration into the deck (LAB-030)."
-        },
-        {
-          "id": "exp-gauge-2026-05-02-merger-architecture",
-          "title": "Capacity check-in + Pilot Check converge into unified Gauge",
-          "date": "2026-05-02 (morning)",
-          "observation": "The capacity check-in PoC and the Pilot Check Station are different views of the same instrument. Each is half-built; together they're the complete instrument. The PoC has felt-sense + bank metaphor + morning-after; the Pilot Check has three-dimension rule-out + targeted prescription. Naming them as separate areas was creating duplication.",
-          "impact": "Architecture decided: merger queued as LAB-025 (Make the Gauge a workshop, embed capacity check-in). Pilot Check Station may dissolve into a use-pattern of the Gauge after the merger."
-        }
-      ],
-      "chunks": [
-        {
-          "id": "chunk-hash-house-gauge-pilot-check",
-          "title": "Hash house = Pilot Check visit (refuel, re-orient, decide)",
-          "summary": "The lab's heartbeat IS the hash house. Pilot Check = hash-house visit: refuel, re-orient, decide whether to continue. A tightening of an existing instrument, not a new one.",
-          "body": "In rogaining, the **hash house** is the central base camp. Racers return there to refuel, check time, re-orient, and decide whether to continue the current route or revise. Elite racers treat each hash-house visit as a decision point, not just a rest stop: they assess their capacity against remaining time and course, then commit or pivot.\n\nThe lab's Pilot Check is the hash house visit. The parallels are direct:\n\n- **Refuel** → capacity read (Cognitive / Emotional / Physical sliders).\n- **Re-orient** → Gauge dispatch (cleared or grounded) + diagnosis of which dimension is red.\n- **Decide whether to continue** → Full Turn vs. Partial Turn vs. Recovery insertion.\n\nThis framing tightens an instrument that already exists — it doesn't add a new one. The Gauge is the continuous instrument (between every phase); the Pilot Check is the explicit pre-leg hash-house visit (before a Full Turn starts).\n\nPractical implication: the Pilot Check form can be framed to the author as 'you're at the hash house — what's your read?' rather than 'complete this checklist.' The framing change may improve compliance on sessions where the operator is inclined to skip the check. The hash-house visit is non-optional in rogaining; that normative weight transfers.\n\nThe Debrief's 'Capacity + next' field closes the loop: post-leg gauge read = leaving the hash house for the next leg.\n\nCross-ref: chunk-gauge-heartbeat (The Gauge) — the heartbeat is the continuous rhythm; the hash house is the explicit check-in point within that rhythm."
-        },
-        {
-          "id": "chunk-gauge-heartbeat",
-          "title": "The heartbeat — capacity ↔ restoration as meta-rhythm",
-          "summary": "The continuous Gauge-read-and-dispatch cycle is the framework's beating rhythm. Without it, the framework is just phases without honoring capacity.",
-          "body": "The framework has two central images. The cache-game (Jess's contribution) names how the day's game gets designed — Frame as the game-design moment. The heartbeat names how the day's rhythm cycles.\n\nThe heartbeat: capacity check → action plan → capacity check → action plan. The Gauge reads, the result dispatches: cleared (continue with the planned phase) or grounded (insert recovery, re-read). The cycle runs continuously throughout the day, between every phase, across days.\n\nWith the heartbeat, every phase boundary is gated by capacity and every grounded reading dispatches a targeted recovery. Without it, the cycle just runs through phases regardless of state — and the framework collapses into ritual.\n\nThe Pilot Check is the explicit pre-flight version of the heartbeat (rule-out across cognitive / emotional / physical, dispatching recovery hours per red dimension). The Gauge is the continuous instrument the heartbeat runs on.\n\nThe two images compose. The cache-game is *how the day's game is designed.* The heartbeat is *how the day's rhythm cycles.* Neither alone is the framework; together they make the practice live."
-        }
-      ],
-      "notes": [
-        "The capacity check-in is the felt-sense layer of the Gauge. It's been doing real recovery-planning work and is the seed the Gauge grows from.",
-        "2026-04-30 — The morning gauge worked (recovery turnaround)."
-      ]
-    },
-    {
       "id": "director-desk",
       "name": "Director's Desk",
       "type": "aux / persistent",
@@ -6675,24 +6623,6 @@
       "brief": "One week of disciplined Frame runs feeding into the Archive.",
       "full": "Run one full week of formal Frame practice. Capture lab notes for each turn. Feed findings into the Archive and the Frame form v1 revision cycle."
     },
-    "LAB-020": {
-      "id": "LAB-020",
-      "title": "Per-turn gauge entries (vs only per-day)",
-      "status": "backlog",
-      "priority": "P1",
-      "area": "the-gauge",
-      "brief": "Upgrade the gauge to record a reading at the start of each turn, not just daily.",
-      "full": "Upgrade the gauge to record a reading at the start of each turn, not just once per day. This feeds the multi-signal model and enables intra-day capacity tracking."
-    },
-    "LAB-021": {
-      "id": "LAB-021",
-      "title": "Capacity check-in v0.2 (turn-aware data model)",
-      "status": "backlog",
-      "priority": "P1",
-      "area": "the-gauge",
-      "brief": "Rebuild the check-in PoC with a turn-aware data model.",
-      "full": "Rebuild the capacity check-in PoC with a turn-aware data model. Each record tagged with turn ID, time-of-day, and which phase triggered the check-in. Enables correlation analysis between gauge readings and turn outcomes."
-    },
     "LAB-022": {
       "id": "LAB-022",
       "title": "Cowork integration (morning prompt opens Frame card)",
@@ -6719,15 +6649,6 @@
       "area": "director-desk",
       "brief": "Both Directors present in the lab simultaneously with shared state.",
       "full": "Multiplayer mode: both Directors (Danvers + Jess) present in the lab simultaneously. Shared gauge state, shared items, separate Frame cards. Real-time updates via WebSocket or polling."
-    },
-    "LAB-025": {
-      "id": "LAB-025",
-      "title": "Make the Gauge a workshop (embed capacity check-in)",
-      "status": "backlog",
-      "priority": "P1",
-      "area": "the-gauge",
-      "brief": "Promote the Gauge from a regular area to a workshop, with the capacity check-in PoC embedded as the instrument view.",
-      "full": "Same workshop pattern as Frame. Top half of drawer = the live instrument (capacity check-in PoC, embedded as iframe or directly merged), bottom half = the floor view (items, artifacts, notes, recent gauge readings as cards). Eventually adds the multi-signal layers (behavioral, temporal) on top of the felt-sense PoC. Architecturally, makes the PoC's daily ritual a first-class part of the lab rather than a side artifact."
     },
     "LAB-026": {
       "id": "LAB-026",
@@ -6764,15 +6685,6 @@
       "area": "director-desk",
       "brief": "An AI agent generates the title for Log entries from observation + impact. Manual override stays available.",
       "full": "When a Log entry is saved (or after observation/impact are filled), an AI agent suggests a 4–8 word label that captures the entry's gist. User accepts, edits, or replaces. Belongs to the broader 'magical workshop' direction where AI teammates contribute structured content. Touches every workshop area, not just Frame. Requires an LLM call (Claude API) — server endpoint or client-side proxy. Lower-tier model (Haiku) sufficient for titling. Lives in director-desk because the capability spans the whole lab, not one area."
-    },
-    "LAB-030": {
-      "id": "LAB-030",
-      "title": "Integrate the heartbeat into the deck",
-      "status": "backlog",
-      "priority": "P1",
-      "area": "the-gauge",
-      "brief": "Update deck slides to surface the heartbeat as the framework's second central image alongside the cache-game.",
-      "full": "The framework now has two named central images. The cache-game is well-represented in the deck (Frame batches with subtitles tied to the metaphor). The heartbeat (capacity ↔ restoration as continuous meta-rhythm) is not yet in the deck. Update slides 11 and 17–18 (Gauge and multi-signal model) to name the heartbeat explicitly. Possibly add a slide that pairs the two images. Coordinates with chunk-gauge-heartbeat in the-gauge area."
     },
     "LAB-031": {
       "id": "LAB-031",
@@ -9789,7 +9701,7 @@
       title: 'Turn v0.1 Map',
       kind: 'deck',
       subtitle: '21 slides · 4 acts · beginner-facing',
-      preview: 'The original turn-architecture deck. Frame · Comprehend · Sync · Produce · Debrief · Recover, with the three meta-disciplines (Trim · Heartbeat · Transition).',
+      preview: 'The original turn-architecture deck. Frame · Comprehend · Sync · Produce · Debrief · Recover, with the two meta-disciplines (Trim · Transition).',
       deck_href: 'turn-v0.1-map.html'
     }
   ];

--- a/quenton-quince/LAB_CONTEXT.md
+++ b/quenton-quince/LAB_CONTEXT.md
@@ -87,11 +87,11 @@ Originated from Jess's adventure-caching race story. Maps to Frame's four-batch 
 
 Three end-states: collected enough → finish line; tired/hurt/done with what you got → head home early; time runs out → buzzer.
 
-### The heartbeat
+### The bookended day
 
-The give-and-take rhythm of capacity check ↔ restoration. The Gauge reads, the result dispatches: cleared (continue) or grounded (insert recovery, re-read). This rhythm runs continuously, between phases, across days. Without the heartbeat, the framework is just phases without honoring capacity. With it, every boundary is gated and every grounded reading dispatches targeted recovery.
+The day has two fixed posts: a Pilot Check at the start and a Recovery ritual at the end. Between them the turn cycle runs as many times as capacity allows. The bookends aren't optional and they aren't symmetric — the morning check rules out the dimensions that would make the day unsafe to begin; the evening recovery closes the loops the day opened so they don't bleed into tomorrow. Everything in between (Comprehend → Frame → Sync → Produce → Debrief, with Transition and Trim available throughout) inherits its license to run from the morning check and its right to end from the evening recovery.
 
-The Pilot Check is the explicit pre-flight version of the heartbeat (rule-out across cognitive / emotional / physical, dispatching recovery hours per red dimension). The Gauge is the continuous instrument the heartbeat runs on.
+**Together:** The cache-game is _how the day's game is designed_ (Frame's metaphor). The bookended day is _how the day is held_ — opened deliberately, closed deliberately, with the cycle living in the protected middle.
 
 ## The framework in one paragraph
 


### PR DESCRIPTION
## Summary

- Retires the Gauge as a free-standing lab area: floor tile deleted, area JSON deleted, LAB-020 / LAB-021 / LAB-025 / LAB-030 item records deleted
- Replaces the heartbeat as the framework's second central image with "the bookended day" (Pilot Check opens the day, Recovery closes it, turn cycle runs in the protected middle)
- Updates `cognitive-lab/PROCESS.md`, `quenton-quince/LAB_CONTEXT.md` with the new bookended-day prose
- Appends dated DECISIONS.md entry (2026-05-11, reverse-chronological)
- Removes LAB-020 / LAB-021 lines from `cognitive-lab/cognitive-lab-spec.md`
- Archives all deleted content in `cognitive-lab/archive/heartbeat-retirement-2026-05-11.md`
- Drops "Heartbeat" from the three-meta-disciplines parenthetical in the deck-theater preview string

See DECISIONS.md entry 2026-05-11 and `cognitive-lab/archive/heartbeat-retirement-2026-05-11.md` for the full rationale and verbatim archived content.

**PR sequence:** This is PR1 of 3. PR2 (queued): Pilot Check consolidation. PR3 (queued): bottom-row architecture + day-band middle + open-turn vocab.

## Flags for author

- **`cognitive-lab/LAB_CONTEXT.md` does not exist.** The brief specified this path; the file with matching content and line numbers is `quenton-quince/LAB_CONTEXT.md`, which I updated. If a separate `cognitive-lab/LAB_CONTEXT.md` was intended (new file, different from the quenton-quince version), that's unbuilt — let me know the target content and I'll create it.
- **Surviving heartbeat refs outside PR1 scope** (not edited, flagged for follow-up):
  - `quenton-quince/SYSTEM_PROMPT.md` lines 11 + 22
  - `quenton-quince/METHODOLOGY.md` line 27
  - `cognitive-lab/SESSION_PROMPTS.md` lines 42 + 54
  - `cognitive-lab-v0.1.html` lines 5973 + 5981 (inside a historical Director's Desk log entry — durable record, probably leave as-is)
  - `quenton-quince/LAB_CONTEXT.md` Band 4 description still reads "The Gauge · Pilot Check Station · Director's Desk" (minor, in the how-the-lab-is-structured section)
- **`turn-v0.1-map.html` had no heartbeat reference** — that task was a confirmed no-op (file is 988 lines; grepped clean).
- **Item status mechanism:** LAB-020/021/025/030 status updates to `archived` require browser-side localStorage cycling; records are deleted from the baseline JSON so the auto-Log won't fire from the UI. Archive file serves as the record.

## Test plan

- [ ] Open `cognitive-lab-v0.1.html` in browser. Confirm Gauge tile is gone from Band 4, no console errors, no orphan `data-area="the-gauge"` references, Pilot Check and Recovery still open cleanly
- [ ] Confirm bookended-day prose reads correctly in Quenton's LAB_CONTEXT and PROCESS.md
- [ ] `grep -rn "heartbeat\|the-gauge" cognitive-lab/` returns hits only in `archive/`, `DECISIONS.md`, and the historical log entries noted above

🤖 Generated with [Claude Code](https://claude.com/claude-code)