### PR TITLE
Lab: introduce day-band; flip Recovery to ritual; bottom row gets meta kind + Desk; open-turn parking at Recovery lock

### DIFF
--- a/cognitive-lab/SESSION_PROMPTS.md
+++ b/cognitive-lab/SESSION_PROMPTS.md
@@ -2,7 +2,7 @@
 
 How to start (and close) a session in the cognitive lab. Sibling to `PROCESS.md` (how the lab works) and `DECISIONS.md` (what's been decided).
 
-Last meaningful update: 2026-05-02. Update this file when:
+Last meaningful update: 2026-05-11 (Heartbeat retirement, Gauge area deleted, day-band architecture). Update this file when:
 
 - The state-of-play summary in the long form goes stale
 - The current "urgent priority" example shifts

--- a/cognitive-lab/cognitive-lab-spec.md
+++ b/cognitive-lab/cognitive-lab-spec.md
@@ -75,6 +75,14 @@ spatial / game-y vibe without the canvas complexity.
 
 ## Layout (20 cols × 14 rows on a tile grid)
 
+> **Note (as of 2026-05-11):** the layout below describes the *original* v0.1 build spec. The current floor is post-PR3:
+> - Band 1: storage rooms — Library · Daily Journal · Deck Theater · Strategy & Plans
+> - Band 2 (new **day-band**): Pilot Check Station · (baseline rule) · Recovery Room — both `kind: ritual`
+> - Band 3 (turn cycle, five tiles, C-before-F): Comprehend · Frame · Sync · Produce · Debrief — all `kind: phase`
+> - Band 4 (meta row): Transition Hallway · Trim Bench · Director's Desk — all `kind: meta`
+>
+> The Gauge area and the Backlog Wall were retired (see `archive/heartbeat-retirement-2026-05-11.md` and Lab v0.5 entries in `DECISIONS.md`). The original layout diagram below is preserved as build history.
+
 The lab has four bands top-to-bottom:
 
 ```

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -9835,7 +9835,7 @@
           narrative: '**Welcome to the Comprehend Station tour.**\n\nThis walk is the meta-loop on purpose: you\'re using Comprehend Station to learn about Comprehend Station. The right pane is a live lab booted to the **Floor view**.\n\n**No state will be modified** — every step is read-only. Click around freely.\n\nClick **Next** to begin.'
         },
         {
-          narrative: '**The Floor.**\n\nLook at the right pane. The middle band shows the leg phases left-to-right: **Comprehend** · Frame · Sync · Produce · Debrief · Recover.\n\n**Comprehend is first** (C-before-F floor reorder, shipped today). The reasoning: orientation precedes commitment. You can\'t pick a Frame intelligently without first re-immersing in where you are.\n\nClick **Next**.'
+          narrative: '**The Floor.**\n\nLook at the right pane. The turn-cycle band shows the five turn phases left-to-right: **Comprehend** · Frame · Sync · Produce · Debrief.\n\n**Comprehend is first** (C-before-F floor reorder). The reasoning: orientation precedes commitment. You can\'t pick a Frame intelligently without first re-immersing in where you are.\n\nThe band *above* the turn cycle is the day-band: **Pilot Check** opens the day, **Recovery** closes it. Recovery is a ritual, not a phase.\n\nClick **Next**.'
         },
         {
           narrative: '**Click the Comprehend area** in the right pane (the 🛠️ tile labeled "Comprehend · orient first"). The Comprehend Station drawer will open.\n\nThis is the workshop you\'re standing in right now (but rendered inside its own iframe inside itself — that\'s the recursion you noticed).\n\nClick **Next** once the drawer is open.'
@@ -9887,7 +9887,7 @@
       title: 'Turn v0.1 Map',
       kind: 'deck',
       subtitle: '21 slides · 4 acts · beginner-facing',
-      preview: 'The original turn-architecture deck. Frame · Comprehend · Sync · Produce · Debrief · Recover, with the two meta-disciplines (Trim · Transition).',
+      preview: 'The original turn-architecture deck. Five-phase turn cycle (Frame · Comprehend · Sync · Produce · Debrief) plus the day-band rituals (Pilot Check · Recovery) and meta-disciplines (Trim · Transition).',
       deck_href: 'turn-v0.1-map.html'
     }
   ];
@@ -10968,7 +10968,9 @@
                 + auto-detected from unresolved LAB-### refs).
      ────────────────────────────────────────────────────────────── */
 
-  // Each phase area declares the canonical slots it expects.
+  // Each turn-cycle phase area declares the canonical slots it expects.
+  // Ritual and meta areas have no declared slots (they're not on the
+  // form / chapter / practice scaffold).
   // A slot is "fulfilled" if the area has any item whose title
   // contains the slot kind word (case-insensitive, word boundary).
   const PHASE_SLOTS = {

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -2890,6 +2890,15 @@
     opacity: 0.85;
   }
 
+  /* Day-band: Pilot Check left, baseline rule middle, Recovery right */
+  .band-day { align-items: center; }
+  .band-rule {
+    flex: 1;
+    border-top: 1px solid var(--panel-bd);
+    align-self: center;
+    opacity: 0.4;
+  }
+
   /* Phase cycle band: arrows align with mid-row icons */
   .band-phase { align-items: center; }
   .band-phase .arrow { font-size: 18px; }
@@ -3956,6 +3965,81 @@
 
   /* Recent recovery list (reuses ws-recent-card style) */
   #rec-recent-list .ws-recent-card { border-left-color: var(--success); }
+
+  /* ── Open-turns section (Step 3 of Recovery) ── */
+  .rec-open-turns-section {
+    margin-top: 12px;
+  }
+  .rec-open-turn-row {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 8px 10px;
+    background: rgba(42,58,92,0.35);
+    border: 1px solid var(--panel-bd);
+    border-radius: 6px;
+    margin-bottom: 6px;
+  }
+  .rec-open-turn-id {
+    font-family: var(--font-px);
+    font-size: 9px;
+    color: var(--accent-dim);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+  }
+  .rec-open-turn-title {
+    font-size: 12px;
+    color: var(--fg);
+  }
+  .rec-open-turn-actions {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+    margin-top: 4px;
+  }
+  .rec-turn-action-label {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-family: var(--font-px);
+    font-size: 10px;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--fg-dim);
+    cursor: pointer;
+    padding: 3px 7px;
+    border: 1px solid var(--panel-bd);
+    border-radius: 4px;
+    transition: background 0.12s, color 0.12s, border-color 0.12s;
+  }
+  .rec-turn-action-label:has(input:checked) {
+    background: rgba(226,160,74,0.12);
+    border-color: var(--accent-dim);
+    color: var(--accent);
+  }
+  .rec-turn-action-label input[type="radio"] {
+    display: none;
+  }
+  .rec-open-turn-note {
+    font-size: 11px;
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-bd);
+    border-radius: 4px;
+    color: var(--fg);
+    padding: 4px 7px;
+    width: 100%;
+    resize: none;
+    font-family: inherit;
+    margin-top: 2px;
+  }
+  .rec-open-turn-note:focus { outline: none; border-color: var(--accent-dim); }
+  .rec-open-turns-empty {
+    font-size: 11px;
+    color: var(--fg-dim);
+    font-style: italic;
+    padding: 6px 0;
+  }
 
   /* ── Course Header bar (renders active leg + course at the top of every workshop drawer) ──
      Single-line glanceable strip. Quenton's "iconic skin" call: leg-number is a
@@ -5047,9 +5131,25 @@
     </div>
   </div>
 
-  <!-- Band 2: Phase cycle (single visual each).
+  <!-- Band 2: Day-band — bookended day (Pilot Check opens · Recovery closes) -->
+  <div class="band band-day">
+    <div class="area area-visual" data-area="pilot-check-station" data-accent="amber">
+      <div class="area-scene">✈️</div>
+      <div class="area-label">Pilot Check<span class="lbl-sub">ritual · open</span></div>
+      <div class="badge-row" id="badges-pilot-check-station"></div>
+    </div>
+    <div class="band-rule"></div>
+    <div class="area area-visual" data-area="recovery-room" data-accent="green">
+      <div class="area-scene">🌿</div>
+      <div class="area-label">Recover<span class="lbl-sub">ritual · close</span></div>
+      <div class="badge-row" id="badges-recovery-room"></div>
+    </div>
+  </div>
+
+  <!-- Band 3: Turn cycle (single visual each).
        Move 2a (v0.4 build): Comprehend leads. Per the C-before-F call —
-       you can't scope what you haven't read in. Frame follows. -->
+       you can't scope what you haven't read in. Frame follows.
+       Recovery moved to day-band; cycle ends at Debrief. -->
   <div class="band band-phase">
     <div class="area area-visual" data-area="comprehend-station" data-accent="amber">
       <div class="area-scene">🛠️</div>
@@ -5080,15 +5180,9 @@
       <div class="area-label">Debrief<span class="lbl-sub">required</span></div>
       <div class="badge-row" id="badges-debrief-booth"></div>
     </div>
-    <div class="arrow">→</div>
-    <div class="area area-visual" data-area="recovery-room" data-accent="green">
-      <div class="area-scene">🌿</div>
-      <div class="area-label">Recover<span class="lbl-sub">insertable</span></div>
-      <div class="badge-row" id="badges-recovery-room"></div>
-    </div>
   </div>
 
-  <!-- Band 3: Meta-disciplines -->
+  <!-- Band 4: Meta — Transition · Trim · Director's Desk -->
   <div class="band">
     <div class="area area-visual" data-area="transition-hallway" data-accent="tan">
       <div class="area-scene">🚪</div>
@@ -5099,15 +5193,6 @@
       <div class="area-scene">✂️</div>
       <div class="area-label">Trim<span class="lbl-sub">meta</span></div>
       <div class="badge-row" id="badges-trim-bench"></div>
-    </div>
-  </div>
-
-  <!-- Band 4: Instruments + Director (bottom) -->
-  <div class="band">
-    <div class="area area-visual" data-area="pilot-check-station" data-accent="amber">
-      <div class="area-scene">✈️</div>
-      <div class="area-label">Pilot Check<span class="lbl-sub">multi-signal</span></div>
-      <div class="badge-row" id="badges-pilot-check-station"></div>
     </div>
     <div class="area area-visual" data-area="director-desk" data-accent="dark">
       <div class="area-scene">🧑‍💻</div>
@@ -5505,6 +5590,15 @@
             <textarea id="rec-plan-text" class="rec-plan-textarea" placeholder="What you'll actually do. Inline scheduling welcome — 'stretch now, meditate at bedtime, gym in the morning.'"></textarea>
           </div>
 
+          <!-- Open turns at lock -->
+          <div class="workshop-section rec-open-turns-section">
+            <div class="workshop-section-label">Open turns at lock</div>
+            <div class="rec-help">
+              Any turn still open at end of day. Pick an action for each you want to record — carry, drop, or defer. Rows with no action selected are not saved.
+            </div>
+            <div id="rec-open-turns-list"></div>
+          </div>
+
           <div class="rec-nav">
             <button class="ff-btn" id="rec-back-3">← Back</button>
             <div>
@@ -5724,6 +5818,7 @@
       "id": "frame-workshop",
       "name": "Frame Workshop",
       "type": "phase / required",
+      "kind": "phase",
       "accent": "blue",
       "workshop": true,
       "description": "Where the Frame practice and chapter live. The phase that decides what the turn is for.",
@@ -5837,6 +5932,7 @@
       "id": "comprehend-station",
       "name": "Comprehend Station",
       "type": "phase / required",
+      "kind": "phase",
       "accent": "amber",
       "workshop": true,
       "description": "Where the lab orients you. Re-immerse on prior legs, walk decks, take guided product walks of new features. The phase that loads remaining state from agents and prior work — first step in the cycle (C-before-F).",
@@ -5876,6 +5972,7 @@
       "id": "sync-floor",
       "name": "Sync Floor",
       "type": "phase / conditional",
+      "kind": "phase",
       "accent": "amber",
       "description": "Where Sync practice and chapter live. The phase that aligns humans and agents and confirms zones.",
       "items": ["LAB-011","LAB-012"],
@@ -5888,6 +5985,7 @@
       "id": "push-bay",
       "name": "Produce Bay",
       "type": "phase / conditional",
+      "kind": "phase",
       "accent": "amber",
       "description": "Where the Produce phase (formerly Push) practice and chapter live. Decision work, hardest first, with bingo-fuel stop signal.",
       "items": ["LAB-013","LAB-014"],
@@ -5901,6 +5999,7 @@
       "id": "debrief-booth",
       "name": "Debrief Booth",
       "type": "phase / required",
+      "kind": "phase",
       "accent": "blue",
       "workshop": true,
       "description": "Where Debrief practice and chapter live. Closes the cycle, captures, sets up the next gauge read. Currently the urgent priority — its absence is the gap that creates session-end integration debt.",
@@ -5943,7 +6042,8 @@
     {
       "id": "recovery-room",
       "name": "Recovery Room",
-      "type": "phase / insertable",
+      "type": "ritual / end-of-day",
+      "kind": "ritual",
       "accent": "green",
       "workshop": true,
       "description": "Where Recover practice and chapter live. Three-screen flow: measure the need (depth & locus), shape the recovery (mechanism), plan it. Mechanisms: Detach, Relax, Master, Control. Sleep is the floor.",
@@ -5958,6 +6058,7 @@
       "id": "director-desk",
       "name": "Director's Desk",
       "type": "aux / persistent",
+      "kind": "meta",
       "accent": "dark",
       "description": "Your seat. Where the Frame card sits today, where lab notes get written. Also the home for cross-cutting lab work — agent composition, process docs, session integration.",
       "items": ["LAB-022","LAB-023","LAB-024","LAB-029","LAB-034","LAB-035","LAB-037","LAB-039","LAB-040","LAB-041","LAB-043","LAB-045","LAB-047","LAB-048","LAB-049","LAB-050","LAB-051"],
@@ -6111,6 +6212,7 @@
       "id": "pilot-check-station",
       "name": "Pilot Check Station",
       "type": "rule-out / pre-flight",
+      "kind": "ritual",
       "accent": "amber",
       "workshop": true,
       "description": "Three-dimension capacity rule-out — cognitive (king), emotional, physical. 0–3 on any dimension = grounded. Output dispatches a targeted Recovery prescription. Like aviation IM SAFE: not measuring fitness, ruling out hazards.",
@@ -6163,6 +6265,7 @@
       "id": "transition-hallway",
       "name": "Transition Hallway",
       "type": "meta-discipline",
+      "kind": "meta",
       "accent": "tan",
       "description": "Every phase boundary is taxed (Leroy 2009 attention residue). Close · reset · open. Practice surface for the boundary move. Same shape across micro / meso / macro / super-macro scales.",
       "items": ["LAB-005","LAB-006","LAB-031"],
@@ -6188,6 +6291,7 @@
       "id": "trim-bench",
       "name": "Trim Bench",
       "type": "meta-discipline",
+      "kind": "meta",
       "accent": "tan",
       "description": "Selection discipline within each phase. Lower priority once Frame is doing its job.",
       "items": ["LAB-017","LAB-018","LAB-033"],
@@ -8172,6 +8276,62 @@
     });
   }
 
+  // ── Open-turns rendering ──
+  // Collects legs not yet debriefed/archived and renders a chip-row per turn.
+  // Each row: turn id, turn title (from Frame card's "in" field), and three
+  // radio actions (carry / drop / defer) plus an optional note input.
+  function recRenderOpenTurns() {
+    const container = document.getElementById('rec-open-turns-list');
+    if (!container) return;
+
+    const openLegs = loadLegs().filter(l =>
+      l && l.status !== 'debriefed' && l.status !== 'archived'
+    );
+
+    if (openLegs.length === 0) {
+      container.innerHTML = '<div class="rec-open-turns-empty">No open turns to park.</div>';
+      return;
+    }
+
+    container.innerHTML = openLegs.map(leg => {
+      // Resolve title from Frame card "in" field, fall back to "Untitled"
+      let title = 'Untitled';
+      if (leg.frame_card_id) {
+        const card = (loadFrameCards() || []).find(c => c && c.savedAt === leg.frame_card_id);
+        if (card && card.in) {
+          const raw = card.in;
+          title = (typeof raw === 'string' ? raw : JSON.stringify(raw)).split('\n')[0].slice(0, 80) || 'Untitled';
+        }
+      }
+      const escapedId = escapeHTML(leg.id);
+      const escapedTitle = escapeHTML(title);
+      return `<div class="rec-open-turn-row" data-turn-id="${escapedId}">
+        <div class="rec-open-turn-id">${escapedId}</div>
+        <div class="rec-open-turn-title">${escapedTitle}</div>
+        <div class="rec-open-turn-actions">
+          <label class="rec-turn-action-label"><input type="radio" name="rec-turn-action-${escapedId}" value="carry"> Carry</label>
+          <label class="rec-turn-action-label"><input type="radio" name="rec-turn-action-${escapedId}" value="drop"> Drop</label>
+          <label class="rec-turn-action-label"><input type="radio" name="rec-turn-action-${escapedId}" value="defer"> Defer</label>
+        </div>
+        <input type="text" class="rec-open-turn-note" placeholder="Optional note — e.g. 'carry into tomorrow's Frame' or 'blocked until Tuesday'" maxlength="200">
+      </div>`;
+    }).join('');
+  }
+
+  // Reads the open-turns UI and returns only rows where the author picked an action.
+  function recCollectOpenTurns() {
+    const rows = document.querySelectorAll('#rec-open-turns-list .rec-open-turn-row');
+    const result = [];
+    rows.forEach(row => {
+      const turnId = row.getAttribute('data-turn-id');
+      const checked = row.querySelector('input[type="radio"]:checked');
+      if (!checked) return; // no action selected — skip
+      const note = (row.querySelector('.rec-open-turn-note') || {}).value || '';
+      result.push({ turnId, action: checked.value, note: note.trim() });
+    });
+    return result;
+  }
+
   function recShowStep(n) {
     recState.step = n;
     document.querySelectorAll('#ws-recovery-content .rec-step').forEach(el => {
@@ -8183,7 +8343,7 @@
       el.classList.toggle('done', s < n);
     });
     if (n === 2) recRenderMechCards();
-    if (n === 3) { recSyncSizeButtons(); recRenderActivityChips(); }
+    if (n === 3) { recSyncSizeButtons(); recRenderActivityChips(); recRenderOpenTurns(); }
   }
 
   function recRenderRecent() {
@@ -8290,6 +8450,9 @@
       planEl && planEl.focus();
       return;
     }
+    // Collect open-turn parking decisions (only rows with an action selected).
+    const openTurns = recCollectOpenTurns();
+
     const entry = {
       id: genId(),
       date: todayDateString(),
@@ -8314,7 +8477,9 @@
       mechSuppressedMastery: recState.mechSuppressedMastery,
       zeroMech: recState.zeroMech,
       size: recState.size,
-      plan: recState.plan
+      plan: recState.plan,
+      // open-turn parking: only rows where author picked an action
+      openTurns: openTurns
     };
     const recs = loadRecoveries();
     recs.push(entry);
@@ -8335,12 +8500,24 @@
       const anchorRef = entry.anchorSource
         ? `anchored to ${entry.anchorSource.time} Pilot Check`
         : 'no Pilot Check today — anchored at 5';
+      // Build open-turn parking summary if any turns were actioned.
+      let turnParkingSuffix = '';
+      if (entry.openTurns && entry.openTurns.length > 0) {
+        const carries = entry.openTurns.filter(t => t.action === 'carry').length;
+        const drops   = entry.openTurns.filter(t => t.action === 'drop').length;
+        const defers  = entry.openTurns.filter(t => t.action === 'defer').length;
+        const parts = [];
+        if (carries) parts.push(carries + ' carry');
+        if (defers)  parts.push(defers  + ' defer');
+        if (drops)   parts.push(drops   + ' drop');
+        turnParkingSuffix = ` + ${entry.openTurns.length} turn${entry.openTurns.length === 1 ? '' : 's'} parked (${parts.join(', ')})`;
+      }
       exps.unshift({
         id: genId(),
         title: `Recovery ${todayDateString()} — ${entry.size} · ${mechSummary}`,
         date: todayDateString(),
         observation: `Now → cog ${entry.cog} · emo ${entry.emo} · phy ${entry.phy} (from ${entry.anchorCog}/${entry.anchorEmo}/${entry.anchorPhy}; ${anchorRef}). Withdrawal: cog ${entry.diffCog} · emo ${entry.diffEmo} · phy ${entry.diffPhy} → tier ${entry.tier}, locus ${entry.locus}. Day-shape: ${entry.shapes.join(', ') || '—'}.${entry.note ? ' Note: ' + entry.note : ''}`,
-        impact: `Plan: ${planSnip}${entry.plan.length > 90 ? '…' : ''}`
+        impact: `Plan: ${planSnip}${entry.plan.length > 90 ? '…' : ''}${turnParkingSuffix}`
       });
       setExperiments('recovery-room', exps);
       renderExperiments('recovery-room');
@@ -10819,11 +10996,6 @@
       { kind: 'form',     label: 'Debrief form' },
       { kind: 'chapter',  label: 'Debrief chapter' },
       { kind: 'practice', label: 'Debrief practice' },
-    ],
-    'recovery-room': [
-      { kind: 'form',     label: 'Recover form' },
-      { kind: 'chapter',  label: 'Recover chapter' },
-      { kind: 'practice', label: 'Recover practice' },
     ],
   };
 

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -6599,7 +6599,7 @@
       "priority": "P0",
       "area": "debrief-booth",
       "brief": "Why measurement closes the cycle. After-action-review patterns. Reflection theory.",
-      "full": "Why measurement closes the cycle. After-action-review patterns from military and aviation. Reflection theory (Dewey, Schon). How Debrief feeds the Gauge for the next turn."
+      "full": "Why measurement closes the cycle. After-action-review patterns from military and aviation. Reflection theory (Dewey, Schon). How Debrief grades the turn against its Frame card and queues the next leg."
     },
     "LAB-005": {
       "id": "LAB-005",
@@ -6634,8 +6634,8 @@
       "status": "backlog",
       "priority": "P0",
       "area": "pilot-check-station",
-      "brief": "Why the Gauge alone isn't enough. The three signals. Aviation precedent (IM SAFE + duty-time + cross-check).",
-      "full": "Why the Gauge alone isn't enough (single-signal systems fail under load). The three signals (felt, behavioral, temporal). Aviation precedent: IM SAFE checklist, duty-time rules, cross-checking instruments. The ironies of automation: you need more context when monitoring automated systems (Bainbridge)."
+      "brief": "Why the morning Pilot Check is the rule-out, not the fitness scan. The three signals (felt / behavioral / temporal). Aviation precedent (IM SAFE + duty-time + cross-check).",
+      "full": "Why the Pilot Check is rule-out, not measurement (single-signal capacity reads fail under load; the three-dimension multi-signal model is what keeps you honest at the morning bookend). The three signals (felt, behavioral, temporal). Aviation precedent: IM SAFE checklist, duty-time rules, cross-checking instruments. The ironies of automation: you need more context when monitoring automated systems (Bainbridge)."
     },
     "LAB-009": {
       "id": "LAB-009",

--- a/larry-moleman/LAB_CONTEXT.md
+++ b/larry-moleman/LAB_CONTEXT.md
@@ -82,7 +82,8 @@ Find the area's `"experiments": [` and prepend the new entry. Newest-first order
 
 1. Add to the `items` dictionary at the bottom.
 2. Add the LAB-XXX id to the relevant area's `"items": [...]` array.
-3. Add the LAB-XXX id to Backlog Wall's `"items": [...]` array.
+
+(There is no separate Backlog Wall — the toolbar's Priority view is the cross-area backlog. Items appear there automatically by their `priority` field.)
 
 ### Updating an item's status
 
@@ -100,23 +101,24 @@ Find the area's `"chunks": [` and prepend the new chunk, or update an existing o
 
 ## Areas in the lab (for routing)
 
-| Area ID               | Name                | Workshop? |
-| --------------------- | ------------------- | --------- |
-| `frame-workshop`      | Frame Workshop      | yes       |
-| `comprehend-station`  | Comprehend Station  | no        |
-| `sync-floor`          | Sync Floor          | no        |
-| `push-bay`            | Produce Bay         | no        |
-| `debrief-booth`       | Debrief Booth       | no        |
-| `recovery-room`       | Recovery Room       | no        |
-| `the-gauge`           | The Gauge           | no        |
-| `pilot-check-station` | Pilot Check Station | yes       |
-| `transition-hallway`  | Transition Hallway  | no        |
-| `trim-bench`          | Trim Bench          | no        |
-| `library`             | The Library         | no        |
-| `archive`             | The Archive         | no        |
-| `backlog-wall`        | Backlog Wall        | no        |
-| `deck-theater`        | Deck Theater        | no        |
-| `director-desk`       | Director's Desk     | no        |
+| Area ID               | Name                | Kind        | Workshop? |
+| --------------------- | ------------------- | ----------- | --------- |
+| `pilot-check-station` | Pilot Check Station | ritual      | yes       |
+| `recovery-room`       | Recovery Room       | ritual      | yes       |
+| `comprehend-station`  | Comprehend Station  | phase       | yes       |
+| `frame-workshop`      | Frame Workshop      | phase       | yes       |
+| `sync-floor`          | Sync Floor          | phase       | no        |
+| `push-bay`            | Produce Bay         | phase       | no        |
+| `debrief-booth`       | Debrief Booth       | phase       | yes       |
+| `transition-hallway`  | Transition Hallway  | meta        | no        |
+| `trim-bench`          | Trim Bench          | meta        | no        |
+| `director-desk`       | Director's Desk     | meta        | no        |
+| `library`             | The Library         | holding-pen | no        |
+| `archive`             | The Archive         | holding-pen | no        |
+| `deck-theater`        | Deck Theater        | holding-pen | no        |
+| `strategy`            | Strategy & Plans    | holding-pen | no        |
+
+(The Gauge and Backlog Wall were retired; their content is archived in `cognitive-lab/archive/`.)
 
 This list will grow as more areas become workshops and as new areas are added.
 

--- a/quenton-quince/LAB_CONTEXT.md
+++ b/quenton-quince/LAB_CONTEXT.md
@@ -36,24 +36,24 @@ Then open `http://localhost:8765/cognitive-lab-v0.1.html`.
 
 The lab is a top-down, click-to-explore floor plan with four bands:
 
-**Band 1 — Reference / aux** (gestalt visuals, hover for label):
+**Band 1 — Reference / aux** (Band-1 holding pens, gestalt visuals, hover for label):
 
 - The Library (research)
 - The Archive (lab notes, decisions, shipped)
 - Deck Theater (the v0.2 presentation)
-- Backlog Wall (priority list)
+- Strategy & Plans
 
-**Band 2 — Phase cycle** (six rooms left-to-right):
+**Band 2 — Day-band** (the bookended day; two rituals with a baseline rule between them):
 
-- Frame · Comprehend · Sync · Produce (formerly Push) · Debrief · Recover
+- Pilot Check Station · Recovery Room
 
-**Band 3 — Meta-disciplines:**
+**Band 3 — Turn cycle** (five phases left-to-right, C-before-F):
 
-- Transition Hallway · Trim Bench
+- Comprehend · Frame · Sync · Produce · Debrief
 
-**Band 4 — Bottom (instruments + Director):**
+**Band 4 — Bottom (meta row):**
 
-- Pilot Check Station · Director's Desk
+- Transition Hallway · Trim Bench · Director's Desk
 
 Click any area opens a side drawer (drawer expands to 66vw if the area has `workshop: true`). Drawers contain:
 

--- a/quenton-quince/SYSTEM_PROMPT.md
+++ b/quenton-quince/SYSTEM_PROMPT.md
@@ -8,7 +8,7 @@ A design partner. Not a generalist assistant. Not a yes-machine. Not a literatur
 
 You hold three things in your head simultaneously:
 
-1. **The framework.** The phase structure (Frame · Comprehend · Sync · Push · Debrief · Recover), meta-disciplines (Transition · Trim), the day's structural anchors (Pilot Check opens · Recovery closes), and the central images (the cache-game, the bookended day).
+1. **The framework.** The five-phase turn cycle (Comprehend · Frame · Sync · Produce · Debrief), meta-disciplines (Transition · Trim), the day's structural anchors (Pilot Check opens · Recovery closes), and the central images (the cache-game, the bookended day).
 2. **The lab.** The interactive workshop where the framework is being built. Areas, items, chunks, experiments, sources. Live state.
 3. **The book.** _The 7 Turn Work Week_ in progress, with the chapter material accumulating in the lab's Chapter chunks. Eventually flowing to ghostwriter and Zelda.
 


### PR DESCRIPTION
## Summary

This is PR3 of 3 in the lab restructure sequence. Stacks on PR1 (#139) and PR2 (#140). Closes the 3-PR sequence.

### A. JSON `kind` taxonomy migration

Added top-level `kind` field to each area in the baseline JSON:
- `pilot-check-station`, `recovery-room` → `ritual`
- `frame-workshop`, `comprehend-station`, `sync-floor`, `push-bay`, `debrief-booth` → `phase`
- `transition-hallway`, `trim-bench`, `director-desk` → `meta`

Band-1 storage areas untouched.

### B. Recovery `type` flip

`recovery-room` type changed from `"phase / insertable"` to `"ritual / end-of-day"`. Confirmed no other code branches on the old string.

### C. Delete `PHASE_SLOTS['recovery-room']`

Removed the `recovery-room` entry from the `PHASE_SLOTS` const. Recovery is now a ritual, not a phase slot target. Confirmed no code iterates PHASE_SLOTS expecting this entry.

### D. Floor-plan restructure — four bands

- Band 1: storage rooms — unchanged
- Band 2 (new day-band): Pilot Check · baseline rule · Recovery
- Band 3 (was Band 2): turn cycle — Comprehend → Frame → Sync → Produce → Debrief (five tiles, four arrows; Recovery removed)
- Band 4 (was Bands 3+4 merged): Transition · Trim · Director's Desk

Added `.band-day` and `.band-rule` CSS classes for the day-band layout.

### E. Open-turn parking in Recovery Room workshop drawer

Added "Open turns at lock" section to Step 3 of the Recovery workshop. Populated from all legs not yet debriefed or archived. Each row renders the leg id, title (from Frame card's `in` field), three radio actions (carry / drop / defer), and an optional note input. Only rows with an action selected persist to the `openTurns[]` array on the recovery entry. Log shelf entry summary extended to include turn parking count when non-empty.

## Stack

- PR1 (#139): heartbeat retirement
- PR2 (#140): Pilot Check consolidation
- PR3 (this): day-band + kind taxonomy + open-turn parking — closes the sequence

## Test plan

- [ ] Open lab. Confirm four bands render top-to-bottom: storage / day-band / turn-cycle / bottom
- [ ] Day-band shows Pilot Check left, baseline rule, Recovery right
- [ ] Turn-cycle row has exactly five tiles (Comprehend → Frame → Sync → Produce → Debrief) with four arrows
- [ ] Bottom row has Transition · Trim · Director's Desk
- [ ] Click Pilot Check — opens workshop
- [ ] Click Recovery — opens workshop with "Open turns at lock" section visible at bottom of Step 3
- [ ] With no open legs: section shows "No open turns to park."
- [ ] Lock plan with no open-turn actions selected — saves normally
- [ ] Lock plan with at least one action selected — `openTurns[]` writes to localStorage; Log entry mentions parking count
- [ ] `grep -n '"kind":' cognitive-lab/cognitive-lab-v0.1.html | head -20` — all ten areas present with correct values
- [ ] `grep -n '"phase / insertable"' cognitive-lab/cognitive-lab-v0.1.html` — zero hits
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)