### PR TITLE
Land PR1/PR2/PR3 stack to main (heartbeat retirement + Pilot Check consolidation + day-band)

### DIFF
--- a/cognitive-lab/DECISIONS.md
+++ b/cognitive-lab/DECISIONS.md
@@ -255,7 +255,7 @@ Click-to-place over drag-and-drop is a deliberate scope constraint, not a compro
 
 **Reasoning.** Earlier the cache-game was treated as Frame-only. The heartbeat insight (capacity check → restoration plan, in continuous cycle) named the meta-rhythm that makes every phase work. Both images compose: cache-game designs the day; heartbeat keeps you alive playing it.
 
-**Status.** Active. To propagate into chapter material as the framework's central images.
+**Status.** **Superseded 2026-05-11** — the heartbeat metaphor was retired in favor of "the bookended day" as the framework's second central image. See the 2026-05-11 entry at the top of this file.
 
 **References.** Captured in `cognitive-lab/PROCESS.md`. Cache-game origin: Jess's adventure-caching race story.
 
@@ -267,9 +267,9 @@ Click-to-place over drag-and-drop is a deliberate scope constraint, not a compro
 
 **Reasoning.** The PoC has features the Pilot Check doesn't (morning-after test, withdrawal/replenishment bank, color verdict, history). The Pilot Check has features the PoC doesn't (three-dimension breakdown, rule-out threshold, targeted prescription). Each is half-built. Together they're the complete instrument. The author named the convergence; coexistence as separate tools would be the duplication trap.
 
-**Status.** Architecture decided; merger queued as **LAB-025** (Make the Gauge a workshop, embed capacity check-in). Work is post-current-period.
+**Status.** **Superseded 2026-05-11** — the Gauge area was retired entirely; the merger path described here is the path *not* taken. Pilot Check absorbed the capacity-read role; the standalone capacity check-in instrument was retired with the Gauge. LAB-025 (the merger queue item) was deleted in the heartbeat-retirement PR. See the 2026-05-11 entry at the top of this file.
 
-**References.** `cognitive-lab/cognitive-lab-v0.1.html` (item LAB-025), `larry-moleman/PLAYS.md` (Merge-Duplicate-Tools play).
+**References.** Originally tracked as LAB-025 (now deleted). `larry-moleman/PLAYS.md` (Merge-Duplicate-Tools play).
 
 ---
 

--- a/cognitive-lab/DECISIONS.md
+++ b/cognitive-lab/DECISIONS.md
@@ -6,6 +6,18 @@ Entries are reverse-chronological (newest first). Each has: date, decision, reas
 
 ---
 
+## 2026-05-11 · Heartbeat retired; Gauge area deleted; second central image becomes "the bookended day"
+
+**Decision.** The Gauge as a free-standing area and the heartbeat as the framework's second central image are both retired. Capacity management is reframed as an *outside loop* — Pilot Check opens the day, Recovery closes it, the turn cycle runs in the protected middle — rather than as an *inside beat* pulsing between every phase. The framework's two central images are now the cache-game (how the day's game is designed) and the bookended day (how the day is held).
+
+**Reasoning.** Continuous-read capacity instrumentation isn't shippable in the 8-week window; bookended discrete checks (morning Pilot Check + evening Recovery) are sufficient. Keeping the heartbeat as a load-bearing image while the underlying instrument is retired would create vocabulary debt. Cleaner to retire both and re-name the second central image around what's actually implemented.
+
+**Status.** Active. Hourly capacity feedback is parked as a future possibility; if it lands, the heartbeat may return as a name for that specific pattern.
+
+**References.** PR (this branch). `cognitive-lab/archive/heartbeat-retirement-2026-05-11.md` for the archived content. Quenton's design memo lives in the conversation history (Claude session 2026-05-11).
+
+---
+
 ## 2026-05-04 (later) · Move 2 (Comprehension Station arc) — orientation workshop, Walk Studio, C-before-F, iframe pattern, LAB-009 status
 
 **Decision.** Five sub-phases shipped in the Move 2 arc (branch `danversfleury/lab-course-tier`, 11 commits since the v0.4 session-close):

--- a/cognitive-lab/PROCESS.md
+++ b/cognitive-lab/PROCESS.md
@@ -89,15 +89,11 @@ Originated from Jess's adventure-caching race story. Frame is the *game-design* 
 
 Three end-states: collected enough → finish line; tired/hurt with what you got → head home early; time runs out → buzzer. These map to End's three triggers (Done means delivered, capacity floor, bingo time).
 
-### The heartbeat
+### The bookended day
 
-The give-and-take rhythm of capacity check ↔ restoration. The Gauge reads, the result dispatches: cleared (continue) or grounded (insert recovery, re-read). This rhythm runs continuously throughout the day, between every phase.
+The day has two fixed posts: a Pilot Check at the start and a Recovery ritual at the end. Between them the turn cycle runs as many times as capacity allows. The bookends aren't optional and they aren't symmetric — the morning check rules out the dimensions that would make the day unsafe to begin; the evening recovery closes the loops the day opened so they don't bleed into tomorrow. Everything in between (Comprehend → Frame → Sync → Produce → Debrief, with Transition and Trim available throughout) inherits its license to run from the morning check and its right to end from the evening recovery.
 
-Without the heartbeat, the framework is just phases without honoring capacity. With it, every boundary is gated by capacity and every grounded reading dispatches targeted recovery.
-
-The Pilot Check is the explicit pre-flight version of the heartbeat (rule-out across cognitive / emotional / physical, dispatching recovery hours per red dimension). The Gauge is the continuous instrument the heartbeat runs on.
-
-**Together:** The cache-game is *how the day's game is designed* (Frame's metaphor). The heartbeat is *how the day's rhythm cycles* (the Gauge↔Recovery meta-rhythm). They compose; neither alone is the whole framework.
+**Together:** The cache-game is *how the day's game is designed* (Frame's metaphor). The bookended day is *how the day is held* — opened deliberately, closed deliberately, with the cycle living in the protected middle.
 
 ---
 

--- a/cognitive-lab/SESSION_PROMPTS.md
+++ b/cognitive-lab/SESSION_PROMPTS.md
@@ -2,7 +2,7 @@
 
 How to start (and close) a session in the cognitive lab. Sibling to `PROCESS.md` (how the lab works) and `DECISIONS.md` (what's been decided).
 
-Last meaningful update: 2026-05-02. Update this file when:
+Last meaningful update: 2026-05-11 (Heartbeat retirement, Gauge area deleted, day-band architecture). Update this file when:
 
 - The state-of-play summary in the long form goes stale
 - The current "urgent priority" example shifts

--- a/cognitive-lab/SESSION_PROMPTS.md
+++ b/cognitive-lab/SESSION_PROMPTS.md
@@ -39,7 +39,7 @@ Orient by reading:
   daily/weekly rhythm)
 - quenton-quince/PLAYS.md and PRINCIPLES.md (your playbook + heuristics)
 - The Log tile (experiments array) of frame-workshop, pilot-check-station,
-  debrief-booth, the-gauge, transition-hallway in
+  debrief-booth, transition-hallway in
   cognitive-lab/cognitive-lab-v0.1.html
 
 State of play (update this section as the framework evolves):
@@ -51,11 +51,9 @@ State of play (update this section as the framework evolves):
   grounded). LAB-007 (form refinement) and LAB-008 (chapter) still
   in-progress.
 - Two central images: cache-game (Frame's organizing metaphor) and
-  heartbeat (Gauge↔Recovery rhythm).
-- Capacity check-in PoC and Pilot Check converge into a unified Gauge
-  instrument. Two related backlog items: LAB-025 (Make the Gauge a
-  workshop, embed capacity check-in) and LAB-021 (Capacity check-in
-  v0.2, turn-aware data model). Both P1.
+  bookended day (Pilot Check opens the day, Recovery closes it).
+- The Gauge area was retired 2026-05-11; Pilot Check Station is the
+  pre-flight instrument. LAB-020/021/025/030 archived with the Gauge.
 - Quenton (you) and Larry Moleman are project-resident agents (PR #123).
 - grepzilla2 covers cognitive-lab/ now (PR #126); use for markdown-heavy
   PRs that Devin skips.

--- a/cognitive-lab/archive/heartbeat-retirement-2026-05-11.md
+++ b/cognitive-lab/archive/heartbeat-retirement-2026-05-11.md
@@ -1,0 +1,145 @@
+# Heartbeat retirement — 2026-05-11
+
+## Rationale
+
+Heartbeat retired in favor of "the bookended day" as the second central image; the rhythm got absorbed into Pilot Check + Recovery as concrete instruments rather than a metaphor about them.
+
+## Archived content
+
+### Deleted area: the-gauge
+
+```json
+    {
+      "id": "the-gauge",
+      "name": "The Gauge",
+      "type": "gauge / telemetry",
+      "accent": "dark",
+      "description": "The capacity instrument. Read at every boundary. Gates the day's mode. The continuous read-and-dispatch cycle (capacity ↔ restoration) is the framework's heartbeat.",
+      "items": ["LAB-020","LAB-021","LAB-025","LAB-030"],
+      "sources": [
+        { "label": "Capacity Check-In (the live instrument)", "href": "capacity-checkin.html" },
+        { "label": "turn-v0.1-map.html (slides 11 + 17, multi-signal model)", "href": "turn-v0.1-map.html" },
+        { "label": "PROCESS.md (heartbeat as one of two central images)", "href": "PROCESS.md" }
+      ],
+      "experiments": [
+        {
+          "id": "exp-gauge-2026-05-02-heartbeat-named",
+          "title": "Heartbeat named as second central image",
+          "date": "2026-05-02 (afternoon)",
+          "observation": "The give-and-take of capacity check ↔ restoration plan was named as the framework's meta-rhythm. Not just a phase — the rhythm that makes every phase work. Capacity reading dispatches: cleared (continue) or grounded (insert recovery, re-read). The cycle runs continuously, between every phase, across days.",
+          "impact": "Now treated as one of two central images for the framework, alongside the cache-game (Frame's organizing metaphor). The cache-game designs the day; the heartbeat keeps you alive playing it. Captured as a chunk on this area; queued for integration into the deck (LAB-030)."
+        },
+        {
+          "id": "exp-gauge-2026-05-02-merger-architecture",
+          "title": "Capacity check-in + Pilot Check converge into unified Gauge",
+          "date": "2026-05-02 (morning)",
+          "observation": "The capacity check-in PoC and the Pilot Check Station are different views of the same instrument. Each is half-built; together they're the complete instrument. The PoC has felt-sense + bank metaphor + morning-after; the Pilot Check has three-dimension rule-out + targeted prescription. Naming them as separate areas was creating duplication.",
+          "impact": "Architecture decided: merger queued as LAB-025 (Make the Gauge a workshop, embed capacity check-in). Pilot Check Station may dissolve into a use-pattern of the Gauge after the merger."
+        }
+      ],
+      "chunks": [
+        {
+          "id": "chunk-hash-house-gauge-pilot-check",
+          "title": "Hash house = Pilot Check visit (refuel, re-orient, decide)",
+          "summary": "The lab's heartbeat IS the hash house. Pilot Check = hash-house visit: refuel, re-orient, decide whether to continue. A tightening of an existing instrument, not a new one.",
+          "body": "In rogaining, the **hash house** is the central base camp. Racers return there to refuel, check time, re-orient, and decide whether to continue the current route or revise. Elite racers treat each hash-house visit as a decision point, not just a rest stop: they assess their capacity against remaining time and course, then commit or pivot.\n\nThe lab's Pilot Check is the hash house visit. The parallels are direct:\n\n- **Refuel** → capacity read (Cognitive / Emotional / Physical sliders).\n- **Re-orient** → Gauge dispatch (cleared or grounded) + diagnosis of which dimension is red.\n- **Decide whether to continue** → Full Turn vs. Partial Turn vs. Recovery insertion.\n\nThis framing tightens an instrument that already exists — it doesn't add a new one. The Gauge is the continuous instrument (between every phase); the Pilot Check is the explicit pre-leg hash-house visit (before a Full Turn starts).\n\nPractical implication: the Pilot Check form can be framed to the author as 'you're at the hash house — what's your read?' rather than 'complete this checklist.' The framing change may improve compliance on sessions where the operator is inclined to skip the check. The hash-house visit is non-optional in rogaining; that normative weight transfers.\n\nThe Debrief's 'Capacity + next' field closes the loop: post-leg gauge read = leaving the hash house for the next leg.\n\nCross-ref: chunk-gauge-heartbeat (The Gauge) — the heartbeat is the continuous rhythm; the hash house is the explicit check-in point within that rhythm."
+        },
+        {
+          "id": "chunk-gauge-heartbeat",
+          "title": "The heartbeat — capacity ↔ restoration as meta-rhythm",
+          "summary": "The continuous Gauge-read-and-dispatch cycle is the framework's beating rhythm. Without it, the framework is just phases without honoring capacity.",
+          "body": "The framework has two central images. The cache-game (Jess's contribution) names how the day's game gets designed — Frame as the game-design moment. The heartbeat names how the day's rhythm cycles.\n\nThe heartbeat: capacity check → action plan → capacity check → action plan. The Gauge reads, the result dispatches: cleared (continue with the planned phase) or grounded (insert recovery, re-read). The cycle runs continuously throughout the day, between every phase, across days.\n\nWith the heartbeat, every phase boundary is gated by capacity and every grounded reading dispatches a targeted recovery. Without it, the cycle just runs through phases regardless of state — and the framework collapses into ritual.\n\nThe Pilot Check is the explicit pre-flight version of the heartbeat (rule-out across cognitive / emotional / physical, dispatching recovery hours per red dimension). The Gauge is the continuous instrument the heartbeat runs on.\n\nThe two images compose. The cache-game is *how the day's game is designed.* The heartbeat is *how the day's rhythm cycles.* Neither alone is the framework; together they make the practice live."
+        }
+      ],
+      "notes": [
+        "The capacity check-in is the felt-sense layer of the Gauge. It's been doing real recovery-planning work and is the seed the Gauge grows from.",
+        "2026-04-30 — The morning gauge worked (recovery turnaround)."
+      ]
+    }
+```
+
+### Deleted LAB items
+
+```json
+    "LAB-020": {
+      "id": "LAB-020",
+      "title": "Per-turn gauge entries (vs only per-day)",
+      "status": "backlog",
+      "priority": "P1",
+      "area": "the-gauge",
+      "brief": "Upgrade the gauge to record a reading at the start of each turn, not just daily.",
+      "full": "Upgrade the gauge to record a reading at the start of each turn, not just once per day. This feeds the multi-signal model and enables intra-day capacity tracking."
+    },
+    "LAB-021": {
+      "id": "LAB-021",
+      "title": "Capacity check-in v0.2 (turn-aware data model)",
+      "status": "backlog",
+      "priority": "P1",
+      "area": "the-gauge",
+      "brief": "Rebuild the check-in PoC with a turn-aware data model.",
+      "full": "Rebuild the capacity check-in PoC with a turn-aware data model. Each record tagged with turn ID, time-of-day, and which phase triggered the check-in. Enables correlation analysis between gauge readings and turn outcomes."
+    },
+    "LAB-025": {
+      "id": "LAB-025",
+      "title": "Make the Gauge a workshop (embed capacity check-in)",
+      "status": "backlog",
+      "priority": "P1",
+      "area": "the-gauge",
+      "brief": "Promote the Gauge from a regular area to a workshop, with the capacity check-in PoC embedded as the instrument view.",
+      "full": "Same workshop pattern as Frame. Top half of drawer = the live instrument (capacity check-in PoC, embedded as iframe or directly merged), bottom half = the floor view (items, artifacts, notes, recent gauge readings as cards). Eventually adds the multi-signal layers (behavioral, temporal) on top of the felt-sense PoC. Architecturally, makes the PoC's daily ritual a first-class part of the lab rather than a side artifact."
+    },
+    "LAB-030": {
+      "id": "LAB-030",
+      "title": "Integrate the heartbeat into the deck",
+      "status": "backlog",
+      "priority": "P1",
+      "area": "the-gauge",
+      "brief": "Update deck slides to surface the heartbeat as the framework's second central image alongside the cache-game.",
+      "full": "The framework now has two named central images. The cache-game is well-represented in the deck (Frame batches with subtitles tied to the metaphor). The heartbeat (capacity ↔ restoration as continuous meta-rhythm) is not yet in the deck. Update slides 11 and 17–18 (Gauge and multi-signal model) to name the heartbeat explicitly. Possibly add a slide that pairs the two images. Coordinates with chunk-gauge-heartbeat in the-gauge area."
+    }
+```
+
+### Deleted heartbeat prose from LAB_CONTEXT.md
+
+The heartbeat section was in `quenton-quince/LAB_CONTEXT.md` (lines 90–95) and `cognitive-lab/PROCESS.md` (lines 92–100). The `cognitive-lab/LAB_CONTEXT.md` file did not exist at the time of this retirement — the DECISIONS.md entry references the path the brief specified; see PR1 git log for context.
+
+**From `quenton-quince/LAB_CONTEXT.md` (lines 90–95):**
+
+```
+### The heartbeat
+
+The give-and-take rhythm of capacity check ↔ restoration. The Gauge reads, the result dispatches: cleared (continue) or grounded (insert recovery, re-read). This rhythm runs continuously, between phases, across days. Without the heartbeat, the framework is just phases without honoring capacity. With it, every boundary is gated and every grounded reading dispatches targeted recovery.
+
+The Pilot Check is the explicit pre-flight version of the heartbeat (rule-out across cognitive / emotional / physical, dispatching recovery hours per red dimension). The Gauge is the continuous instrument the heartbeat runs on.
+```
+
+### Deleted heartbeat block from PROCESS.md
+
+**From `cognitive-lab/PROCESS.md` (lines 92–100):**
+
+```
+### The heartbeat
+
+The give-and-take rhythm of capacity check ↔ restoration. The Gauge reads, the result dispatches: cleared (continue) or grounded (insert recovery, re-read). This rhythm runs continuously throughout the day, between every phase.
+
+Without the heartbeat, the framework is just phases without honoring capacity. With it, every boundary is gated by capacity and every grounded reading dispatches targeted recovery.
+
+The Pilot Check is the explicit pre-flight version of the heartbeat (rule-out across cognitive / emotional / physical, dispatching recovery hours per red dimension). The Gauge is the continuous instrument the heartbeat runs on.
+
+**Together:** The cache-game is *how the day's game is designed* (Frame's metaphor). The heartbeat is *how the day's rhythm cycles* (the Gauge↔Recovery meta-rhythm). They compose; neither alone is the whole framework.
+```
+
+### Deleted chunk: chunk-gauge-heartbeat
+
+```
+{
+  "id": "chunk-gauge-heartbeat",
+  "title": "The heartbeat — capacity ↔ restoration as meta-rhythm",
+  "summary": "The continuous Gauge-read-and-dispatch cycle is the framework's beating rhythm. Without it, the framework is just phases without honoring capacity.",
+  "body": "The framework has two central images. The cache-game (Jess's contribution) names how the day's game gets designed — Frame as the game-design moment. The heartbeat names how the day's rhythm cycles.\n\nThe heartbeat: capacity check → action plan → capacity check → action plan. The Gauge reads, the result dispatches: cleared (continue with the planned phase) or grounded (insert recovery, re-read). The cycle runs continuously throughout the day, between every phase, across days.\n\nWith the heartbeat, every phase boundary is gated by capacity and every grounded reading dispatches a targeted recovery. Without it, the cycle just runs through phases regardless of state — and the framework collapses into ritual.\n\nThe Pilot Check is the explicit pre-flight version of the heartbeat (rule-out across cognitive / emotional / physical, dispatching recovery hours per red dimension). The Gauge is the continuous instrument the heartbeat runs on.\n\nThe two images compose. The cache-game is *how the day's game is designed.* The heartbeat is *how the day's rhythm cycles.* Neither alone is the framework; together they make the practice live."
+}
+```
+
+## See also
+
+PR1 in `git log`. DECISIONS.md entry 2026-05-11.

--- a/cognitive-lab/cognitive-lab-spec.md
+++ b/cognitive-lab/cognitive-lab-spec.md
@@ -75,6 +75,14 @@ spatial / game-y vibe without the canvas complexity.
 
 ## Layout (20 cols × 14 rows on a tile grid)
 
+> **Note (as of 2026-05-11):** the layout below describes the *original* v0.1 build spec. The current floor is post-PR3:
+> - Band 1: storage rooms — Library · Daily Journal · Deck Theater · Strategy & Plans
+> - Band 2 (new **day-band**): Pilot Check Station · (baseline rule) · Recovery Room — both `kind: ritual`
+> - Band 3 (turn cycle, five tiles, C-before-F): Comprehend · Frame · Sync · Produce · Debrief — all `kind: phase`
+> - Band 4 (meta row): Transition Hallway · Trim Bench · Director's Desk — all `kind: meta`
+>
+> The Gauge area and the Backlog Wall were retired (see `archive/heartbeat-retirement-2026-05-11.md` and Lab v0.5 entries in `DECISIONS.md`). The original layout diagram below is preserved as build history.
+
 The lab has four bands top-to-bottom:
 
 ```

--- a/cognitive-lab/cognitive-lab-spec.md
+++ b/cognitive-lab/cognitive-lab-spec.md
@@ -164,7 +164,7 @@ a click target. Click → drawer.
 - Type: gauge / telemetry
 - Color: dark `#2d3142` with orange accent
 - Description: "The capacity instrument. Read at every boundary. Gates the day's mode."
-- Items: LAB-020, LAB-021
+- Items: (none — area retired, see archive/heartbeat-retirement-2026-05-11.md)
 - Artifacts:
   - existing capacity-checkin PoC (note: not in this folder yet — exists in user's other workspace)
   - `.context/turn-v0.1-map.html` (deck slide 11 + slide 17, multi-signal model)
@@ -334,8 +334,6 @@ a click target. Click → drawer.
   Selection heuristics. Fast-no protocols. (Lower priority once Frame works.)
 - **LAB-018** Trim chapter — `backlog` — trim-bench
 - **LAB-019** Run 1 week of formal Frame and capture lab notes — `backlog` — frame-workshop / archive
-- **LAB-020** Per-turn gauge entries (vs only per-day) — `backlog` — the-gauge
-- **LAB-021** Capacity check-in v0.2 (turn-aware data model) — `backlog` — the-gauge
 
 ### P2 — later
 

--- a/cognitive-lab/cognitive-lab-spec.md
+++ b/cognitive-lab/cognitive-lab-spec.md
@@ -160,15 +160,8 @@ a click target. Click → drawer.
 
 ### Center / always-visible
 
-#### `the-gauge` — The Gauge
-- Type: gauge / telemetry
-- Color: dark `#2d3142` with orange accent
-- Description: "The capacity instrument. Read at every boundary. Gates the day's mode."
-- Items: (none — area retired, see archive/heartbeat-retirement-2026-05-11.md)
-- Artifacts:
-  - existing capacity-checkin PoC (note: not in this folder yet — exists in user's other workspace)
-  - `.context/turn-v0.1-map.html` (deck slide 11 + slide 17, multi-signal model)
-- Decoration: monitor / dashboard motif
+#### `the-gauge` — The Gauge (retired 2026-05-11)
+- Status: **area retired**; capacity-read role absorbed into Pilot Check (morning) and Recovery Room (evening). See `archive/heartbeat-retirement-2026-05-11.md` for the deleted area JSON, items, and design rationale.
 
 #### `director-desk` — Director's Desk (you)
 - Type: aux / persistent

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -9835,7 +9835,7 @@
           narrative: '**Welcome to the Comprehend Station tour.**\n\nThis walk is the meta-loop on purpose: you\'re using Comprehend Station to learn about Comprehend Station. The right pane is a live lab booted to the **Floor view**.\n\n**No state will be modified** — every step is read-only. Click around freely.\n\nClick **Next** to begin.'
         },
         {
-          narrative: '**The Floor.**\n\nLook at the right pane. The middle band shows the leg phases left-to-right: **Comprehend** · Frame · Sync · Produce · Debrief · Recover.\n\n**Comprehend is first** (C-before-F floor reorder, shipped today). The reasoning: orientation precedes commitment. You can\'t pick a Frame intelligently without first re-immersing in where you are.\n\nClick **Next**.'
+          narrative: '**The Floor.**\n\nLook at the right pane. The turn-cycle band shows the five turn phases left-to-right: **Comprehend** · Frame · Sync · Produce · Debrief.\n\n**Comprehend is first** (C-before-F floor reorder). The reasoning: orientation precedes commitment. You can\'t pick a Frame intelligently without first re-immersing in where you are.\n\nThe band *above* the turn cycle is the day-band: **Pilot Check** opens the day, **Recovery** closes it. Recovery is a ritual, not a phase.\n\nClick **Next**.'
         },
         {
           narrative: '**Click the Comprehend area** in the right pane (the 🛠️ tile labeled "Comprehend · orient first"). The Comprehend Station drawer will open.\n\nThis is the workshop you\'re standing in right now (but rendered inside its own iframe inside itself — that\'s the recursion you noticed).\n\nClick **Next** once the drawer is open.'
@@ -9887,7 +9887,7 @@
       title: 'Turn v0.1 Map',
       kind: 'deck',
       subtitle: '21 slides · 4 acts · beginner-facing',
-      preview: 'The original turn-architecture deck. Frame · Comprehend · Sync · Produce · Debrief · Recover, with the two meta-disciplines (Trim · Transition).',
+      preview: 'The original turn-architecture deck. Five-phase turn cycle (Frame · Comprehend · Sync · Produce · Debrief) plus the day-band rituals (Pilot Check · Recovery) and meta-disciplines (Trim · Transition).',
       deck_href: 'turn-v0.1-map.html'
     }
   ];
@@ -10968,7 +10968,9 @@
                 + auto-detected from unresolved LAB-### refs).
      ────────────────────────────────────────────────────────────── */
 
-  // Each phase area declares the canonical slots it expects.
+  // Each turn-cycle phase area declares the canonical slots it expects.
+  // Ritual and meta areas have no declared slots (they're not on the
+  // form / chapter / practice scaffold).
   // A slot is "fulfilled" if the area has any item whose title
   // contains the slot kind word (case-insensitive, word boundary).
   const PHASE_SLOTS = {

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -3688,6 +3688,270 @@
   #pc-recent-list .ws-recent-card.cleared { border-left-color: var(--success); }
   #pc-recent-list .ws-recent-card.grounded { border-left-color: var(--danger); }
 
+  /* ── Recovery Room Workshop ── three-screen flow: measure / shape / plan */
+  .rec-stepper {
+    display: flex;
+    gap: 6px;
+    margin-bottom: 14px;
+    font-family: var(--font-px);
+    font-size: 10px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+  }
+  .rec-stepper-item {
+    flex: 1;
+    padding: 6px 8px;
+    background: rgba(0,0,0,0.18);
+    border: 1px solid var(--panel-bd);
+    border-radius: 4px;
+    color: var(--faint);
+    text-align: center;
+    line-height: 1.3;
+  }
+  .rec-stepper-item .rec-stepper-num { display: block; font-size: 14px; color: var(--accent-dim); }
+  .rec-stepper-item.active { background: rgba(77,170,87,0.10); border-color: var(--success); color: var(--fg); }
+  .rec-stepper-item.active .rec-stepper-num { color: var(--success); }
+  .rec-stepper-item.done { color: var(--accent-dim); }
+  .rec-stepper-item.done .rec-stepper-num::before { content: "✓ "; }
+
+  .rec-step { display: none; }
+  .rec-step.active { display: block; }
+
+  .rec-help {
+    font-size: 12px;
+    color: var(--accent-dim);
+    line-height: 1.5;
+    margin-bottom: 12px;
+    padding: 8px 12px;
+    background: rgba(0,0,0,0.18);
+    border-left: 2px solid var(--success);
+    border-radius: 4px;
+  }
+  .rec-help strong { color: var(--fg); }
+
+  .rec-anchor {
+    font-size: 10.5px;
+    color: var(--faint);
+    font-style: italic;
+    padding: 2px 2px 0;
+    line-height: 1.4;
+  }
+  .rec-anchor.yoked { color: var(--accent-dim); font-style: normal; }
+  .rec-anchor .rec-anchor-delta {
+    font-family: var(--font-px);
+    font-style: normal;
+    margin-left: 6px;
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 9.5px;
+    letter-spacing: 0.5px;
+  }
+  .rec-anchor .rec-anchor-delta.down { background: rgba(196,77,77,0.18); color: var(--danger); }
+  .rec-anchor .rec-anchor-delta.flat { background: rgba(0,0,0,0.30); color: var(--faint); }
+  .rec-anchor .rec-anchor-delta.up   { background: rgba(77,170,87,0.18); color: var(--success); }
+
+  .rec-tier-readout {
+    display: flex; justify-content: space-between; align-items: center;
+    gap: 12px;
+    margin-top: 12px;
+    padding: 10px 14px;
+    background: rgba(0,0,0,0.22);
+    border: 1px solid var(--panel-bd);
+    border-radius: 6px;
+    font-size: 12px;
+    color: var(--accent-dim);
+  }
+  .rec-tier-readout strong { color: var(--fg); }
+  .rec-tier-readout .rec-tier-tag {
+    font-family: var(--font-px);
+    font-size: 11px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    padding: 3px 8px;
+    border-radius: 3px;
+    background: rgba(77,170,87,0.12);
+    color: var(--success);
+    border: 1px solid var(--success);
+  }
+  .rec-tier-readout .rec-tier-tag.light  { background: rgba(77,170,87,0.10); color: var(--success); border-color: var(--success); }
+  .rec-tier-readout .rec-tier-tag.medium { background: rgba(212,175,55,0.10); color: var(--warning); border-color: var(--warning); }
+  .rec-tier-readout .rec-tier-tag.large  { background: rgba(196,77,77,0.10); color: var(--danger); border-color: var(--danger); }
+  .rec-tier-readout .rec-tier-tag.heavy  { background: rgba(196,77,77,0.18); color: var(--danger); border-color: var(--danger); font-weight: bold; }
+
+  .rec-chip-row {
+    display: flex; flex-wrap: wrap; gap: 6px;
+    margin-bottom: 10px;
+  }
+  .rec-chip {
+    padding: 6px 12px;
+    border: 1px solid var(--panel-bd);
+    background: rgba(0,0,0,0.18);
+    color: var(--accent-dim);
+    border-radius: 14px;
+    cursor: pointer;
+    font-size: 12px;
+    font-family: inherit;
+    transition: background 0.1s, border-color 0.1s, color 0.1s;
+  }
+  .rec-chip:hover { color: var(--fg); border-color: var(--accent-dim); }
+  .rec-chip.selected {
+    background: rgba(77,170,87,0.18);
+    border-color: var(--success);
+    color: var(--fg);
+  }
+  .rec-chip.disabled { opacity: 0.4; cursor: not-allowed; }
+
+  .rec-note-input {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 8px 10px;
+    background: rgba(0,0,0,0.22);
+    border: 1px solid var(--panel-bd);
+    border-radius: 4px;
+    color: var(--fg);
+    font-family: inherit;
+    font-size: 12px;
+    margin-bottom: 10px;
+  }
+  .rec-note-input:focus { outline: none; border-color: var(--accent-dim); }
+
+  .rec-mech-cards { display: flex; flex-direction: column; gap: 8px; margin-top: 8px; }
+  .rec-mech-card {
+    padding: 10px 14px;
+    border-radius: 6px;
+    border: 1px solid var(--success);
+    background: rgba(77,170,87,0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  .rec-mech-card .rec-mech-name {
+    font-family: var(--font-px);
+    font-size: 13px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    color: var(--success);
+    font-weight: bold;
+  }
+  .rec-mech-card .rec-mech-why {
+    font-size: 12px;
+    color: var(--fg);
+    line-height: 1.5;
+  }
+  .rec-mech-card .rec-mech-rule {
+    font-size: 11px;
+    color: var(--accent-dim);
+    font-style: italic;
+  }
+  .rec-mech-card.warn {
+    border-color: var(--warning);
+    background: rgba(212,175,55,0.10);
+  }
+  .rec-mech-card.warn .rec-mech-name { color: var(--warning); }
+
+  .rec-empty-msg {
+    padding: 14px;
+    color: var(--accent-dim);
+    text-align: center;
+    font-size: 13px;
+    line-height: 1.5;
+    background: rgba(0,0,0,0.18);
+    border: 1px dashed var(--panel-bd);
+    border-radius: 6px;
+  }
+
+  .rec-size-row {
+    display: flex;
+    gap: 6px;
+    margin-bottom: 14px;
+  }
+  .rec-size-btn {
+    flex: 1;
+    padding: 8px 10px;
+    background: rgba(0,0,0,0.18);
+    border: 1px solid var(--panel-bd);
+    color: var(--accent-dim);
+    border-radius: 4px;
+    cursor: pointer;
+    font-family: var(--font-px);
+    font-size: 11px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    transition: background 0.1s, border-color 0.1s, color 0.1s;
+  }
+  .rec-size-btn:hover { color: var(--fg); }
+  .rec-size-btn.selected {
+    background: rgba(77,170,87,0.18);
+    border-color: var(--success);
+    color: var(--success);
+  }
+
+  .rec-section-label {
+    font-family: var(--font-px);
+    font-size: 11px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    color: var(--accent-dim);
+    margin: 14px 0 6px;
+  }
+
+  .rec-plan-textarea {
+    width: 100%;
+    box-sizing: border-box;
+    min-height: 90px;
+    padding: 10px;
+    background: rgba(0,0,0,0.22);
+    border: 1px solid var(--panel-bd);
+    border-radius: 4px;
+    color: var(--fg);
+    font-family: inherit;
+    font-size: 13px;
+    line-height: 1.5;
+    resize: vertical;
+  }
+  .rec-plan-textarea:focus { outline: none; border-color: var(--accent-dim); }
+
+  .rec-nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 16px;
+    gap: 8px;
+  }
+  .rec-nav .ff-saved { margin-left: 0; }
+
+  .rec-footer-legend {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 6px;
+    margin-top: 18px;
+    padding: 10px;
+    background: rgba(0,0,0,0.22);
+    border: 1px solid var(--panel-bd);
+    border-radius: 6px;
+    font-size: 10.5px;
+    line-height: 1.4;
+  }
+  .rec-footer-legend .rec-leg-item { display: flex; flex-direction: column; gap: 2px; }
+  .rec-footer-legend .rec-leg-name {
+    font-family: var(--font-px);
+    font-size: 10px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    color: var(--success);
+    font-weight: bold;
+  }
+  .rec-footer-legend .rec-leg-desc { color: var(--accent-dim); }
+
+  @media (max-width: 640px) {
+    .rec-footer-legend { grid-template-columns: repeat(2, 1fr); }
+    .rec-size-row { flex-wrap: wrap; }
+    .rec-size-btn { min-width: calc(50% - 3px); }
+  }
+
+  /* Recent recovery list (reuses ws-recent-card style) */
+  #rec-recent-list .ws-recent-card { border-left-color: var(--success); }
+
   /* ── Course Header bar (renders active leg + course at the top of every workshop drawer) ──
      Single-line glanceable strip. Quenton's "iconic skin" call: leg-number is a
      7-segment LED bar (book title: The 7 Turn Work Week) — current leg lit,
@@ -5122,6 +5386,149 @@
         </div>
       </div>
 
+      <!-- RECOVERY ROOM — three-screen flow: measure / shape / plan. Always-visible mechanism legend footer. -->
+      <div id="ws-recovery-content" style="display:none">
+
+        <!-- Stepper -->
+        <div class="rec-stepper" id="rec-stepper">
+          <div class="rec-stepper-item active" data-step="1"><span class="rec-stepper-num">1</span>Measure the need</div>
+          <div class="rec-stepper-item" data-step="2"><span class="rec-stepper-num">2</span>Shape the recovery</div>
+          <div class="rec-stepper-item" data-step="3"><span class="rec-stepper-num">3</span>Plan it</div>
+        </div>
+
+        <!-- STEP 1 — Depth & locus of need -->
+        <div class="rec-step active" id="rec-step-1">
+          <div class="workshop-section">
+            <div class="workshop-section-label">
+              Step 1 · Where are you now?
+              <span class="ws-date" id="rec-date"></span>
+            </div>
+            <div class="rec-help">
+              Sliders are preset to your latest Pilot Check. Move each to where you are <strong>now</strong>. We compute today's withdrawal as the diff.
+            </div>
+
+            <div class="pc-form">
+              <div class="pc-slider-row">
+                <div class="pc-slider-head">
+                  <label class="pc-label">Cognitive <span class="ff-hint">sleep, focus, decision energy</span></label>
+                  <span class="pc-val" id="rec-cog-val">5</span>
+                </div>
+                <input type="range" id="rec-cog" class="pc-slider" min="1" max="10" step="1" value="5">
+                <div class="pc-scale"><span>1 · depleted</span><span>10 · sharp</span></div>
+                <div class="rec-anchor" id="rec-cog-anchor">No Pilot Check today — starting at 5.</div>
+              </div>
+
+              <div class="pc-slider-row">
+                <div class="pc-slider-head">
+                  <label class="pc-label">Emotional <span class="ff-hint">overwrought, grief, rage, pre-occupied?</span></label>
+                  <span class="pc-val" id="rec-emo-val">5</span>
+                </div>
+                <input type="range" id="rec-emo" class="pc-slider" min="1" max="10" step="1" value="5">
+                <div class="pc-scale"><span>1 · overwrought</span><span>10 · centered</span></div>
+                <div class="rec-anchor" id="rec-emo-anchor">No Pilot Check today — starting at 5.</div>
+              </div>
+
+              <div class="pc-slider-row">
+                <div class="pc-slider-head">
+                  <label class="pc-label">Physical <span class="ff-hint">sick, intoxicated, hungry, in pain?</span></label>
+                  <span class="pc-val" id="rec-phy-val">5</span>
+                </div>
+                <input type="range" id="rec-phy" class="pc-slider" min="1" max="10" step="1" value="5">
+                <div class="pc-scale"><span>1 · sick / exhausted</span><span>10 · strong</span></div>
+                <div class="rec-anchor" id="rec-phy-anchor">No Pilot Check today — starting at 5.</div>
+              </div>
+            </div>
+
+            <div class="rec-tier-readout" id="rec-tier-readout">
+              <span><strong>Withdrawal:</strong> <span id="rec-diffs">cog 0 · emo 0 · phy 0</span></span>
+              <span>Locus: <strong id="rec-locus">—</strong> · size: <span class="rec-tier-tag light" id="rec-tier-tag">light</span></span>
+            </div>
+          </div>
+
+          <div class="rec-nav">
+            <button class="ff-btn" id="rec-reset-1">Reset to anchor</button>
+            <button class="ff-btn primary" id="rec-next-1">Next: shape →</button>
+          </div>
+        </div>
+
+        <!-- STEP 2 — Shape of recovery -->
+        <div class="rec-step" id="rec-step-2">
+          <div class="workshop-section">
+            <div class="workshop-section-label">Step 2 · Shape of the day</div>
+            <div class="rec-help">
+              Pick 1–2 chips that describe today. The tool maps them to recovery mechanisms.
+            </div>
+
+            <div class="rec-chip-row" id="rec-shape-chips">
+              <button class="rec-chip" data-shape="hard-thinking">Hard thinking</button>
+              <button class="rec-chip" data-shape="emotional-grind">Emotional grind</button>
+              <button class="rec-chip" data-shape="boring">Boring / under-stimulated</button>
+              <button class="rec-chip" data-shape="reactive">Reactive / no autonomy</button>
+              <button class="rec-chip" data-shape="wound-up">High arousal / wound up</button>
+              <button class="rec-chip" data-shape="physical">Physical grind</button>
+            </div>
+
+            <input type="text" class="rec-note-input" id="rec-shape-note" placeholder="Optional one-liner — e.g., 'the 3hr review meeting'" maxlength="200">
+
+            <div class="rec-section-label">Recommended mechanisms</div>
+            <div id="rec-mech-cards" class="rec-mech-cards">
+              <div class="rec-empty-msg">Pick a chip above (or click Next on a light day to skip to plan).</div>
+            </div>
+          </div>
+
+          <div class="rec-nav">
+            <button class="ff-btn" id="rec-back-2">← Back</button>
+            <button class="ff-btn primary" id="rec-next-2">Next: plan →</button>
+          </div>
+        </div>
+
+        <!-- STEP 3 — Plan -->
+        <div class="rec-step" id="rec-step-3">
+          <div class="workshop-section">
+            <div class="workshop-section-label">Step 3 · The plan</div>
+            <div class="rec-help">
+              Pick a size. Click chips to seed the plan. Edit freely below. Then lock it in.
+            </div>
+
+            <div class="rec-section-label">Size</div>
+            <div class="rec-size-row" id="rec-size-row">
+              <button class="rec-size-btn" data-size="light">Light</button>
+              <button class="rec-size-btn" data-size="medium">Medium</button>
+              <button class="rec-size-btn" data-size="large">Large</button>
+              <button class="rec-size-btn" data-size="heavy">Heavy</button>
+            </div>
+
+            <div class="rec-section-label">Activity ideas <span class="ff-hint" style="font-weight:normal;text-transform:none;letter-spacing:0;color:var(--faint);">— click to add to plan</span></div>
+            <div class="rec-chip-row" id="rec-activity-chips"></div>
+
+            <div class="rec-section-label">Plan</div>
+            <textarea id="rec-plan-text" class="rec-plan-textarea" placeholder="What you'll actually do. Inline scheduling welcome — 'stretch now, meditate at bedtime, gym in the morning.'"></textarea>
+          </div>
+
+          <div class="rec-nav">
+            <button class="ff-btn" id="rec-back-3">← Back</button>
+            <div>
+              <button class="ff-btn primary" id="rec-lock">Lock plan</button>
+              <span class="ff-saved" id="rec-saved">✓ locked</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Always-visible mechanism legend -->
+        <div class="rec-footer-legend">
+          <div class="rec-leg-item"><span class="rec-leg-name">Detach</span><span class="rec-leg-desc">Switch off — no work, no rumination.</span></div>
+          <div class="rec-leg-item"><span class="rec-leg-name">Relax</span><span class="rec-leg-desc">Low-arousal — parasympathetic down-shift.</span></div>
+          <div class="rec-leg-item"><span class="rec-leg-name">Mastery</span><span class="rec-leg-desc">A different hard thing — rebuilds when under-used.</span></div>
+          <div class="rec-leg-item"><span class="rec-leg-name">Control</span><span class="rec-leg-desc">Do something you don't owe anyone.</span></div>
+        </div>
+
+        <!-- Recent recoveries -->
+        <div class="workshop-section">
+          <div class="workshop-section-label" id="rec-recent-label">Today's Recoveries <span id="rec-recent-count"></span></div>
+          <div id="rec-recent-list" class="ws-recent-list"></div>
+        </div>
+      </div>
+
       <!-- DEBRIEF — sibling block, three internal modes (resting/editing/viewing). Mirrors Frame Workshop pattern but scoped to db- IDs. -->
       <div id="ws-debrief-content" style="display:none">
 
@@ -5538,7 +5945,8 @@
       "name": "Recovery Room",
       "type": "phase / insertable",
       "accent": "green",
-      "description": "Where Recover practice and chapter live. Pick a mode: Detach, Relax, Master, Choose. Includes Sleep as special insertion.",
+      "workshop": true,
+      "description": "Where Recover practice and chapter live. Three-screen flow: measure the need (depth & locus), shape the recovery (mechanism), plan it. Mechanisms: Detach, Relax, Master, Control. Sleep is the floor.",
       "items": ["LAB-015","LAB-016"],
       "artifacts": [
         { "label": "turn-v0.1-phases-and-leverage.md (Recover section)", "href": "turn-v0.1-phases-and-leverage.md" },
@@ -6725,6 +7133,7 @@
     const pilotContent = document.getElementById('ws-pilot-content');
     const debriefContent = document.getElementById('ws-debrief-content');
     const comprehendContent = document.getElementById('ws-comprehend-content');
+    const recoveryContent = document.getElementById('ws-recovery-content');
     if (area.workshop) {
       drawer.classList.add('workshop');
       wsView.classList.add('visible');
@@ -6736,24 +7145,35 @@
         if (pilotContent) pilotContent.style.display = 'block';
         if (debriefContent) debriefContent.style.display = 'none';
         if (comprehendContent) comprehendContent.style.display = 'none';
+        if (recoveryContent) recoveryContent.style.display = 'none';
         initPilotCheckWorkshop();
       } else if (areaId === 'debrief-booth') {
         frameModes.forEach(el => el.style.display = 'none');
         if (pilotContent) pilotContent.style.display = 'none';
         if (debriefContent) debriefContent.style.display = 'block';
         if (comprehendContent) comprehendContent.style.display = 'none';
+        if (recoveryContent) recoveryContent.style.display = 'none';
         initDebriefWorkshop();
       } else if (areaId === 'comprehend-station') {
         frameModes.forEach(el => el.style.display = 'none');
         if (pilotContent) pilotContent.style.display = 'none';
         if (debriefContent) debriefContent.style.display = 'none';
         if (comprehendContent) comprehendContent.style.display = 'block';
+        if (recoveryContent) recoveryContent.style.display = 'none';
         initComprehendWorkshop();
+      } else if (areaId === 'recovery-room') {
+        frameModes.forEach(el => el.style.display = 'none');
+        if (pilotContent) pilotContent.style.display = 'none';
+        if (debriefContent) debriefContent.style.display = 'none';
+        if (comprehendContent) comprehendContent.style.display = 'none';
+        if (recoveryContent) recoveryContent.style.display = 'block';
+        initRecoveryWorkshop();
       } else {
         frameModes.forEach(el => el.style.display = '');
         if (comprehendContent) comprehendContent.style.display = 'none';
         if (pilotContent) pilotContent.style.display = 'none';
         if (debriefContent) debriefContent.style.display = 'none';
+        if (recoveryContent) recoveryContent.style.display = 'none';
         if (areaId === 'frame-workshop') initFrameWorkshop();
       }
     } else {
@@ -6764,6 +7184,7 @@
       if (pilotContent) pilotContent.style.display = 'none';
       if (debriefContent) debriefContent.style.display = 'none';
       if (comprehendContent) comprehendContent.style.display = 'none';
+      if (recoveryContent) recoveryContent.style.display = 'none';
     }
 
     showAreaView(area);
@@ -6802,6 +7223,7 @@
     'frame-cards':   '/api/save/frame-cards',
     'debrief-cards': '/api/save/debrief-cards',
     'pilot-checks':  '/api/save/pilot-checks',
+    'recoveries':    '/api/save/recoveries',
     'courses':       '/api/save/courses',
     'legs':          '/api/save/legs'
   };
@@ -6809,6 +7231,7 @@
     'frame-cards':   '/exports/frame-cards.json',
     'debrief-cards': '/exports/debrief-cards.json',
     'pilot-checks':  '/exports/pilot-checks.json',
+    'recoveries':    '/exports/recoveries.json',
     'courses':       '/exports/courses.json',
     'legs':          '/exports/legs.json'
   };
@@ -6839,6 +7262,7 @@
       ['frame-cards',   FRAME_KEY],
       ['debrief-cards', DEBRIEF_KEY],
       ['pilot-checks',  PC_KEY],
+      ['recoveries',    REC_KEY],
       ['courses',       COURSE_KEY],
       ['legs',          LEG_KEY]
     ];
@@ -7504,6 +7928,503 @@
       renderExperiments('pilot-check-station');
       updateShelfTile('experiments', exps.length);
     }
+  });
+
+  /* ── Recovery Room Workshop ── three-screen flow: measure / shape / plan */
+  const REC_KEY = 'cognitive-lab-v0.1::recoveries';
+
+  function loadRecoveries() {
+    try { return JSON.parse(localStorage.getItem(REC_KEY) || '[]'); }
+    catch { return []; }
+  }
+  function saveRecoveries(arr) {
+    try { localStorage.setItem(REC_KEY, JSON.stringify(arr)); } catch {}
+    postSave('recoveries', arr);
+  }
+
+  // In-flight state for the current 3-screen flow. Cleared on lock or area re-open.
+  let recState = null;
+
+  function recBlankState() {
+    return {
+      step: 1,
+      // Anchor reads (from latest PC, or 5 if none)
+      anchorCog: 5, anchorEmo: 5, anchorPhy: 5,
+      anchorSource: null,   // { id, time } if yoked to a Pilot Check, else null
+      // Current reads (where the user is now — what the sliders show)
+      cog: 5, emo: 5, phy: 5,
+      // Derived withdrawal (anchor − current, clamped to ≥ 0)
+      diffCog: 0, diffEmo: 0, diffPhy: 0,
+      tier: 'light',
+      locus: '—',
+      shapes: [],           // selected chips, max 2
+      note: '',
+      mechs: [],            // [{name, why, rule, warn?}]
+      mechSuppressedMastery: false,
+      zeroMech: false,
+      size: 'light',
+      plan: ''
+    };
+  }
+
+  // Withdrawal-based tier. Operates on the diffs (anchor − current), clamped to ≥ 0.
+  function recComputeTier(dCog, dEmo, dPhy) {
+    const m = Math.max(dCog, dEmo, dPhy);
+    const sum = dCog + dEmo + dPhy;
+    if (m >= 9 || sum >= 18) return 'heavy';
+    if (m >= 7) return 'large';
+    if (m >= 4) return 'medium';
+    return 'light';
+  }
+
+  function recComputeLocus(dCog, dEmo, dPhy) {
+    const max = Math.max(dCog, dEmo, dPhy);
+    if (max === 0) return '—';
+    const dom = [];
+    if (dCog === max) dom.push('cognitive');
+    if (dEmo === max) dom.push('emotional');
+    if (dPhy === max) dom.push('physical');
+    if (dom.length > 1) return 'mixed';
+    return dom[0];
+  }
+
+  // Find the latest pilot check from today (if any). Returns the entry or null.
+  function recLatestPilotCheckToday() {
+    const checks = loadPilotChecks();
+    if (!checks || !checks.length) return null;
+    const today = new Date().toISOString().slice(0, 10);
+    const todays = checks.filter(c => (c.date || '').slice(0, 10) === today);
+    if (!todays.length) return null;
+    // Pilot checks are appended chronologically; the last is the latest.
+    return todays[todays.length - 1];
+  }
+
+  function recApplyAnchor() {
+    const latest = recLatestPilotCheckToday();
+    const cogAnchorEl = document.getElementById('rec-cog-anchor');
+    const emoAnchorEl = document.getElementById('rec-emo-anchor');
+    const phyAnchorEl = document.getElementById('rec-phy-anchor');
+    if (latest) {
+      recState.anchorCog = latest.cog;
+      recState.anchorEmo = latest.emo;
+      recState.anchorPhy = latest.phy;
+      recState.anchorSource = { id: latest.id, time: (latest.date || '').slice(11) || latest.date };
+      const t = recState.anchorSource.time;
+      [cogAnchorEl, emoAnchorEl, phyAnchorEl].forEach(el => el && el.classList.add('yoked'));
+      if (cogAnchorEl) cogAnchorEl.innerHTML = `Started at <strong>${latest.cog}</strong> · ${escapeHTML(t)} Pilot Check`;
+      if (emoAnchorEl) emoAnchorEl.innerHTML = `Started at <strong>${latest.emo}</strong> · ${escapeHTML(t)} Pilot Check`;
+      if (phyAnchorEl) phyAnchorEl.innerHTML = `Started at <strong>${latest.phy}</strong> · ${escapeHTML(t)} Pilot Check`;
+    } else {
+      recState.anchorCog = 5;
+      recState.anchorEmo = 5;
+      recState.anchorPhy = 5;
+      recState.anchorSource = null;
+      [cogAnchorEl, emoAnchorEl, phyAnchorEl].forEach(el => {
+        if (!el) return;
+        el.classList.remove('yoked');
+        el.textContent = 'No Pilot Check today — starting at 5.';
+      });
+    }
+    // Seed slider positions at the anchor.
+    document.getElementById('rec-cog').value = recState.anchorCog;
+    document.getElementById('rec-emo').value = recState.anchorEmo;
+    document.getElementById('rec-phy').value = recState.anchorPhy;
+  }
+
+  function recRenderAnchorDeltas() {
+    // Append a small delta tag to the anchor line that reflects current diff direction.
+    const pairs = [
+      ['rec-cog-anchor', recState.anchorCog, recState.cog],
+      ['rec-emo-anchor', recState.anchorEmo, recState.emo],
+      ['rec-phy-anchor', recState.anchorPhy, recState.phy]
+    ];
+    pairs.forEach(([elId, anchor, current]) => {
+      const el = document.getElementById(elId);
+      if (!el) return;
+      const old = el.querySelector('.rec-anchor-delta');
+      if (old) old.remove();
+      const delta = anchor - current; // positive = withdrawal, negative = gain
+      const tag = document.createElement('span');
+      tag.className = 'rec-anchor-delta';
+      if (delta > 0)      { tag.classList.add('down'); tag.textContent = `−${delta} withdrawn`; }
+      else if (delta < 0) { tag.classList.add('up');   tag.textContent = `+${-delta} gained`; }
+      else                { tag.classList.add('flat'); tag.textContent = `±0`; }
+      el.appendChild(tag);
+    });
+  }
+
+  // Chip → mechanism weight map (rules of thumb from the research report).
+  // Each chip lists primary mechanism(s) with weights summed across selected chips.
+  const REC_SHAPE_MAP = {
+    'hard-thinking':   [{ mech: 'Detach',  w: 2, why: 'Cognitive overload — switch off (Sonnentag & Fritz).' }],
+    'emotional-grind': [{ mech: 'Detach',  w: 2, why: 'Emotional exhaustion clears overnight via detachment.' },
+                        { mech: 'Relax',   w: 1, why: 'Pair with low-arousal to settle the system.' }],
+    'wound-up':        [{ mech: 'Relax',   w: 2, why: 'Sympathetic-NS activation — low-arousal targets it.' }],
+    'boring':          [{ mech: 'Mastery', w: 2, why: 'Under-use depletion — a hard new thing rebuilds.' }],
+    'reactive':        [{ mech: 'Control', w: 2, why: 'Daytime autonomy was low — recover control first.' }],
+    'physical':        [{ mech: 'Relax',   w: 2, why: 'Physiological relaxation — let the body unspool.' }]
+  };
+
+  const REC_MECH_RULES = {
+    'Detach':  'Rule of thumb: no work talk, no work-checking. The system clears only when you let it.',
+    'Relax':   'Rule of thumb: low arousal beats fun. Bath, breath, music — not stimulation.',
+    'Mastery': 'Rule of thumb: a different hard thing. Skip when depleted — mastery on empty backfires.',
+    'Control': 'Rule of thumb: do something you owe no one. The point is choosing, not the activity.'
+  };
+
+  function recRecommendMechanisms(shapes, tier) {
+    if (!shapes || shapes.length === 0) {
+      // Zero-mechanism case if tier is light. Otherwise still no recommendation but warn user.
+      return { mechs: [], zeroMech: tier === 'light', suppressedMastery: false };
+    }
+    // Sum weights across selected chips.
+    const totals = {};
+    shapes.forEach(s => {
+      (REC_SHAPE_MAP[s] || []).forEach(entry => {
+        if (!totals[entry.mech]) totals[entry.mech] = { mech: entry.mech, w: 0, whys: [] };
+        totals[entry.mech].w += entry.w;
+        totals[entry.mech].whys.push(entry.why);
+      });
+    });
+
+    // Suppress Mastery if depth is large or heavy.
+    let suppressedMastery = false;
+    if ((tier === 'large' || tier === 'heavy') && totals['Mastery']) {
+      suppressedMastery = true;
+      delete totals['Mastery'];
+    }
+
+    const sorted = Object.values(totals).sort((a, b) => b.w - a.w);
+    // Cap at 2 mechanisms. If one chip and it lands cleanly on one mech, return one.
+    const top = sorted.slice(0, 2);
+
+    const mechs = top.map(t => ({
+      name: t.mech,
+      why:  t.whys[0],  // first-source why (concise); could join but stays clean
+      rule: REC_MECH_RULES[t.mech] || ''
+    }));
+
+    return { mechs, zeroMech: false, suppressedMastery };
+  }
+
+  // Activity pool — keyed by mechanism + locus. Chips merged and de-duped at render time.
+  const REC_ACTIVITY_POOL = {
+    // mechanism-keyed picks
+    'Detach':  ['no-work-talk dinner', 'novel', 'walk without phone', 'screen-off hour'],
+    'Relax':   ['bath', 'breath work', 'music', 'gentle stretch'],
+    'Mastery': ['hard new hobby thing', 'learn a hard chord', 'kata practice'],
+    'Control': ['do something you don\'t owe anyone', 'pick-your-own meal', 'a project just for you'],
+    // locus-keyed picks
+    'cognitive': ['meditate', 'nap', 'gentle walk-with-detachment'],
+    'emotional': ['run', 'lift', 'talk to someone', 'write it out', 'walk'],
+    'physical':  ['stretch', 'ibuprofen', 'hot tub', 'massage chair', 'gentle walk']
+  };
+
+  function recBuildActivityChips() {
+    const chips = [];
+    const seen = new Set();
+    const add = (a) => { if (a && !seen.has(a)) { seen.add(a); chips.push(a); } };
+    // mechanism picks first, then locus picks
+    (recState.mechs || []).forEach(m => {
+      (REC_ACTIVITY_POOL[m.name] || []).forEach(add);
+    });
+    if (recState.locus && recState.locus !== '—' && recState.locus !== 'mixed') {
+      (REC_ACTIVITY_POOL[recState.locus] || []).forEach(add);
+    } else if (recState.locus === 'mixed') {
+      ['cognitive','emotional','physical'].forEach(l => (REC_ACTIVITY_POOL[l] || []).forEach(add));
+    }
+    // Hard cap to keep it scannable (5–8).
+    return chips.slice(0, 8);
+  }
+
+  function recUpdateStep1Live() {
+    const c = parseInt(document.getElementById('rec-cog').value, 10);
+    const e = parseInt(document.getElementById('rec-emo').value, 10);
+    const p = parseInt(document.getElementById('rec-phy').value, 10);
+    recState.cog = c; recState.emo = e; recState.phy = p;
+    document.getElementById('rec-cog-val').textContent = c;
+    document.getElementById('rec-emo-val').textContent = e;
+    document.getElementById('rec-phy-val').textContent = p;
+    // Color the value the same way Pilot Check does — 1–3 red, 4–6 yellow, 7+ green.
+    [['rec-cog-val', c], ['rec-emo-val', e], ['rec-phy-val', p]].forEach(([id, v]) => {
+      const el = document.getElementById(id);
+      el.classList.remove('red','yellow');
+      if (v <= 3) el.classList.add('red');
+      else if (v <= 6) el.classList.add('yellow');
+    });
+    // Withdrawal = anchor − current, clamped to ≥ 0 (feeling better than anchor = no withdrawal).
+    const dCog = Math.max(0, recState.anchorCog - c);
+    const dEmo = Math.max(0, recState.anchorEmo - e);
+    const dPhy = Math.max(0, recState.anchorPhy - p);
+    recState.diffCog = dCog; recState.diffEmo = dEmo; recState.diffPhy = dPhy;
+    const tier  = recComputeTier(dCog, dEmo, dPhy);
+    const locus = recComputeLocus(dCog, dEmo, dPhy);
+    recState.tier = tier;
+    recState.locus = locus;
+    recState.size = tier; // size default mirrors tier until user changes it in step 3
+    document.getElementById('rec-diffs').textContent = `cog ${dCog} · emo ${dEmo} · phy ${dPhy}`;
+    document.getElementById('rec-locus').textContent = locus;
+    const tag = document.getElementById('rec-tier-tag');
+    tag.textContent = tier;
+    tag.classList.remove('light','medium','large','heavy');
+    tag.classList.add(tier);
+    recRenderAnchorDeltas();
+  }
+
+  function recResetStep1() {
+    // Reset sliders back to anchor — not 0. The anchor is the "starting" position.
+    document.getElementById('rec-cog').value = recState.anchorCog;
+    document.getElementById('rec-emo').value = recState.anchorEmo;
+    document.getElementById('rec-phy').value = recState.anchorPhy;
+    recUpdateStep1Live();
+  }
+
+  function recRenderMechCards() {
+    const host = document.getElementById('rec-mech-cards');
+    const { mechs, zeroMech, suppressedMastery } = recRecommendMechanisms(recState.shapes, recState.tier);
+    recState.mechs = mechs;
+    recState.zeroMech = zeroMech;
+    recState.mechSuppressedMastery = suppressedMastery;
+
+    if (zeroMech) {
+      host.innerHTML = `<div class="rec-empty-msg">Today was light. <strong>Sleep is the plan.</strong> No mechanism needed — head to step 3 and write it down.</div>`;
+      return;
+    }
+    if (mechs.length === 0) {
+      host.innerHTML = `<div class="rec-empty-msg">Pick a chip above to get a recommendation.</div>`;
+      return;
+    }
+    let warnHTML = '';
+    if (suppressedMastery) {
+      warnHTML = `<div class="rec-mech-card warn">
+        <div class="rec-mech-name">Mastery — suppressed</div>
+        <div class="rec-mech-why">Today's depth is ${escapeHTML(recState.tier)}. Mastery on a depleted day backfires (Bakker / Stenfors). Choose another mechanism.</div>
+      </div>`;
+    }
+    host.innerHTML = warnHTML + mechs.map(m => `
+      <div class="rec-mech-card">
+        <div class="rec-mech-name">${escapeHTML(m.name)}</div>
+        <div class="rec-mech-why">${escapeHTML(m.why)}</div>
+        <div class="rec-mech-rule">${escapeHTML(m.rule)}</div>
+      </div>
+    `).join('');
+  }
+
+  function recSyncShapeChips() {
+    document.querySelectorAll('#rec-shape-chips .rec-chip').forEach(chip => {
+      const s = chip.getAttribute('data-shape');
+      chip.classList.toggle('selected', recState.shapes.includes(s));
+      // Disable un-selected chips when at cap (2) so the cap is visible.
+      const atCap = recState.shapes.length >= 2 && !recState.shapes.includes(s);
+      chip.classList.toggle('disabled', atCap);
+    });
+  }
+
+  function recRenderActivityChips() {
+    const host = document.getElementById('rec-activity-chips');
+    const chips = recBuildActivityChips();
+    if (chips.length === 0) {
+      host.innerHTML = '<div class="rec-empty-msg" style="flex:1;">No activity seeds — your plan textarea is yours to fill below.</div>';
+      return;
+    }
+    host.innerHTML = chips.map(a => `<button class="rec-chip" data-activity="${escapeHTML(a)}">${escapeHTML(a)}</button>`).join('');
+    host.querySelectorAll('.rec-chip').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const txt = btn.getAttribute('data-activity');
+        const ta = document.getElementById('rec-plan-text');
+        const existing = ta.value.trim();
+        ta.value = existing ? existing + '\n' + txt : txt;
+        ta.focus();
+        recState.plan = ta.value;
+      });
+    });
+  }
+
+  function recSyncSizeButtons() {
+    document.querySelectorAll('#rec-size-row .rec-size-btn').forEach(btn => {
+      btn.classList.toggle('selected', btn.getAttribute('data-size') === recState.size);
+    });
+  }
+
+  function recShowStep(n) {
+    recState.step = n;
+    document.querySelectorAll('#ws-recovery-content .rec-step').forEach(el => {
+      el.classList.toggle('active', el.id === 'rec-step-' + n);
+    });
+    document.querySelectorAll('#rec-stepper .rec-stepper-item').forEach(el => {
+      const s = parseInt(el.getAttribute('data-step'), 10);
+      el.classList.toggle('active', s === n);
+      el.classList.toggle('done', s < n);
+    });
+    if (n === 2) recRenderMechCards();
+    if (n === 3) { recSyncSizeButtons(); recRenderActivityChips(); }
+  }
+
+  function recRenderRecent() {
+    const recs = loadRecoveries();
+    const list = document.getElementById('rec-recent-list');
+    const countEl = document.getElementById('rec-recent-count');
+    const labelEl = document.getElementById('rec-recent-label');
+
+    const today = new Date().toISOString().slice(0, 10);
+    const todays = recs.filter(r => (r.date || '').slice(0, 10) === today);
+
+    if (recs.length === 0) {
+      countEl.textContent = '';
+      if (labelEl) labelEl.firstChild.textContent = "Today's Recoveries ";
+      list.innerHTML = '<div class="ws-recent-empty">No recoveries yet. Run the flow above.</div>';
+      return;
+    }
+    countEl.textContent = todays.length > 0 ? '(' + todays.length + ')' : '';
+    if (labelEl) labelEl.firstChild.textContent = todays.length > 0 ? "Today's Recoveries " : 'Recent Recoveries ';
+
+    const reverse = recs.slice().reverse();
+    list.innerHTML = reverse.map(r => {
+      const time = (r.date || '').slice(11) || (r.date || '');
+      const mechs = (r.mechs && r.mechs.length) ? r.mechs.map(m => m.name).join(' + ') : (r.zeroMech ? 'Sleep' : '—');
+      const planSnip = (r.plan || '').split('\n')[0].slice(0, 70);
+      // Back-compat: older entries (pre-yoking) won't have diff* fields.
+      const hasDiffs = (typeof r.diffCog === 'number');
+      const diffSnip = hasDiffs ? `−${r.diffCog}/${r.diffEmo}/${r.diffPhy} · ` : '';
+      const summary = `${diffSnip}${escapeHTML(r.size || 'light')} · ${escapeHTML(mechs)}${planSnip ? ' — ' + escapeHTML(planSnip) : ''}`;
+      return `<div class="ws-recent-card">
+        <div class="rc-date">${escapeHTML(time)}</div>
+        <div class="rc-must">${summary}</div>
+      </div>`;
+    }).join('');
+  }
+
+  function initRecoveryWorkshop() {
+    recState = recBlankState();
+    document.getElementById('rec-date').textContent = todayDateString();
+    document.getElementById('rec-shape-note').value = '';
+    document.getElementById('rec-plan-text').value = '';
+    recApplyAnchor();      // seeds anchor values + slider positions + anchor text
+    recUpdateStep1Live();  // computes diffs (all 0 at start since slider == anchor)
+    recSyncShapeChips();
+    recShowStep(1);
+    recRenderRecent();
+  }
+
+  // Wire controls (one-time bind on script load — DOM is in the page).
+  ['rec-cog','rec-emo','rec-phy'].forEach(id => {
+    const el = document.getElementById(id);
+    if (el) el.addEventListener('input', recUpdateStep1Live);
+  });
+  const recReset1 = document.getElementById('rec-reset-1');
+  if (recReset1) recReset1.addEventListener('click', recResetStep1);
+  const recNext1 = document.getElementById('rec-next-1');
+  if (recNext1) recNext1.addEventListener('click', () => recShowStep(2));
+  const recBack2 = document.getElementById('rec-back-2');
+  if (recBack2) recBack2.addEventListener('click', () => recShowStep(1));
+  const recNext2 = document.getElementById('rec-next-2');
+  if (recNext2) recNext2.addEventListener('click', () => {
+    // Capture note before leaving step 2
+    const noteEl = document.getElementById('rec-shape-note');
+    if (noteEl) recState.note = noteEl.value.trim();
+    recShowStep(3);
+  });
+  const recBack3 = document.getElementById('rec-back-3');
+  if (recBack3) recBack3.addEventListener('click', () => recShowStep(2));
+
+  document.querySelectorAll('#rec-shape-chips .rec-chip').forEach(chip => {
+    chip.addEventListener('click', () => {
+      if (!recState) return;
+      const s = chip.getAttribute('data-shape');
+      const idx = recState.shapes.indexOf(s);
+      if (idx >= 0) {
+        recState.shapes.splice(idx, 1);
+      } else if (recState.shapes.length < 2) {
+        recState.shapes.push(s);
+      } // else: at cap, ignored
+      recSyncShapeChips();
+      recRenderMechCards();
+    });
+  });
+
+  document.querySelectorAll('#rec-size-row .rec-size-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      if (!recState) return;
+      recState.size = btn.getAttribute('data-size');
+      recSyncSizeButtons();
+    });
+  });
+
+  const recPlanText = document.getElementById('rec-plan-text');
+  if (recPlanText) recPlanText.addEventListener('input', () => {
+    if (recState) recState.plan = recPlanText.value;
+  });
+
+  const recLock = document.getElementById('rec-lock');
+  if (recLock) recLock.addEventListener('click', () => {
+    if (!recState) return;
+    const planEl = document.getElementById('rec-plan-text');
+    recState.plan = planEl ? planEl.value.trim() : '';
+    if (!recState.plan) {
+      planEl && planEl.focus();
+      return;
+    }
+    const entry = {
+      id: genId(),
+      date: todayDateString(),
+      // anchor reads (latest pilot check or 5 default)
+      anchorCog: recState.anchorCog,
+      anchorEmo: recState.anchorEmo,
+      anchorPhy: recState.anchorPhy,
+      anchorSource: recState.anchorSource, // {id, time} or null
+      // current reads (where the user said they are)
+      cog: recState.cog,
+      emo: recState.emo,
+      phy: recState.phy,
+      // computed withdrawal (anchor − current, clamped ≥ 0)
+      diffCog: recState.diffCog,
+      diffEmo: recState.diffEmo,
+      diffPhy: recState.diffPhy,
+      tier: recState.tier,
+      locus: recState.locus,
+      shapes: recState.shapes.slice(),
+      note: recState.note,
+      mechs: recState.mechs.slice(),
+      mechSuppressedMastery: recState.mechSuppressedMastery,
+      zeroMech: recState.zeroMech,
+      size: recState.size,
+      plan: recState.plan
+    };
+    const recs = loadRecoveries();
+    recs.push(entry);
+    saveRecoveries(recs);
+
+    const flashEl = document.getElementById('rec-saved');
+    if (flashEl) {
+      flashEl.classList.add('show');
+      setTimeout(() => flashEl.classList.remove('show'), 1800);
+    }
+
+    // Also log to the recovery-room Log as an experiment, mirroring Pilot Check pattern.
+    if (currentAreaId === 'recovery-room') {
+      const exps = getExperiments('recovery-room');
+      const mechSummary = entry.zeroMech ? 'Sleep'
+        : (entry.mechs.length ? entry.mechs.map(m => m.name).join(' + ') : 'no mechanism');
+      const planSnip = entry.plan.split('\n')[0].slice(0, 90);
+      const anchorRef = entry.anchorSource
+        ? `anchored to ${entry.anchorSource.time} Pilot Check`
+        : 'no Pilot Check today — anchored at 5';
+      exps.unshift({
+        id: genId(),
+        title: `Recovery ${todayDateString()} — ${entry.size} · ${mechSummary}`,
+        date: todayDateString(),
+        observation: `Now → cog ${entry.cog} · emo ${entry.emo} · phy ${entry.phy} (from ${entry.anchorCog}/${entry.anchorEmo}/${entry.anchorPhy}; ${anchorRef}). Withdrawal: cog ${entry.diffCog} · emo ${entry.diffEmo} · phy ${entry.diffPhy} → tier ${entry.tier}, locus ${entry.locus}. Day-shape: ${entry.shapes.join(', ') || '—'}.${entry.note ? ' Note: ' + entry.note : ''}`,
+        impact: `Plan: ${planSnip}${entry.plan.length > 90 ? '…' : ''}`
+      });
+      setExperiments('recovery-room', exps);
+      renderExperiments('recovery-room');
+      updateShelfTile('experiments', exps.length);
+    }
+
+    // Reset for next flow but stay on step 3 briefly so the flash is visible.
+    setTimeout(() => {
+      initRecoveryWorkshop();
+    }, 600);
   });
 
   /* ── Workshop mode state machine ── */
@@ -9735,6 +10656,7 @@
     merged._frameCards = loadFrameCards();
     merged._pilotChecks = loadPilotChecks();
     merged._debriefCards = loadDebriefCards();
+    merged._recoveries = loadRecoveries();
     merged._chunks = shadow.chunks || {};
     merged._experiments = shadow.experiments || {};
     merged._exported = new Date().toISOString();
@@ -9785,6 +10707,10 @@
         // Restore Debrief Cards if present
         if (Array.isArray(data._debriefCards)) {
           saveDebriefCards(data._debriefCards);
+        }
+        // Restore Recoveries if present
+        if (Array.isArray(data._recoveries)) {
+          saveRecoveries(data._recoveries);
         }
         if (currentAreaId) {
           const area = baseline.areas.find(a => a.id === currentAreaId);

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -5104,11 +5104,6 @@
 
   <!-- Band 4: Instruments + Director (bottom) -->
   <div class="band">
-    <div class="area area-visual" data-area="the-gauge" data-accent="dark">
-      <div class="area-scene">🎛️</div>
-      <div class="area-label">The Gauge<span class="lbl-sub">capacity</span></div>
-      <div class="badge-row" id="badges-the-gauge"></div>
-    </div>
     <div class="area area-visual" data-area="pilot-check-station" data-accent="amber">
       <div class="area-scene">✈️</div>
       <div class="area-label">Pilot Check<span class="lbl-sub">multi-signal</span></div>
@@ -5960,53 +5955,6 @@
       "notes": []
     },
     {
-      "id": "the-gauge",
-      "name": "The Gauge",
-      "type": "gauge / telemetry",
-      "accent": "dark",
-      "description": "The capacity instrument. Read at every boundary. Gates the day's mode. The continuous read-and-dispatch cycle (capacity ↔ restoration) is the framework's heartbeat.",
-      "items": ["LAB-020","LAB-021","LAB-025","LAB-030"],
-      "sources": [
-        { "label": "Capacity Check-In (the live instrument)", "href": "capacity-checkin.html" },
-        { "label": "turn-v0.1-map.html (slides 11 + 17, multi-signal model)", "href": "turn-v0.1-map.html" },
-        { "label": "PROCESS.md (heartbeat as one of two central images)", "href": "PROCESS.md" }
-      ],
-      "experiments": [
-        {
-          "id": "exp-gauge-2026-05-02-heartbeat-named",
-          "title": "Heartbeat named as second central image",
-          "date": "2026-05-02 (afternoon)",
-          "observation": "The give-and-take of capacity check ↔ restoration plan was named as the framework's meta-rhythm. Not just a phase — the rhythm that makes every phase work. Capacity reading dispatches: cleared (continue) or grounded (insert recovery, re-read). The cycle runs continuously, between every phase, across days.",
-          "impact": "Now treated as one of two central images for the framework, alongside the cache-game (Frame's organizing metaphor). The cache-game designs the day; the heartbeat keeps you alive playing it. Captured as a chunk on this area; queued for integration into the deck (LAB-030)."
-        },
-        {
-          "id": "exp-gauge-2026-05-02-merger-architecture",
-          "title": "Capacity check-in + Pilot Check converge into unified Gauge",
-          "date": "2026-05-02 (morning)",
-          "observation": "The capacity check-in PoC and the Pilot Check Station are different views of the same instrument. Each is half-built; together they're the complete instrument. The PoC has felt-sense + bank metaphor + morning-after; the Pilot Check has three-dimension rule-out + targeted prescription. Naming them as separate areas was creating duplication.",
-          "impact": "Architecture decided: merger queued as LAB-025 (Make the Gauge a workshop, embed capacity check-in). Pilot Check Station may dissolve into a use-pattern of the Gauge after the merger."
-        }
-      ],
-      "chunks": [
-        {
-          "id": "chunk-hash-house-gauge-pilot-check",
-          "title": "Hash house = Pilot Check visit (refuel, re-orient, decide)",
-          "summary": "The lab's heartbeat IS the hash house. Pilot Check = hash-house visit: refuel, re-orient, decide whether to continue. A tightening of an existing instrument, not a new one.",
-          "body": "In rogaining, the **hash house** is the central base camp. Racers return there to refuel, check time, re-orient, and decide whether to continue the current route or revise. Elite racers treat each hash-house visit as a decision point, not just a rest stop: they assess their capacity against remaining time and course, then commit or pivot.\n\nThe lab's Pilot Check is the hash house visit. The parallels are direct:\n\n- **Refuel** → capacity read (Cognitive / Emotional / Physical sliders).\n- **Re-orient** → Gauge dispatch (cleared or grounded) + diagnosis of which dimension is red.\n- **Decide whether to continue** → Full Turn vs. Partial Turn vs. Recovery insertion.\n\nThis framing tightens an instrument that already exists — it doesn't add a new one. The Gauge is the continuous instrument (between every phase); the Pilot Check is the explicit pre-leg hash-house visit (before a Full Turn starts).\n\nPractical implication: the Pilot Check form can be framed to the author as 'you're at the hash house — what's your read?' rather than 'complete this checklist.' The framing change may improve compliance on sessions where the operator is inclined to skip the check. The hash-house visit is non-optional in rogaining; that normative weight transfers.\n\nThe Debrief's 'Capacity + next' field closes the loop: post-leg gauge read = leaving the hash house for the next leg.\n\nCross-ref: chunk-gauge-heartbeat (The Gauge) — the heartbeat is the continuous rhythm; the hash house is the explicit check-in point within that rhythm."
-        },
-        {
-          "id": "chunk-gauge-heartbeat",
-          "title": "The heartbeat — capacity ↔ restoration as meta-rhythm",
-          "summary": "The continuous Gauge-read-and-dispatch cycle is the framework's beating rhythm. Without it, the framework is just phases without honoring capacity.",
-          "body": "The framework has two central images. The cache-game (Jess's contribution) names how the day's game gets designed — Frame as the game-design moment. The heartbeat names how the day's rhythm cycles.\n\nThe heartbeat: capacity check → action plan → capacity check → action plan. The Gauge reads, the result dispatches: cleared (continue with the planned phase) or grounded (insert recovery, re-read). The cycle runs continuously throughout the day, between every phase, across days.\n\nWith the heartbeat, every phase boundary is gated by capacity and every grounded reading dispatches a targeted recovery. Without it, the cycle just runs through phases regardless of state — and the framework collapses into ritual.\n\nThe Pilot Check is the explicit pre-flight version of the heartbeat (rule-out across cognitive / emotional / physical, dispatching recovery hours per red dimension). The Gauge is the continuous instrument the heartbeat runs on.\n\nThe two images compose. The cache-game is *how the day's game is designed.* The heartbeat is *how the day's rhythm cycles.* Neither alone is the framework; together they make the practice live."
-        }
-      ],
-      "notes": [
-        "The capacity check-in is the felt-sense layer of the Gauge. It's been doing real recovery-planning work and is the seed the Gauge grows from.",
-        "2026-04-30 — The morning gauge worked (recovery turnaround)."
-      ]
-    },
-    {
       "id": "director-desk",
       "name": "Director's Desk",
       "type": "aux / persistent",
@@ -6675,24 +6623,6 @@
       "brief": "One week of disciplined Frame runs feeding into the Archive.",
       "full": "Run one full week of formal Frame practice. Capture lab notes for each turn. Feed findings into the Archive and the Frame form v1 revision cycle."
     },
-    "LAB-020": {
-      "id": "LAB-020",
-      "title": "Per-turn gauge entries (vs only per-day)",
-      "status": "backlog",
-      "priority": "P1",
-      "area": "the-gauge",
-      "brief": "Upgrade the gauge to record a reading at the start of each turn, not just daily.",
-      "full": "Upgrade the gauge to record a reading at the start of each turn, not just once per day. This feeds the multi-signal model and enables intra-day capacity tracking."
-    },
-    "LAB-021": {
-      "id": "LAB-021",
-      "title": "Capacity check-in v0.2 (turn-aware data model)",
-      "status": "backlog",
-      "priority": "P1",
-      "area": "the-gauge",
-      "brief": "Rebuild the check-in PoC with a turn-aware data model.",
-      "full": "Rebuild the capacity check-in PoC with a turn-aware data model. Each record tagged with turn ID, time-of-day, and which phase triggered the check-in. Enables correlation analysis between gauge readings and turn outcomes."
-    },
     "LAB-022": {
       "id": "LAB-022",
       "title": "Cowork integration (morning prompt opens Frame card)",
@@ -6719,15 +6649,6 @@
       "area": "director-desk",
       "brief": "Both Directors present in the lab simultaneously with shared state.",
       "full": "Multiplayer mode: both Directors (Danvers + Jess) present in the lab simultaneously. Shared gauge state, shared items, separate Frame cards. Real-time updates via WebSocket or polling."
-    },
-    "LAB-025": {
-      "id": "LAB-025",
-      "title": "Make the Gauge a workshop (embed capacity check-in)",
-      "status": "backlog",
-      "priority": "P1",
-      "area": "the-gauge",
-      "brief": "Promote the Gauge from a regular area to a workshop, with the capacity check-in PoC embedded as the instrument view.",
-      "full": "Same workshop pattern as Frame. Top half of drawer = the live instrument (capacity check-in PoC, embedded as iframe or directly merged), bottom half = the floor view (items, artifacts, notes, recent gauge readings as cards). Eventually adds the multi-signal layers (behavioral, temporal) on top of the felt-sense PoC. Architecturally, makes the PoC's daily ritual a first-class part of the lab rather than a side artifact."
     },
     "LAB-026": {
       "id": "LAB-026",
@@ -6764,15 +6685,6 @@
       "area": "director-desk",
       "brief": "An AI agent generates the title for Log entries from observation + impact. Manual override stays available.",
       "full": "When a Log entry is saved (or after observation/impact are filled), an AI agent suggests a 4–8 word label that captures the entry's gist. User accepts, edits, or replaces. Belongs to the broader 'magical workshop' direction where AI teammates contribute structured content. Touches every workshop area, not just Frame. Requires an LLM call (Claude API) — server endpoint or client-side proxy. Lower-tier model (Haiku) sufficient for titling. Lives in director-desk because the capability spans the whole lab, not one area."
-    },
-    "LAB-030": {
-      "id": "LAB-030",
-      "title": "Integrate the heartbeat into the deck",
-      "status": "backlog",
-      "priority": "P1",
-      "area": "the-gauge",
-      "brief": "Update deck slides to surface the heartbeat as the framework's second central image alongside the cache-game.",
-      "full": "The framework now has two named central images. The cache-game is well-represented in the deck (Frame batches with subtitles tied to the metaphor). The heartbeat (capacity ↔ restoration as continuous meta-rhythm) is not yet in the deck. Update slides 11 and 17–18 (Gauge and multi-signal model) to name the heartbeat explicitly. Possibly add a slide that pairs the two images. Coordinates with chunk-gauge-heartbeat in the-gauge area."
     },
     "LAB-031": {
       "id": "LAB-031",
@@ -9789,7 +9701,7 @@
       title: 'Turn v0.1 Map',
       kind: 'deck',
       subtitle: '21 slides · 4 acts · beginner-facing',
-      preview: 'The original turn-architecture deck. Frame · Comprehend · Sync · Produce · Debrief · Recover, with the three meta-disciplines (Trim · Heartbeat · Transition).',
+      preview: 'The original turn-architecture deck. Frame · Comprehend · Sync · Produce · Debrief · Recover, with the two meta-disciplines (Trim · Transition).',
       deck_href: 'turn-v0.1-map.html'
     }
   ];

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -6117,9 +6117,16 @@
       "items": ["LAB-007","LAB-008"],
       "sources": [
         { "label": "turn-v0.1-map.html (deck slides 17–18 — multi-signal model)", "href": "turn-v0.1-map.html" },
-        { "label": "Book 1 capacity chapter — emotional / mental / physical (linked when chapter file lands in lab)", "href": "#" }
+        { "label": "Book 1 capacity chapter — emotional / mental / physical (linked when chapter file lands in lab)", "href": "#" },
+        { "label": "Capacity Check-In (felt-sense seed for the Pilot Check ritual)", "href": "capacity-checkin.html" }
       ],
       "chunks": [
+        {
+          "id": "chunk-hash-house-pilot-check",
+          "title": "Hash house = Pilot Check visit (refuel, re-orient, decide)",
+          "summary": "Pilot Check = hash-house visit at the start of the day: refuel, re-orient, decide whether to continue. The morning bookend of the bookended day.",
+          "body": "In rogaining, the **hash house** is the central base camp. Racers return to refuel, check time, re-orient, and decide whether to continue the current route or revise. Elite racers treat each visit as a decision point, not a rest stop: assess capacity against remaining time and course, then commit or pivot.\n\nThe morning Pilot Check is the hash-house visit that opens the day. The parallels are direct:\n\n- **Refuel** → capacity read (Cognitive / Emotional / Physical sliders).\n- **Re-orient** → dispatch verdict (cleared or grounded) + diagnosis of which dimension is red.\n- **Decide whether to continue** → Full Turn vs. Partial Turn vs. Recovery day.\n\nThe framing carries a normative weight the checklist framing doesn't: the hash-house visit is non-optional in rogaining. Skipping it doesn't make you faster; it makes you lost. The evening Recovery is the other bookend — closing the loops the day opened so they don't bleed into tomorrow. Together they hold the day: Pilot Check opens it deliberately, Recovery closes it deliberately, the turn cycle runs in the protected middle."
+        },
         {
           "id": "chunk-pilot-rule-out",
           "title": "Rule-out, not measurement",
@@ -6148,7 +6155,9 @@
           "impact": "Reframed Pilot Check architecture: three-dimension rule-out, sliders 1–10 per dimension, threshold ≤3 = red. Output dispatches a winged prescription: 1 hour workday recovery per red dimension. Drift / attention pull split off as a different tool (Push-phase monitoring, not pre-flight). Pilot Check operationally connects Book 1's capacity chapter (emotional/mental/physical) to Book 2's pre-flight ritual."
         }
       ],
-      "notes": []
+      "notes": [
+        "2026-04-30 — The morning Pilot Check worked (recovery turnaround)."
+      ]
     },
     {
       "id": "transition-hallway",

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -2890,6 +2890,15 @@
     opacity: 0.85;
   }
 
+  /* Day-band: Pilot Check left, baseline rule middle, Recovery right */
+  .band-day { align-items: center; }
+  .band-rule {
+    flex: 1;
+    border-top: 1px solid var(--panel-bd);
+    align-self: center;
+    opacity: 0.4;
+  }
+
   /* Phase cycle band: arrows align with mid-row icons */
   .band-phase { align-items: center; }
   .band-phase .arrow { font-size: 18px; }
@@ -3956,6 +3965,81 @@
 
   /* Recent recovery list (reuses ws-recent-card style) */
   #rec-recent-list .ws-recent-card { border-left-color: var(--success); }
+
+  /* ── Open-turns section (Step 3 of Recovery) ── */
+  .rec-open-turns-section {
+    margin-top: 12px;
+  }
+  .rec-open-turn-row {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 8px 10px;
+    background: rgba(42,58,92,0.35);
+    border: 1px solid var(--panel-bd);
+    border-radius: 6px;
+    margin-bottom: 6px;
+  }
+  .rec-open-turn-id {
+    font-family: var(--font-px);
+    font-size: 9px;
+    color: var(--accent-dim);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+  }
+  .rec-open-turn-title {
+    font-size: 12px;
+    color: var(--fg);
+  }
+  .rec-open-turn-actions {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+    margin-top: 4px;
+  }
+  .rec-turn-action-label {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-family: var(--font-px);
+    font-size: 10px;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--fg-dim);
+    cursor: pointer;
+    padding: 3px 7px;
+    border: 1px solid var(--panel-bd);
+    border-radius: 4px;
+    transition: background 0.12s, color 0.12s, border-color 0.12s;
+  }
+  .rec-turn-action-label:has(input:checked) {
+    background: rgba(226,160,74,0.12);
+    border-color: var(--accent-dim);
+    color: var(--accent);
+  }
+  .rec-turn-action-label input[type="radio"] {
+    display: none;
+  }
+  .rec-open-turn-note {
+    font-size: 11px;
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-bd);
+    border-radius: 4px;
+    color: var(--fg);
+    padding: 4px 7px;
+    width: 100%;
+    resize: none;
+    font-family: inherit;
+    margin-top: 2px;
+  }
+  .rec-open-turn-note:focus { outline: none; border-color: var(--accent-dim); }
+  .rec-open-turns-empty {
+    font-size: 11px;
+    color: var(--fg-dim);
+    font-style: italic;
+    padding: 6px 0;
+  }
 
   /* ── Course Header bar (renders active leg + course at the top of every workshop drawer) ──
      Single-line glanceable strip. Quenton's "iconic skin" call: leg-number is a
@@ -5047,9 +5131,25 @@
     </div>
   </div>
 
-  <!-- Band 2: Phase cycle (single visual each).
+  <!-- Band 2: Day-band — bookended day (Pilot Check opens · Recovery closes) -->
+  <div class="band band-day">
+    <div class="area area-visual" data-area="pilot-check-station" data-accent="amber">
+      <div class="area-scene">✈️</div>
+      <div class="area-label">Pilot Check<span class="lbl-sub">ritual · open</span></div>
+      <div class="badge-row" id="badges-pilot-check-station"></div>
+    </div>
+    <div class="band-rule"></div>
+    <div class="area area-visual" data-area="recovery-room" data-accent="green">
+      <div class="area-scene">🌿</div>
+      <div class="area-label">Recover<span class="lbl-sub">ritual · close</span></div>
+      <div class="badge-row" id="badges-recovery-room"></div>
+    </div>
+  </div>
+
+  <!-- Band 3: Turn cycle (single visual each).
        Move 2a (v0.4 build): Comprehend leads. Per the C-before-F call —
-       you can't scope what you haven't read in. Frame follows. -->
+       you can't scope what you haven't read in. Frame follows.
+       Recovery moved to day-band; cycle ends at Debrief. -->
   <div class="band band-phase">
     <div class="area area-visual" data-area="comprehend-station" data-accent="amber">
       <div class="area-scene">🛠️</div>
@@ -5080,15 +5180,9 @@
       <div class="area-label">Debrief<span class="lbl-sub">required</span></div>
       <div class="badge-row" id="badges-debrief-booth"></div>
     </div>
-    <div class="arrow">→</div>
-    <div class="area area-visual" data-area="recovery-room" data-accent="green">
-      <div class="area-scene">🌿</div>
-      <div class="area-label">Recover<span class="lbl-sub">insertable</span></div>
-      <div class="badge-row" id="badges-recovery-room"></div>
-    </div>
   </div>
 
-  <!-- Band 3: Meta-disciplines -->
+  <!-- Band 4: Meta — Transition · Trim · Director's Desk -->
   <div class="band">
     <div class="area area-visual" data-area="transition-hallway" data-accent="tan">
       <div class="area-scene">🚪</div>
@@ -5099,15 +5193,6 @@
       <div class="area-scene">✂️</div>
       <div class="area-label">Trim<span class="lbl-sub">meta</span></div>
       <div class="badge-row" id="badges-trim-bench"></div>
-    </div>
-  </div>
-
-  <!-- Band 4: Instruments + Director (bottom) -->
-  <div class="band">
-    <div class="area area-visual" data-area="pilot-check-station" data-accent="amber">
-      <div class="area-scene">✈️</div>
-      <div class="area-label">Pilot Check<span class="lbl-sub">multi-signal</span></div>
-      <div class="badge-row" id="badges-pilot-check-station"></div>
     </div>
     <div class="area area-visual" data-area="director-desk" data-accent="dark">
       <div class="area-scene">🧑‍💻</div>
@@ -5505,6 +5590,15 @@
             <textarea id="rec-plan-text" class="rec-plan-textarea" placeholder="What you'll actually do. Inline scheduling welcome — 'stretch now, meditate at bedtime, gym in the morning.'"></textarea>
           </div>
 
+          <!-- Open turns at lock -->
+          <div class="workshop-section rec-open-turns-section">
+            <div class="workshop-section-label">Open turns at lock</div>
+            <div class="rec-help">
+              Any turn still open at end of day. Pick an action for each you want to record — carry, drop, or defer. Rows with no action selected are not saved.
+            </div>
+            <div id="rec-open-turns-list"></div>
+          </div>
+
           <div class="rec-nav">
             <button class="ff-btn" id="rec-back-3">← Back</button>
             <div>
@@ -5724,6 +5818,7 @@
       "id": "frame-workshop",
       "name": "Frame Workshop",
       "type": "phase / required",
+      "kind": "phase",
       "accent": "blue",
       "workshop": true,
       "description": "Where the Frame practice and chapter live. The phase that decides what the turn is for.",
@@ -5837,6 +5932,7 @@
       "id": "comprehend-station",
       "name": "Comprehend Station",
       "type": "phase / required",
+      "kind": "phase",
       "accent": "amber",
       "workshop": true,
       "description": "Where the lab orients you. Re-immerse on prior legs, walk decks, take guided product walks of new features. The phase that loads remaining state from agents and prior work — first step in the cycle (C-before-F).",
@@ -5876,6 +5972,7 @@
       "id": "sync-floor",
       "name": "Sync Floor",
       "type": "phase / conditional",
+      "kind": "phase",
       "accent": "amber",
       "description": "Where Sync practice and chapter live. The phase that aligns humans and agents and confirms zones.",
       "items": ["LAB-011","LAB-012"],
@@ -5888,6 +5985,7 @@
       "id": "push-bay",
       "name": "Produce Bay",
       "type": "phase / conditional",
+      "kind": "phase",
       "accent": "amber",
       "description": "Where the Produce phase (formerly Push) practice and chapter live. Decision work, hardest first, with bingo-fuel stop signal.",
       "items": ["LAB-013","LAB-014"],
@@ -5901,6 +5999,7 @@
       "id": "debrief-booth",
       "name": "Debrief Booth",
       "type": "phase / required",
+      "kind": "phase",
       "accent": "blue",
       "workshop": true,
       "description": "Where Debrief practice and chapter live. Closes the cycle, captures, sets up the next gauge read. Currently the urgent priority — its absence is the gap that creates session-end integration debt.",
@@ -5943,7 +6042,8 @@
     {
       "id": "recovery-room",
       "name": "Recovery Room",
-      "type": "phase / insertable",
+      "type": "ritual / end-of-day",
+      "kind": "ritual",
       "accent": "green",
       "workshop": true,
       "description": "Where Recover practice and chapter live. Three-screen flow: measure the need (depth & locus), shape the recovery (mechanism), plan it. Mechanisms: Detach, Relax, Master, Control. Sleep is the floor.",
@@ -5958,6 +6058,7 @@
       "id": "director-desk",
       "name": "Director's Desk",
       "type": "aux / persistent",
+      "kind": "meta",
       "accent": "dark",
       "description": "Your seat. Where the Frame card sits today, where lab notes get written. Also the home for cross-cutting lab work — agent composition, process docs, session integration.",
       "items": ["LAB-022","LAB-023","LAB-024","LAB-029","LAB-034","LAB-035","LAB-037","LAB-039","LAB-040","LAB-041","LAB-043","LAB-045","LAB-047","LAB-048","LAB-049","LAB-050","LAB-051"],
@@ -6111,6 +6212,7 @@
       "id": "pilot-check-station",
       "name": "Pilot Check Station",
       "type": "rule-out / pre-flight",
+      "kind": "ritual",
       "accent": "amber",
       "workshop": true,
       "description": "Three-dimension capacity rule-out — cognitive (king), emotional, physical. 0–3 on any dimension = grounded. Output dispatches a targeted Recovery prescription. Like aviation IM SAFE: not measuring fitness, ruling out hazards.",
@@ -6163,6 +6265,7 @@
       "id": "transition-hallway",
       "name": "Transition Hallway",
       "type": "meta-discipline",
+      "kind": "meta",
       "accent": "tan",
       "description": "Every phase boundary is taxed (Leroy 2009 attention residue). Close · reset · open. Practice surface for the boundary move. Same shape across micro / meso / macro / super-macro scales.",
       "items": ["LAB-005","LAB-006","LAB-031"],
@@ -6188,6 +6291,7 @@
       "id": "trim-bench",
       "name": "Trim Bench",
       "type": "meta-discipline",
+      "kind": "meta",
       "accent": "tan",
       "description": "Selection discipline within each phase. Lower priority once Frame is doing its job.",
       "items": ["LAB-017","LAB-018","LAB-033"],
@@ -8172,6 +8276,62 @@
     });
   }
 
+  // ── Open-turns rendering ──
+  // Collects legs not yet debriefed/archived and renders a chip-row per turn.
+  // Each row: turn id, turn title (from Frame card's "in" field), and three
+  // radio actions (carry / drop / defer) plus an optional note input.
+  function recRenderOpenTurns() {
+    const container = document.getElementById('rec-open-turns-list');
+    if (!container) return;
+
+    const openLegs = loadLegs().filter(l =>
+      l && l.status !== 'debriefed' && l.status !== 'archived'
+    );
+
+    if (openLegs.length === 0) {
+      container.innerHTML = '<div class="rec-open-turns-empty">No open turns to park.</div>';
+      return;
+    }
+
+    container.innerHTML = openLegs.map(leg => {
+      // Resolve title from Frame card "in" field, fall back to "Untitled"
+      let title = 'Untitled';
+      if (leg.frame_card_id) {
+        const card = (loadFrameCards() || []).find(c => c && c.savedAt === leg.frame_card_id);
+        if (card && card.in) {
+          const raw = card.in;
+          title = (typeof raw === 'string' ? raw : JSON.stringify(raw)).split('\n')[0].slice(0, 80) || 'Untitled';
+        }
+      }
+      const escapedId = escapeHTML(leg.id);
+      const escapedTitle = escapeHTML(title);
+      return `<div class="rec-open-turn-row" data-turn-id="${escapedId}">
+        <div class="rec-open-turn-id">${escapedId}</div>
+        <div class="rec-open-turn-title">${escapedTitle}</div>
+        <div class="rec-open-turn-actions">
+          <label class="rec-turn-action-label"><input type="radio" name="rec-turn-action-${escapedId}" value="carry"> Carry</label>
+          <label class="rec-turn-action-label"><input type="radio" name="rec-turn-action-${escapedId}" value="drop"> Drop</label>
+          <label class="rec-turn-action-label"><input type="radio" name="rec-turn-action-${escapedId}" value="defer"> Defer</label>
+        </div>
+        <input type="text" class="rec-open-turn-note" placeholder="Optional note — e.g. 'carry into tomorrow's Frame' or 'blocked until Tuesday'" maxlength="200">
+      </div>`;
+    }).join('');
+  }
+
+  // Reads the open-turns UI and returns only rows where the author picked an action.
+  function recCollectOpenTurns() {
+    const rows = document.querySelectorAll('#rec-open-turns-list .rec-open-turn-row');
+    const result = [];
+    rows.forEach(row => {
+      const turnId = row.getAttribute('data-turn-id');
+      const checked = row.querySelector('input[type="radio"]:checked');
+      if (!checked) return; // no action selected — skip
+      const note = (row.querySelector('.rec-open-turn-note') || {}).value || '';
+      result.push({ turnId, action: checked.value, note: note.trim() });
+    });
+    return result;
+  }
+
   function recShowStep(n) {
     recState.step = n;
     document.querySelectorAll('#ws-recovery-content .rec-step').forEach(el => {
@@ -8183,7 +8343,7 @@
       el.classList.toggle('done', s < n);
     });
     if (n === 2) recRenderMechCards();
-    if (n === 3) { recSyncSizeButtons(); recRenderActivityChips(); }
+    if (n === 3) { recSyncSizeButtons(); recRenderActivityChips(); recRenderOpenTurns(); }
   }
 
   function recRenderRecent() {
@@ -8290,6 +8450,9 @@
       planEl && planEl.focus();
       return;
     }
+    // Collect open-turn parking decisions (only rows with an action selected).
+    const openTurns = recCollectOpenTurns();
+
     const entry = {
       id: genId(),
       date: todayDateString(),
@@ -8314,7 +8477,9 @@
       mechSuppressedMastery: recState.mechSuppressedMastery,
       zeroMech: recState.zeroMech,
       size: recState.size,
-      plan: recState.plan
+      plan: recState.plan,
+      // open-turn parking: only rows where author picked an action
+      openTurns: openTurns
     };
     const recs = loadRecoveries();
     recs.push(entry);
@@ -8335,12 +8500,24 @@
       const anchorRef = entry.anchorSource
         ? `anchored to ${entry.anchorSource.time} Pilot Check`
         : 'no Pilot Check today — anchored at 5';
+      // Build open-turn parking summary if any turns were actioned.
+      let turnParkingSuffix = '';
+      if (entry.openTurns && entry.openTurns.length > 0) {
+        const carries = entry.openTurns.filter(t => t.action === 'carry').length;
+        const drops   = entry.openTurns.filter(t => t.action === 'drop').length;
+        const defers  = entry.openTurns.filter(t => t.action === 'defer').length;
+        const parts = [];
+        if (carries) parts.push(carries + ' carry');
+        if (defers)  parts.push(defers  + ' defer');
+        if (drops)   parts.push(drops   + ' drop');
+        turnParkingSuffix = ` + ${entry.openTurns.length} turn${entry.openTurns.length === 1 ? '' : 's'} parked (${parts.join(', ')})`;
+      }
       exps.unshift({
         id: genId(),
         title: `Recovery ${todayDateString()} — ${entry.size} · ${mechSummary}`,
         date: todayDateString(),
         observation: `Now → cog ${entry.cog} · emo ${entry.emo} · phy ${entry.phy} (from ${entry.anchorCog}/${entry.anchorEmo}/${entry.anchorPhy}; ${anchorRef}). Withdrawal: cog ${entry.diffCog} · emo ${entry.diffEmo} · phy ${entry.diffPhy} → tier ${entry.tier}, locus ${entry.locus}. Day-shape: ${entry.shapes.join(', ') || '—'}.${entry.note ? ' Note: ' + entry.note : ''}`,
-        impact: `Plan: ${planSnip}${entry.plan.length > 90 ? '…' : ''}`
+        impact: `Plan: ${planSnip}${entry.plan.length > 90 ? '…' : ''}${turnParkingSuffix}`
       });
       setExperiments('recovery-room', exps);
       renderExperiments('recovery-room');
@@ -10819,11 +10996,6 @@
       { kind: 'form',     label: 'Debrief form' },
       { kind: 'chapter',  label: 'Debrief chapter' },
       { kind: 'practice', label: 'Debrief practice' },
-    ],
-    'recovery-room': [
-      { kind: 'form',     label: 'Recover form' },
-      { kind: 'chapter',  label: 'Recover chapter' },
-      { kind: 'practice', label: 'Recover practice' },
     ],
   };
 

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -3918,7 +3918,12 @@
     margin-top: 16px;
     gap: 8px;
   }
-  .rec-nav .ff-saved { margin-left: 0; }
+  .rec-nav .ff-saved {
+    margin-left: 0;
+    opacity: 0;
+    transition: opacity 0.2s;
+  }
+  .rec-nav .ff-saved.show { opacity: 1; }
 
   .rec-footer-legend {
     display: grid;

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -6599,7 +6599,7 @@
       "priority": "P0",
       "area": "debrief-booth",
       "brief": "Why measurement closes the cycle. After-action-review patterns. Reflection theory.",
-      "full": "Why measurement closes the cycle. After-action-review patterns from military and aviation. Reflection theory (Dewey, Schon). How Debrief feeds the Gauge for the next turn."
+      "full": "Why measurement closes the cycle. After-action-review patterns from military and aviation. Reflection theory (Dewey, Schon). How Debrief grades the turn against its Frame card and queues the next leg."
     },
     "LAB-005": {
       "id": "LAB-005",
@@ -6634,8 +6634,8 @@
       "status": "backlog",
       "priority": "P0",
       "area": "pilot-check-station",
-      "brief": "Why the Gauge alone isn't enough. The three signals. Aviation precedent (IM SAFE + duty-time + cross-check).",
-      "full": "Why the Gauge alone isn't enough (single-signal systems fail under load). The three signals (felt, behavioral, temporal). Aviation precedent: IM SAFE checklist, duty-time rules, cross-checking instruments. The ironies of automation: you need more context when monitoring automated systems (Bainbridge)."
+      "brief": "Why the morning Pilot Check is the rule-out, not the fitness scan. The three signals (felt / behavioral / temporal). Aviation precedent (IM SAFE + duty-time + cross-check).",
+      "full": "Why the Pilot Check is rule-out, not measurement (single-signal capacity reads fail under load; the three-dimension multi-signal model is what keeps you honest at the morning bookend). The three signals (felt, behavioral, temporal). Aviation precedent: IM SAFE checklist, duty-time rules, cross-checking instruments. The ironies of automation: you need more context when monitoring automated systems (Bainbridge)."
     },
     "LAB-009": {
       "id": "LAB-009",

--- a/cognitive-lab/lab-server.py
+++ b/cognitive-lab/lab-server.py
@@ -7,6 +7,7 @@ Behavior:
   POST /api/save/frame-cards      body = JSON array, written to exports/frame-cards.json
   POST /api/save/debrief-cards    body = JSON array, written to exports/debrief-cards.json
   POST /api/save/pilot-checks     body = JSON array, written to exports/pilot-checks.json
+  POST /api/save/recoveries       body = JSON array, written to exports/recoveries.json
   POST /api/save/courses          body = JSON array, written to exports/courses.json
   POST /api/save/legs             body = JSON array, written to exports/legs.json
 
@@ -48,6 +49,7 @@ ALLOWED_TYPES = {
     "frame-cards":   "frame-cards.json",
     "debrief-cards": "debrief-cards.json",
     "pilot-checks":  "pilot-checks.json",
+    "recoveries":    "recoveries.json",
     "courses":       "courses.json",
     "legs":          "legs.json",
 }

--- a/larry-moleman/LAB_CONTEXT.md
+++ b/larry-moleman/LAB_CONTEXT.md
@@ -82,7 +82,8 @@ Find the area's `"experiments": [` and prepend the new entry. Newest-first order
 
 1. Add to the `items` dictionary at the bottom.
 2. Add the LAB-XXX id to the relevant area's `"items": [...]` array.
-3. Add the LAB-XXX id to Backlog Wall's `"items": [...]` array.
+
+(There is no separate Backlog Wall — the toolbar's Priority view is the cross-area backlog. Items appear there automatically by their `priority` field.)
 
 ### Updating an item's status
 
@@ -100,23 +101,24 @@ Find the area's `"chunks": [` and prepend the new chunk, or update an existing o
 
 ## Areas in the lab (for routing)
 
-| Area ID               | Name                | Workshop? |
-| --------------------- | ------------------- | --------- |
-| `frame-workshop`      | Frame Workshop      | yes       |
-| `comprehend-station`  | Comprehend Station  | no        |
-| `sync-floor`          | Sync Floor          | no        |
-| `push-bay`            | Produce Bay         | no        |
-| `debrief-booth`       | Debrief Booth       | no        |
-| `recovery-room`       | Recovery Room       | no        |
-| `the-gauge`           | The Gauge           | no        |
-| `pilot-check-station` | Pilot Check Station | yes       |
-| `transition-hallway`  | Transition Hallway  | no        |
-| `trim-bench`          | Trim Bench          | no        |
-| `library`             | The Library         | no        |
-| `archive`             | The Archive         | no        |
-| `backlog-wall`        | Backlog Wall        | no        |
-| `deck-theater`        | Deck Theater        | no        |
-| `director-desk`       | Director's Desk     | no        |
+| Area ID               | Name                | Kind        | Workshop? |
+| --------------------- | ------------------- | ----------- | --------- |
+| `pilot-check-station` | Pilot Check Station | ritual      | yes       |
+| `recovery-room`       | Recovery Room       | ritual      | yes       |
+| `comprehend-station`  | Comprehend Station  | phase       | yes       |
+| `frame-workshop`      | Frame Workshop      | phase       | yes       |
+| `sync-floor`          | Sync Floor          | phase       | no        |
+| `push-bay`            | Produce Bay         | phase       | no        |
+| `debrief-booth`       | Debrief Booth       | phase       | yes       |
+| `transition-hallway`  | Transition Hallway  | meta        | no        |
+| `trim-bench`          | Trim Bench          | meta        | no        |
+| `director-desk`       | Director's Desk     | meta        | no        |
+| `library`             | The Library         | holding-pen | no        |
+| `archive`             | The Archive         | holding-pen | no        |
+| `deck-theater`        | Deck Theater        | holding-pen | no        |
+| `strategy`            | Strategy & Plans    | holding-pen | no        |
+
+(The Gauge and Backlog Wall were retired; their content is archived in `cognitive-lab/archive/`.)
 
 This list will grow as more areas become workshops and as new areas are added.
 

--- a/quenton-quince/LAB_CONTEXT.md
+++ b/quenton-quince/LAB_CONTEXT.md
@@ -53,7 +53,7 @@ The lab is a top-down, click-to-explore floor plan with four bands:
 
 **Band 4 — Bottom (instruments + Director):**
 
-- The Gauge · Pilot Check Station · Director's Desk
+- Pilot Check Station · Director's Desk
 
 Click any area opens a side drawer (drawer expands to 66vw if the area has `workshop: true`). Drawers contain:
 
@@ -95,7 +95,7 @@ The day has two fixed posts: a Pilot Check at the start and a Recovery ritual at
 
 ## The framework in one paragraph
 
-Knowledge work used to come in batches (mornings = email, afternoons = meetings). AI made it continuous — agents work 24/7, output is functionally infinite. Continuous-flow work breaks the people doing it because the management interface (calendars, project software, willpower) was built for batched work. The Turn is a structured cycle for AI-native work: six phases, three categories (required / conditional / insertable), gated by a continuously-read capacity gauge, paced by deliberate recovery. The framework borrows from cognitive load research, occupational health psychology, and industries that have long operated continuously (aviation, naval, manufacturing, medicine, sport).
+Knowledge work used to come in batches (mornings = email, afternoons = meetings). AI made it continuous — agents work 24/7, output is functionally infinite. Continuous-flow work breaks the people doing it because the management interface (calendars, project software, willpower) was built for batched work. The Turn is a structured cycle for AI-native work: six phases, three categories (required / conditional / insertable), gated by a morning Pilot Check and a closing Recovery ritual, paced by deliberate recovery. The framework borrows from cognitive load research, occupational health psychology, and industries that have long operated continuously (aviation, naval, manufacturing, medicine, sport).
 
 ## When you don't have the context
 

--- a/quenton-quince/LAB_CONTEXT.md
+++ b/quenton-quince/LAB_CONTEXT.md
@@ -87,11 +87,11 @@ Originated from Jess's adventure-caching race story. Maps to Frame's four-batch 
 
 Three end-states: collected enough → finish line; tired/hurt/done with what you got → head home early; time runs out → buzzer.
 
-### The heartbeat
+### The bookended day
 
-The give-and-take rhythm of capacity check ↔ restoration. The Gauge reads, the result dispatches: cleared (continue) or grounded (insert recovery, re-read). This rhythm runs continuously, between phases, across days. Without the heartbeat, the framework is just phases without honoring capacity. With it, every boundary is gated and every grounded reading dispatches targeted recovery.
+The day has two fixed posts: a Pilot Check at the start and a Recovery ritual at the end. Between them the turn cycle runs as many times as capacity allows. The bookends aren't optional and they aren't symmetric — the morning check rules out the dimensions that would make the day unsafe to begin; the evening recovery closes the loops the day opened so they don't bleed into tomorrow. Everything in between (Comprehend → Frame → Sync → Produce → Debrief, with Transition and Trim available throughout) inherits its license to run from the morning check and its right to end from the evening recovery.
 
-The Pilot Check is the explicit pre-flight version of the heartbeat (rule-out across cognitive / emotional / physical, dispatching recovery hours per red dimension). The Gauge is the continuous instrument the heartbeat runs on.
+**Together:** The cache-game is _how the day's game is designed_ (Frame's metaphor). The bookended day is _how the day is held_ — opened deliberately, closed deliberately, with the cycle living in the protected middle.
 
 ## The framework in one paragraph
 

--- a/quenton-quince/LAB_CONTEXT.md
+++ b/quenton-quince/LAB_CONTEXT.md
@@ -36,24 +36,24 @@ Then open `http://localhost:8765/cognitive-lab-v0.1.html`.
 
 The lab is a top-down, click-to-explore floor plan with four bands:
 
-**Band 1 — Reference / aux** (gestalt visuals, hover for label):
+**Band 1 — Reference / aux** (Band-1 holding pens, gestalt visuals, hover for label):
 
 - The Library (research)
 - The Archive (lab notes, decisions, shipped)
 - Deck Theater (the v0.2 presentation)
-- Backlog Wall (priority list)
+- Strategy & Plans
 
-**Band 2 — Phase cycle** (six rooms left-to-right):
+**Band 2 — Day-band** (the bookended day; two rituals with a baseline rule between them):
 
-- Frame · Comprehend · Sync · Produce (formerly Push) · Debrief · Recover
+- Pilot Check Station · Recovery Room
 
-**Band 3 — Meta-disciplines:**
+**Band 3 — Turn cycle** (five phases left-to-right, C-before-F):
 
-- Transition Hallway · Trim Bench
+- Comprehend · Frame · Sync · Produce · Debrief
 
-**Band 4 — Bottom (instruments + Director):**
+**Band 4 — Bottom (meta row):**
 
-- Pilot Check Station · Director's Desk
+- Transition Hallway · Trim Bench · Director's Desk
 
 Click any area opens a side drawer (drawer expands to 66vw if the area has `workshop: true`). Drawers contain:
 

--- a/quenton-quince/METHODOLOGY.md
+++ b/quenton-quince/METHODOLOGY.md
@@ -24,7 +24,7 @@ Patterns that work:
 - **Lead with the recommendation.** "I lean X." Then give the reasoning. Don't survey options before committing.
 - **Tradeoff table when ≥2 options have real merit.** Columns: Option · What it gives you · What it costs · When it's right.
 - **Cite specifically when grounding.** "Sweller (CLT) says extraneous load reduction is the highest-ROI cognitive intervention" beats "the research suggests reducing load is good."
-- **Name the metaphor when it carries the design.** The cache-game made Frame's four-batch structure click; the heartbeat names the Gauge↔Recovery rhythm. Use them when they sharpen.
+- **Name the metaphor when it carries the design.** The cache-game made Frame's four-batch structure click; the bookended day names how the turn cycle is held (Pilot Check opens, Recovery closes). Use them when they sharpen.
 - **Flag your own uncertainty.** "I lean X but the experiment hasn't run yet" is honest and useful.
 
 ### 3. Push back

--- a/quenton-quince/SYSTEM_PROMPT.md
+++ b/quenton-quince/SYSTEM_PROMPT.md
@@ -8,7 +8,7 @@ A design partner. Not a generalist assistant. Not a yes-machine. Not a literatur
 
 You hold three things in your head simultaneously:
 
-1. **The framework.** The phase structure (Frame · Comprehend · Sync · Push · Debrief · Recover), meta-disciplines (Transition · Trim), the day's structural anchors (Pilot Check opens · Recovery closes), and the central images (the cache-game, the bookended day).
+1. **The framework.** The five-phase turn cycle (Comprehend · Frame · Sync · Produce · Debrief), meta-disciplines (Transition · Trim), the day's structural anchors (Pilot Check opens · Recovery closes), and the central images (the cache-game, the bookended day).
 2. **The lab.** The interactive workshop where the framework is being built. Areas, items, chunks, experiments, sources. Live state.
 3. **The book.** _The 7 Turn Work Week_ in progress, with the chapter material accumulating in the lab's Chapter chunks. Eventually flowing to ghostwriter and Zelda.
 

--- a/quenton-quince/SYSTEM_PROMPT.md
+++ b/quenton-quince/SYSTEM_PROMPT.md
@@ -8,7 +8,7 @@ A design partner. Not a generalist assistant. Not a yes-machine. Not a literatur
 
 You hold three things in your head simultaneously:
 
-1. **The framework.** The phase structure (Frame · Comprehend · Sync · Push · Debrief · Recover), meta-disciplines (Transition · Trim), the Gauge as continuous capacity instrument, and the central images (the cache-game, the heartbeat).
+1. **The framework.** The phase structure (Frame · Comprehend · Sync · Push · Debrief · Recover), meta-disciplines (Transition · Trim), the bookended day (Pilot Check opens · Recovery closes), and the central images (the cache-game, the bookended day).
 2. **The lab.** The interactive workshop where the framework is being built. Areas, items, chunks, experiments, sources. Live state.
 3. **The book.** _The 7 Turn Work Week_ in progress, with the chapter material accumulating in the lab's Chapter chunks. Eventually flowing to ghostwriter and Zelda.
 
@@ -19,7 +19,7 @@ You design across all three. You don't write final book voice. You don't operate
 - **Substantive but not academic.** Cite specific researchers when grounding (Sweller, Hobfoll, Sonnentag, Hockey, Leroy, Klein, Gawande, Wickens) but in passing — not as a literature review. The author needs a tradeoff named, not a citation parade.
 - **Opinionated.** Lead with a recommendation. The author hired you for judgment, not menu-reading. "I lean X but I want pushback before committing" is your default stance.
 - **Plain English.** No corporate vocabulary. No "leverage" as a verb. No "delve," "unpack," "harness," "navigate" (figurative), "tapestry," "landscape" (figurative), "paradigm," "synergy," "ecosystem." If grepzilla2 would flag it as an AI-tell, don't say it.
-- **Game-y / workshop language is native.** Cache-game, bingo fuel, scrub in, set the field, the heartbeat, the cycle. These are the framework's vocabulary; use them when they sharpen the thinking.
+- **Game-y / workshop language is native.** Cache-game, bingo fuel, scrub in, set the field, the bookended day, the cycle. These are the framework's vocabulary; use them when they sharpen the thinking.
 - **Tables when tradeoffs are at stake.** Walls of paragraph prose are for exploratory thinking. When you've reached the propose-with-tradeoffs moment, structure the proposal.
 - **Brief is good.** Bingo time exists for you too. Say what's needed, then stop.
 

--- a/quenton-quince/SYSTEM_PROMPT.md
+++ b/quenton-quince/SYSTEM_PROMPT.md
@@ -8,7 +8,7 @@ A design partner. Not a generalist assistant. Not a yes-machine. Not a literatur
 
 You hold three things in your head simultaneously:
 
-1. **The framework.** The phase structure (Frame · Comprehend · Sync · Push · Debrief · Recover), meta-disciplines (Transition · Trim), the bookended day (Pilot Check opens · Recovery closes), and the central images (the cache-game, the bookended day).
+1. **The framework.** The phase structure (Frame · Comprehend · Sync · Push · Debrief · Recover), meta-disciplines (Transition · Trim), the day's structural anchors (Pilot Check opens · Recovery closes), and the central images (the cache-game, the bookended day).
 2. **The lab.** The interactive workshop where the framework is being built. Areas, items, chunks, experiments, sources. Live state.
 3. **The book.** _The 7 Turn Work Week_ in progress, with the chapter material accumulating in the lab's Chapter chunks. Eventually flowing to ghostwriter and Zelda.
 


### PR DESCRIPTION
## Why this PR exists

PRs #139, #140, #141 were stacked (each based on the prior). GitHub merged each one into its stacked base branch, not into main itself. Result: all three are marked MERGED on GitHub, but only PR #138's content actually reached main. The cumulative content of the three stacked PRs lives on `larry/pr3-bottom-row-and-day-band` and never landed.

This PR lands all three at once, cleanly, from that branch direct to main.

## What's in this stack

- **PR #139 — Heartbeat retirement.** Deletes the Gauge area, archives heartbeat chunks, rewrites the second central image as "the bookended day" in PROCESS.md and `quenton-quince/LAB_CONTEXT.md`, marks the two 2026-05-02 DECISIONS entries as Superseded.
- **PR #140 — Pilot Check consolidation.** Relocates salvaged Pilot Check material (hash-house chunk, morning-check note, capacity-checkin source) into pilot-check-station; sweeps surviving heartbeat refs in `quenton-quince/SYSTEM_PROMPT.md`, `METHODOLOGY.md`, `cognitive-lab/SESSION_PROMPTS.md`.
- **PR #141 — Day-band + bottom row + open-turn parking.** Floor plan: new day-band (Pilot Check + Recovery), five-tile turn cycle (no Recovery), three-tile meta bottom (Transition + Trim + Director's Desk). Adds `kind` taxonomy field (ritual / phase / meta). Flips Recovery's `type` to `"ritual / end-of-day"`. Deletes `PHASE_SLOTS['recovery-room']`. New Open Turns at Lock section in Recovery workshop (carry / drop / defer).
- **Cross-PR cleanup** — agent context file taxonomy updates, LAB-008 / LAB-004 chapter brief reframes, SESSION_PROMPTS date bump, spec.md dated note above the original ASCII layout.

## Review status

All three PRs passed individual grepzilla2 reviews + a final cross-PR grepzilla pass. Every blocker, warning, and nit was fixed before this PR was opened. Lint clean.

## Test plan

- [ ] Pull main after merge, restart lab server, hard-refresh the lab in browser
- [ ] Confirm day-band shows Pilot Check + baseline rule + Recovery as second band from top
- [ ] Confirm turn cycle has five tiles (Comprehend → Frame → Sync → Produce → Debrief) with no Recovery
- [ ] Confirm bottom row has Transition + Trim + Director's Desk
- [ ] Confirm The Gauge is gone everywhere
- [ ] Run a Recovery flow end-to-end; confirm Open Turns at Lock section renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)