### PR TITLE
Lab: relocate Pilot Check material from retired Gauge; sweep surviving heartbeat references

### DIFF
--- a/cognitive-lab/SESSION_PROMPTS.md
+++ b/cognitive-lab/SESSION_PROMPTS.md
@@ -39,7 +39,7 @@ Orient by reading:
   daily/weekly rhythm)
 - quenton-quince/PLAYS.md and PRINCIPLES.md (your playbook + heuristics)
 - The Log tile (experiments array) of frame-workshop, pilot-check-station,
-  debrief-booth, the-gauge, transition-hallway in
+  debrief-booth, transition-hallway in
   cognitive-lab/cognitive-lab-v0.1.html
 
 State of play (update this section as the framework evolves):
@@ -51,11 +51,9 @@ State of play (update this section as the framework evolves):
   grounded). LAB-007 (form refinement) and LAB-008 (chapter) still
   in-progress.
 - Two central images: cache-game (Frame's organizing metaphor) and
-  heartbeat (Gauge↔Recovery rhythm).
-- Capacity check-in PoC and Pilot Check converge into a unified Gauge
-  instrument. Two related backlog items: LAB-025 (Make the Gauge a
-  workshop, embed capacity check-in) and LAB-021 (Capacity check-in
-  v0.2, turn-aware data model). Both P1.
+  bookended day (Pilot Check opens the day, Recovery closes it).
+- The Gauge area was retired 2026-05-11; Pilot Check Station is the
+  pre-flight instrument. LAB-020/021/025/030 archived with the Gauge.
 - Quenton (you) and Larry Moleman are project-resident agents (PR #123).
 - grepzilla2 covers cognitive-lab/ now (PR #126); use for markdown-heavy
   PRs that Devin skips.

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -6117,9 +6117,16 @@
       "items": ["LAB-007","LAB-008"],
       "sources": [
         { "label": "turn-v0.1-map.html (deck slides 17–18 — multi-signal model)", "href": "turn-v0.1-map.html" },
-        { "label": "Book 1 capacity chapter — emotional / mental / physical (linked when chapter file lands in lab)", "href": "#" }
+        { "label": "Book 1 capacity chapter — emotional / mental / physical (linked when chapter file lands in lab)", "href": "#" },
+        { "label": "Capacity Check-In (felt-sense seed for the Pilot Check ritual)", "href": "capacity-checkin.html" }
       ],
       "chunks": [
+        {
+          "id": "chunk-hash-house-pilot-check",
+          "title": "Hash house = Pilot Check visit (refuel, re-orient, decide)",
+          "summary": "Pilot Check = hash-house visit at the start of the day: refuel, re-orient, decide whether to continue. The morning bookend of the bookended day.",
+          "body": "In rogaining, the **hash house** is the central base camp. Racers return to refuel, check time, re-orient, and decide whether to continue the current route or revise. Elite racers treat each visit as a decision point, not a rest stop: assess capacity against remaining time and course, then commit or pivot.\n\nThe morning Pilot Check is the hash-house visit that opens the day. The parallels are direct:\n\n- **Refuel** → capacity read (Cognitive / Emotional / Physical sliders).\n- **Re-orient** → dispatch verdict (cleared or grounded) + diagnosis of which dimension is red.\n- **Decide whether to continue** → Full Turn vs. Partial Turn vs. Recovery day.\n\nThe framing carries a normative weight the checklist framing doesn't: the hash-house visit is non-optional in rogaining. Skipping it doesn't make you faster; it makes you lost. The evening Recovery is the other bookend — closing the loops the day opened so they don't bleed into tomorrow. Together they hold the day: Pilot Check opens it deliberately, Recovery closes it deliberately, the turn cycle runs in the protected middle."
+        },
         {
           "id": "chunk-pilot-rule-out",
           "title": "Rule-out, not measurement",
@@ -6148,7 +6155,9 @@
           "impact": "Reframed Pilot Check architecture: three-dimension rule-out, sliders 1–10 per dimension, threshold ≤3 = red. Output dispatches a winged prescription: 1 hour workday recovery per red dimension. Drift / attention pull split off as a different tool (Push-phase monitoring, not pre-flight). Pilot Check operationally connects Book 1's capacity chapter (emotional/mental/physical) to Book 2's pre-flight ritual."
         }
       ],
-      "notes": []
+      "notes": [
+        "2026-04-30 — The morning Pilot Check worked (recovery turnaround)."
+      ]
     },
     {
       "id": "transition-hallway",

--- a/quenton-quince/LAB_CONTEXT.md
+++ b/quenton-quince/LAB_CONTEXT.md
@@ -53,7 +53,7 @@ The lab is a top-down, click-to-explore floor plan with four bands:
 
 **Band 4 — Bottom (instruments + Director):**
 
-- The Gauge · Pilot Check Station · Director's Desk
+- Pilot Check Station · Director's Desk
 
 Click any area opens a side drawer (drawer expands to 66vw if the area has `workshop: true`). Drawers contain:
 
@@ -95,7 +95,7 @@ The day has two fixed posts: a Pilot Check at the start and a Recovery ritual at
 
 ## The framework in one paragraph
 
-Knowledge work used to come in batches (mornings = email, afternoons = meetings). AI made it continuous — agents work 24/7, output is functionally infinite. Continuous-flow work breaks the people doing it because the management interface (calendars, project software, willpower) was built for batched work. The Turn is a structured cycle for AI-native work: six phases, three categories (required / conditional / insertable), gated by a continuously-read capacity gauge, paced by deliberate recovery. The framework borrows from cognitive load research, occupational health psychology, and industries that have long operated continuously (aviation, naval, manufacturing, medicine, sport).
+Knowledge work used to come in batches (mornings = email, afternoons = meetings). AI made it continuous — agents work 24/7, output is functionally infinite. Continuous-flow work breaks the people doing it because the management interface (calendars, project software, willpower) was built for batched work. The Turn is a structured cycle for AI-native work: six phases, three categories (required / conditional / insertable), gated by a morning Pilot Check and a closing Recovery ritual, paced by deliberate recovery. The framework borrows from cognitive load research, occupational health psychology, and industries that have long operated continuously (aviation, naval, manufacturing, medicine, sport).
 
 ## When you don't have the context
 

--- a/quenton-quince/METHODOLOGY.md
+++ b/quenton-quince/METHODOLOGY.md
@@ -24,7 +24,7 @@ Patterns that work:
 - **Lead with the recommendation.** "I lean X." Then give the reasoning. Don't survey options before committing.
 - **Tradeoff table when ≥2 options have real merit.** Columns: Option · What it gives you · What it costs · When it's right.
 - **Cite specifically when grounding.** "Sweller (CLT) says extraneous load reduction is the highest-ROI cognitive intervention" beats "the research suggests reducing load is good."
-- **Name the metaphor when it carries the design.** The cache-game made Frame's four-batch structure click; the heartbeat names the Gauge↔Recovery rhythm. Use them when they sharpen.
+- **Name the metaphor when it carries the design.** The cache-game made Frame's four-batch structure click; the bookended day names how the turn cycle is held (Pilot Check opens, Recovery closes). Use them when they sharpen.
 - **Flag your own uncertainty.** "I lean X but the experiment hasn't run yet" is honest and useful.
 
 ### 3. Push back

--- a/quenton-quince/SYSTEM_PROMPT.md
+++ b/quenton-quince/SYSTEM_PROMPT.md
@@ -8,7 +8,7 @@ A design partner. Not a generalist assistant. Not a yes-machine. Not a literatur
 
 You hold three things in your head simultaneously:
 
-1. **The framework.** The phase structure (Frame · Comprehend · Sync · Push · Debrief · Recover), meta-disciplines (Transition · Trim), the Gauge as continuous capacity instrument, and the central images (the cache-game, the heartbeat).
+1. **The framework.** The phase structure (Frame · Comprehend · Sync · Push · Debrief · Recover), meta-disciplines (Transition · Trim), the bookended day (Pilot Check opens · Recovery closes), and the central images (the cache-game, the bookended day).
 2. **The lab.** The interactive workshop where the framework is being built. Areas, items, chunks, experiments, sources. Live state.
 3. **The book.** _The 7 Turn Work Week_ in progress, with the chapter material accumulating in the lab's Chapter chunks. Eventually flowing to ghostwriter and Zelda.
 
@@ -19,7 +19,7 @@ You design across all three. You don't write final book voice. You don't operate
 - **Substantive but not academic.** Cite specific researchers when grounding (Sweller, Hobfoll, Sonnentag, Hockey, Leroy, Klein, Gawande, Wickens) but in passing — not as a literature review. The author needs a tradeoff named, not a citation parade.
 - **Opinionated.** Lead with a recommendation. The author hired you for judgment, not menu-reading. "I lean X but I want pushback before committing" is your default stance.
 - **Plain English.** No corporate vocabulary. No "leverage" as a verb. No "delve," "unpack," "harness," "navigate" (figurative), "tapestry," "landscape" (figurative), "paradigm," "synergy," "ecosystem." If grepzilla2 would flag it as an AI-tell, don't say it.
-- **Game-y / workshop language is native.** Cache-game, bingo fuel, scrub in, set the field, the heartbeat, the cycle. These are the framework's vocabulary; use them when they sharpen the thinking.
+- **Game-y / workshop language is native.** Cache-game, bingo fuel, scrub in, set the field, the bookended day, the cycle. These are the framework's vocabulary; use them when they sharpen the thinking.
 - **Tables when tradeoffs are at stake.** Walls of paragraph prose are for exploratory thinking. When you've reached the propose-with-tradeoffs moment, structure the proposal.
 - **Brief is good.** Bingo time exists for you too. Say what's needed, then stop.
 

--- a/quenton-quince/SYSTEM_PROMPT.md
+++ b/quenton-quince/SYSTEM_PROMPT.md
@@ -8,7 +8,7 @@ A design partner. Not a generalist assistant. Not a yes-machine. Not a literatur
 
 You hold three things in your head simultaneously:
 
-1. **The framework.** The phase structure (Frame · Comprehend · Sync · Push · Debrief · Recover), meta-disciplines (Transition · Trim), the bookended day (Pilot Check opens · Recovery closes), and the central images (the cache-game, the bookended day).
+1. **The framework.** The phase structure (Frame · Comprehend · Sync · Push · Debrief · Recover), meta-disciplines (Transition · Trim), the day's structural anchors (Pilot Check opens · Recovery closes), and the central images (the cache-game, the bookended day).
 2. **The lab.** The interactive workshop where the framework is being built. Areas, items, chunks, experiments, sources. Live state.
 3. **The book.** _The 7 Turn Work Week_ in progress, with the chapter material accumulating in the lab's Chapter chunks. Eventually flowing to ghostwriter and Zelda.
 


### PR DESCRIPTION
## Summary

- **Part A — Pilot Check consolidation:** Salvages hash-house metaphor from the retired Gauge area and places it as a new chunk (`chunk-hash-house-pilot-check`) on `pilot-check-station`. Adds the 2026-04-30 morning check note to the station's `notes` array (with "gauge" replaced by "morning Pilot Check"). Adds `capacity-checkin.html` as a source on the station (confirmed file exists).
- **Part B — Heartbeat reference cleanup sweep:** Updates all surviving heartbeat / Gauge language in `quenton-quince/SYSTEM_PROMPT.md` (2 lines), `quenton-quince/METHODOLOGY.md` (1 line), `quenton-quince/LAB_CONTEXT.md` (Band-4 description + framework paragraph), and `cognitive-lab/SESSION_PROMPTS.md` (2 lines + 1 stale area-reference in the orient list). Historical log strings at lines 5973/5981 in the lab HTML and archive content left untouched.

## Stack

Stacks on PR1 (#139 — heartbeat retirement). Base is `larry/pr1-heartbeat-retirement`.

PR3 queued next: `bottom-row architecture + day-band middle + open-turn vocab`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)