### PR TITLE
Morning orient: first daily newspaper + bookended-day walk

### DIFF
--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -9265,6 +9265,41 @@
                      (triggers the step-0 mutation warning) */
   const WALKS = [
     {
+      id: 'walk-2026-05-11-bookended-day',
+      title: 'The bookended day',
+      kind: 'product',
+      subtitle: '8 steps · 2026-05-11 lab restructure',
+      preview: 'What changed on 2026-05-11: the Recovery Room became a 3-part workshop, the Gauge tile and the heartbeat retired, the floor regrouped into four bands, and the day got bookends. Walk the new shape before today\'s first turn.',
+      target_route: 'view=floor',
+      mutates: false,
+      steps: [
+        {
+          narrative: '**Today reshaped the day.**\n\nSix PRs landed yesterday. The Recovery Room became a workshop. The Gauge as a tile is gone. The heartbeat as a central image is retired. The floor regrouped into four bands. And the day picked up bookends.\n\nThis walk is read-only — no state mutated. Eight steps, ~5 minutes. By the end you\'ll know what the floor looks like and where to start.\n\nClick **Next**.'
+        },
+        {
+          narrative: '**Look at the right pane.** Four bands now, not three.\n\n**Band 1** is the same holding-pen row (Library · Daily Journal · Deck Theater · Strategy & Plans). **Band 2 is new** — the day-band. Pilot Check Station on the left, Recovery Room on the right, the day held between them.\n\nThat shape *is* the framework\'s new second central image: **the bookended day**. It joins **the cache-game** as the two metaphors that carry coherence. The heartbeat — capacity as an inside beat pulsing between phases — retired yesterday. Capacity is now an outside loop: open it in the morning, close it at night.\n\nClick **Next**.'
+        },
+        {
+          narrative: '**Click the Pilot Check Station tile** in Band 2 (far left).\n\nThis is where the day opens. Cognitive / emotional / physical rule-out, dispatching recovery hours per red dimension. The morning gauge that worked — the hash-house chunk, the original `capacity-checkin.html` source, the practice note from when it first stuck — all of that salvaged from the retired Gauge content and rehomed here.\n\nOne instrument, one home. Not two ways to do the same thing.\n\nClick **Next**.'
+        },
+        {
+          narrative: '**Close that drawer and click the Recovery Room** (far right of Band 2).\n\nThree screens, mirroring the Pilot Check pattern:\n\n1. **Measure the need.** Sliders pre-set to today\'s latest Pilot Check. Withdrawal = anchor − current (clamped ≥ 0), drives a tier.\n2. **Shape the recovery.** Six day-shape chips mapping to Sonnentag & Fritz mechanisms (Detach / Relax / Mastery / Control). Mastery suppressed on depleted days.\n3. **Plan it.** Activity chips pre-seeded from a (mechanism × locus) pool, plus a free-text plan locked to localStorage and mirrored to Drive.\n\nScroll Step 3 to the bottom — **Open Turns at Lock**. Chip-list of still-open turns with carry / drop / defer plus a note. That\'s the day\'s hygiene closer.\n\nClick **Next**.'
+        },
+        {
+          narrative: '**Look at Band 3** — Comprehend → Frame → Sync → Push → Debrief.\n\nFive tiles, not six. Recovery is gone from the cycle. It\'s not a phase anymore; it\'s a ritual at the day\'s edge.\n\nThis is what the heartbeat retirement reframed. The old picture: a phase loop with a beat between every transition. The new picture: a phase loop the day runs as many times as it can, gated at the two ends by the bookends. The beat moved to the boundary.\n\nClick **Next**.'
+        },
+        {
+          narrative: '**Bottom band — three meta tiles**, all `kind: meta`:\n\n- **Transition** — close · reset · open, the protocol that scales from 60 seconds to multiple hours.\n- **Trim** — the prune. Cut what doesn\'t earn its keep before the next turn loads it.\n- **Director\'s Desk** — the room above the rooms; where you sit when you\'re choosing what the day is for.\n\nOne breath each. They sit underneath the cycle because they apply to all of it.\n\nClick **Next**.'
+        },
+        {
+          narrative: '**Open the Frame tile briefly** (Band 3, second from the left).\n\nThe form is plain textareas again. Picker, Bonus, and per-card Approach got pulled yesterday. Outcome now pairs **Done means** with **What ruins this** — the both/and twin that closes the loop on the day\'s scoring.\n\nWhy the rollback: selection-over-generation depends on a populated, stable lab. The restructure says current conditions don\'t support it yet. The earned-back trigger lives in **LAB-058**. When the lab is populated and stable, the picker can come back.\n\nClick **Next**.'
+        },
+        {
+          narrative: '**You\'re done.**\n\nThe lab is the new shape. Today\'s opening:\n\n1. Open **Pilot Check Station** (top-left of the day-band). That\'s the bookend.\n2. Run a turn or three through Band 3.\n3. Close with **Recovery Room** (top-right of the day-band). Don\'t skip the **Open Turns at Lock** step.\n\nThe bookended day. The cache-game inside it. That\'s the framework now.\n\nClick **Done** to log this walk to the leg\'s comprehend timeline.'
+        }
+      ]
+    },
+    {
       id: 'walk-build-canvas-v0.1',
       title: 'Build canvas v0.1',
       kind: 'product',

--- a/cognitive-lab/exports/editions/2026-05-11-lab-restructure-daily.md
+++ b/cognitive-lab/exports/editions/2026-05-11-lab-restructure-daily.md
@@ -1,0 +1,106 @@
+# The Cognitive Lab Daily
+
+**Monday, May 11, 2026 · Issue 1**
+
+---
+
+## THE HEARTBEAT IS DEAD. LONG LIVE THE BOOKENDED DAY.
+
+### And: Frame form reverts to textareas — pickers out, "What ruins this" up
+
+---
+
+Two independent threads ran in parallel today and both landed on main before close. Thread one was a planned lab restructure, months in the making, that retired the framework's second central image and rebuilt the day's architecture around two bookending rituals. Thread two was a separate rollback of Frame's Outcome picker — simpler, faster, and a genuine improvement. Neither waited for the other. Six PRs merged.
+
+---
+
+**BELOW THE FOLD**
+
+- Recovery Room workshop ships with three screens and a Drive mirror
+- Four-band floor replaces the flat layout; Pilot Check and Recovery get their own band
+- Open turns at lock: carry, drop, defer
+- The stacked-base merge problem explained
+
+---
+
+## THE RESTRUCTURE
+
+**Heartbeat retired.** The heartbeat was the framework's second central image since May 2. It described a continuous read-and-dispatch cycle: the Gauge reads capacity at every phase boundary; the result routes you to recovery or forward. The cycle was called the framework's heartbeat — capacity ↔ restoration, running everywhere, always.
+
+The problem: the Gauge was a theoretical instrument. The practice that actually ran was two discrete rituals. Pilot Check in the morning. Recovery Room at close. The heartbeat described a product that didn't exist; the bookended day describes what does.
+
+**The bookended day.** Pilot Check opens. Recovery Room closes. The two share one reference point: this morning's three-dimension reading becomes tonight's anchor. Withdrawal = anchor − current. The day is bounded by a measurement pair, not a continuous loop. The cache-game (Frame's metaphor) asks how you design a day worth playing. The bookended day asks how you open and close it reliably. Both together describe a day with a shape.
+
+*From the DECISIONS log, 2026-05-11:* "The heartbeat described a continuous telemetry instrument that doesn't exist in practice and may not need to be. The bookended-day framing describes what actually happens."
+
+**Gauge area retired.** LAB-020, LAB-021, LAB-025, LAB-030 archived to `cognitive-lab/archive/heartbeat-retirement-2026-05-11.md`. The chunk-hash-house-pilot-check was salvaged and relocated to Pilot Check Station. Two 2026-05-02 DECISIONS entries marked Superseded.
+
+---
+
+## FRAME ROLLBACK
+
+**Pickers out.** The Done means picker (typed-ref multi-select scoped to the Course frontier), the Bonus picker, the per-card Approach unfold, the Course/Full-lab scope toggle, and the day-level "How I'll work — overall" scaffold are all gone from the rendered form. The form returns to four plain textareas.
+
+**What improved.** The Outcome batch now pairs Done means with What ruins this — the both/and twin. These two fields were previously split across the Outcome and Safety batches. Putting them side-by-side in the same batch makes the tension visible: what success looks like and what would ruin it belong in the same moment of thinking.
+
+*From the DECISIONS log, 2026-05-11:* "The fix isn't 'make the picker better' — it's 'earn the picker back when daily Frame is running reliably without it.'"
+
+**Restoration gate.** LAB-058 captures two conditions: (1) daily Frame runs steadily for ≥ 2 weeks on the textarea form, and (2) the rogaine loop (off-board picks → Debrief pre-fill) is identifiable as the actual constraint on weekly planning quality. Until both are true, the picker stays out. Status revisit queued for LAB-027, LAB-036, LAB-042.
+
+---
+
+## RECOVERY ROOM SHIPS
+
+Three-screen workshop. Step 1 measures the need: sliders pre-set to this morning's Pilot Check reading; withdrawal computed as anchor − current. Step 2 shapes the recovery: chip-based day-shape selector maps to Sonnentag & Fritz mechanisms (Detach / Relax / Master / Control); activity-chip pool keyed by mechanism × locus. Step 3 plans it — including a new "Open turns at lock" section.
+
+**Open turns at lock.** Three choices for live turns you can't close tonight: carry (this turn continues tomorrow), drop (abandon), defer (valid work, park in backlog). Named vocabulary instead of a blank textarea. The Recovery Room is now the place you close not just your body but your open cognitive loops.
+
+Lock persists to localStorage and mirrors to Drive via `/api/save/recoveries` — new server route, same pattern as Frames and Pilot Checks.
+
+---
+
+## FOUR-BAND FLOOR
+
+The lab floor is restructured. Four bands now:
+
+| Band | Contents |
+|---|---|
+| Band 1 | Storage / holding pens (Drive-canonical) |
+| Day-band | Pilot Check + Recovery Room |
+| Turn-cycle row | Frame · Comprehend · Sync · Produce · Debrief |
+| Meta row | Transition Hallway · Trim Bench · Director's Desk |
+
+Recovery Room moves from the turn-cycle row to the day-band. This is not a visual change only — it's a design claim: Recovery is a daily ritual, not a per-turn phase. `PHASE_SLOTS['recovery-room']` deleted. `kind` taxonomy field added to every non-Band-1 area (ritual / phase / meta).
+
+---
+
+## THE STACKING PROBLEM
+
+PRs #139, #140, and #141 were stacked. Each was meant to merge into main, but each merged into its stacked-base branch instead. Their content didn't reach main on initial merge. PR #143 recovered: the PR3 branch (which held the cumulative content) was opened directly to main, conflicts vs. PR #142 resolved, and the full set landed. Six PRs total, two redundant merge operations, zero lost work.
+
+---
+
+## STAT BOX
+
+| Metric | Count |
+|---|---|
+| PRs merged to main | 6 |
+| Lab items created | 1 (LAB-058) |
+| Lab items archived | 4 (LAB-020, LAB-021, LAB-025, LAB-030) |
+| LAB briefs rewritten | 2 (LAB-008, LAB-004) |
+| DECISIONS entries added | 3 (Heartbeat retirement, Four-band floor, Frame rollback) |
+| DECISIONS entries marked Superseded | 2 (Two central images, Gauge merger) |
+| New chunks added | 3 (chunk-pilot-yoked-to-recovery, chunk-recovery-bookended-day, chunk-hash-house-pilot-check relocated) |
+| Log entries added today | 9 (across 7 areas) |
+
+---
+
+## LOOKING AHEAD
+
+Tomorrow morning: Quenton's lab-restructure walk in Comprehend Station. The Walk Studio product walk for the new floor layout is being drafted in parallel — it will replace any walk steps that still reference the retired six-phase layout or the Gauge. The Walk Studio's first authored walk predates today's restructure; some step descriptions are stale. The sweep is queued.
+
+First thing tomorrow: open the lab, check the new four-band floor, run a Pilot Check, confirm the Recovery Room's anchor-setting path works end-to-end. The bookended day is live in architecture; it needs its first full run.
+
+---
+
+*Filed by Larry Moleman, lab assistant. This edition is the durable record of 2026-05-11's work. For architectural reasoning, see `cognitive-lab/DECISIONS.md`. For the lab's current state, see `cognitive-lab/cognitive-lab-v0.1.html`.*

--- a/cognitive-lab/exports/journal-manifest.json
+++ b/cognitive-lab/exports/journal-manifest.json
@@ -1,5 +1,16 @@
 [
   {
+    "id": "journal-edition-2026-05-11",
+    "date": "2026-05-11",
+    "shelf": "edition",
+    "title": "The Cognitive Lab Daily — May 11, 2026",
+    "path": "cognitive-lab/exports/editions/2026-05-11-lab-restructure-daily.md",
+    "format": "md",
+    "summary": "Six PRs merged across two parallel threads: (1) lab restructure — Heartbeat retirement, bookended-day framing, Recovery Room workshop, four-band floor, kind taxonomy, open-turn parking; (2) Frame rollback — picker/Bonus/per-card Approach removed, Done means paired with What ruins this. PR stacking misadventure recovered via PR #143. First full daily newspaper edition.",
+    "tags": ["heartbeat-retirement", "bookended-day", "recovery-room", "frame-rollback", "lab-restructure", "four-band-floor"],
+    "filedAt": "2026-05-11T00:00:00Z"
+  },
+  {
     "id": "journal-edition-2026-05-04",
     "date": "2026-05-04",
     "shelf": "edition",


### PR DESCRIPTION
## Summary

Two end-of-day artifacts from 2026-05-11 that needed to land this morning so the lab opens with them visible:

- **First daily newspaper edition** — `cognitive-lab/exports/editions/2026-05-11-lab-restructure-daily.md`. Larry's draft as the lab's first newspaper-framed edition: heartbeat retirement + Frame rollback share top billing, DECISIONS quotes pulled in, stat box, looking-ahead. Filed in the journal manifest.

- **walk-2026-05-11-bookended-day** — installed as the first product walk in the WALKS array, so it tops the Walk Studio sidebar. 8 steps, read-only, walks the four-band floor and names the bookended day as the new second central image.

## Test plan

- [ ] After merge, pull main, restart the lab server, open it
- [ ] Open Comprehend Station → Walk Studio sidebar → confirm "The bookended day" walk sits at the top
- [ ] Open the Daily Journal area → Editions shelf → confirm "The Cognitive Lab Daily — May 11, 2026" is the most recent edition
- [ ] Click through 1–2 walk steps to confirm the iframe boots cleanly and the narrative renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)