### PR TITLE
Lab gutter + day-band realign + Band 4 removal

### DIFF
--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -3212,9 +3212,162 @@
     .band-day > .area, .band-day > #today-frame-strip { flex: none; }
   }
 
-  /* Phase cycle band: arrows align with mid-row icons */
-  .band-phase { align-items: center; }
-  .band-phase .arrow { font-size: 18px; }
+  /* ── Phase rail (Band 3) ──
+     Discs on an engraved bar. Position conveys order; the lit disc tells
+     you what phase you're in. Replaces the rectangular emoji-tile pattern
+     with a passive MTG-style track. Each .area-phase keeps the .area /
+     .area-visual class (so click-to-open-drawer, badges, cockpit-mode all
+     still work) but its visual treatment is heavily overridden below. */
+  .band-phase {
+    align-items: center;
+    gap: 0;
+  }
+  /* Strip the rectangular tile chrome — no border, no panel bg, no min-height.
+     The disc is the visible element; the area-label sits below it as a caption. */
+  .band-phase .area-phase {
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    padding: 0;
+    min-height: 0;
+    flex: 0 1 auto;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 6px;
+    overflow: visible;
+  }
+  .band-phase .area-phase:hover {
+    border: none;
+    box-shadow: none;
+  }
+  /* .area-scene becomes the disc container; emoji-fallback font-size is reset. */
+  .band-phase .area-phase .area-scene {
+    flex: 0 0 auto;
+    font-size: 0;
+    filter: none;
+    transition: transform 0.25s;
+  }
+  .band-phase .area-phase:hover .area-scene { transform: none; }
+
+  /* The disc — engraved chip seated on the rail. Same warm-bronze gradient
+     and gold-bordered material as the Today's Frame plate, so the day's
+     interactive elements share a visual lineage. */
+  .band-phase .phase-disc {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 54px;
+    height: 54px;
+    border-radius: 50%;
+    background: radial-gradient(
+      circle at 30% 30%,
+      rgba(232, 184, 109, 0.18) 0%,
+      rgba(40, 28, 16, 0.55) 70%);
+    border: 1px solid rgba(212, 160, 82, 0.35);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 230, 200, 0.18),
+      inset 0 -1px 1px rgba(0, 0, 0, 0.40),
+      0 2px 4px rgba(0, 0, 0, 0.45);
+    color: var(--accent);
+    transition:
+      box-shadow 0.25s ease,
+      border-color 0.25s ease,
+      color 0.25s ease,
+      background 0.25s ease,
+      transform 0.25s ease;
+  }
+  /* The glyph — single-codepoint primary symbol, forced text-style rendering
+     so platforms with color emoji fonts don't substitute their picto. */
+  .band-phase .phase-glyph {
+    font-family: var(--font-display), 'Apple Symbols', 'Segoe UI Symbol', serif;
+    font-variant-emoji: text;
+    font-size: 24px;
+    line-height: 1;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.55);
+  }
+  /* Hover — disc lifts slightly and brightens. Pre-active affordance. */
+  .band-phase .area-phase:hover .phase-disc {
+    transform: translateY(-1px);
+    border-color: rgba(232, 184, 109, 0.55);
+    color: var(--accent-glow);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 230, 200, 0.22),
+      inset 0 -1px 1px rgba(0, 0, 0, 0.40),
+      0 3px 6px rgba(0, 0, 0, 0.45),
+      0 0 8px rgba(232, 184, 109, 0.25);
+  }
+  /* Active (drawer-open) — gold glow on the disc. This is the "you are
+     in phase X" indicator. Lights up when the drawer for that phase is
+     open and reads at a glance even on a busy screen. */
+  .band-phase .area-phase.active .phase-disc {
+    border-color: var(--accent-glow);
+    color: var(--accent-glow);
+    background: radial-gradient(
+      circle at 30% 30%,
+      rgba(232, 184, 109, 0.40) 0%,
+      rgba(80, 56, 28, 0.65) 70%);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 230, 200, 0.30),
+      inset 0 -1px 1px rgba(0, 0, 0, 0.45),
+      0 2px 4px rgba(0, 0, 0, 0.45),
+      0 0 10px rgba(232, 184, 109, 0.45),
+      0 0 22px rgba(232, 184, 109, 0.22);
+  }
+  /* Suppress the base .area.active rectangular glow on phase tiles —
+     the disc carries the signal now, not the (invisible) tile border. */
+  .band-phase .area-phase.active {
+    border-color: transparent !important;
+    box-shadow: none !important;
+  }
+
+  /* Caption — phase name + sub-label sit below the disc as a static caption,
+     not the hover-overlay treatment used elsewhere. */
+  .band-phase .area-phase .area-label {
+    position: static;
+    inset: auto;
+    background: none;
+    border-radius: 0;
+    opacity: 1;
+    pointer-events: none;
+    padding: 0;
+    font-family: var(--font-display);
+    font-size: 13px;
+    font-weight: 500;
+    letter-spacing: 0.06em;
+    text-transform: none;
+    color: var(--fg);
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.45);
+    gap: 1px;
+  }
+  .band-phase .area-phase.active .area-label { color: var(--accent-glow); }
+  .band-phase .area-phase .area-label .lbl-sub {
+    font-family: var(--font-display);
+    font-size: 11px;
+    font-style: italic;
+    letter-spacing: 0.04em;
+    color: var(--fg-dim);
+    text-transform: none;
+    margin-top: 0;
+  }
+  /* Badges live on top-right of the disc, not the (collapsed) tile rect. */
+  .band-phase .area-phase .badge-row {
+    top: -4px;
+    right: calc(50% - 36px);
+  }
+
+  /* Connector between discs — thin engraved line, gold-tinted at the ends. */
+  .band-phase .phase-connector {
+    flex: 1 1 auto;
+    align-self: flex-start;
+    margin-top: 27px;
+    height: 1px;
+    min-width: 12px;
+    background: linear-gradient(
+      to right,
+      rgba(212, 160, 82, 0.05) 0%,
+      rgba(212, 160, 82, 0.40) 50%,
+      rgba(212, 160, 82, 0.05) 100%);
+  }
 
   /* ── Stone-tile framework ──
      Activated by data-tile-art="<name>" data-tile-art-frame="raw" on a tile.
@@ -5845,37 +5998,39 @@
     </div>
   </div>
 
-  <!-- Band 3: Turn cycle (single visual each).
-       Move 2a (v0.4 build): Comprehend leads. Per the C-before-F call —
-       you can't scope what you haven't read in. Frame follows.
-       Recovery moved to day-band; cycle ends at Debrief. -->
+  <!-- Band 3: Turn cycle — phase rail with primary-glyph discs.
+       Each phase is a single-codepoint glyph from a Hellenistic/alchemical
+       day-arc: sun rises (Comprehend) → square (Frame) → linked rings (Sync)
+       → hammer + pick (Produce) → crescent moon (Debrief). Position on the
+       rail conveys order; the lit disc tells you what phase you're in.
+       Replaces the emoji-on-tile pattern with a passive MTG-style indicator. -->
   <div class="band band-phase">
-    <div class="area area-visual" data-area="comprehend-station" data-accent="amber" data-cockpit-mode="true">
-      <div class="area-scene">🛠️</div>
+    <div class="area area-visual area-phase" data-area="comprehend-station" data-accent="amber" data-cockpit-mode="true">
+      <div class="area-scene"><span class="phase-disc"><span class="phase-glyph">&#x2609;&#xFE0E;</span></span></div>
       <div class="area-label">Comprehend<span class="lbl-sub">orient first</span></div>
       <div class="badge-row" id="badges-comprehend-station"></div>
     </div>
-    <div class="arrow">→</div>
-    <div class="area area-visual" data-area="frame-workshop" data-accent="blue" data-cockpit-mode="true">
-      <div class="area-scene">🖼️</div>
+    <div class="phase-connector" aria-hidden="true"></div>
+    <div class="area area-visual area-phase" data-area="frame-workshop" data-accent="blue" data-cockpit-mode="true">
+      <div class="area-scene"><span class="phase-disc"><span class="phase-glyph">&#x25A1;&#xFE0E;</span></span></div>
       <div class="area-label">Frame<span class="lbl-sub">required</span></div>
       <div class="badge-row" id="badges-frame-workshop"></div>
     </div>
-    <div class="arrow">→</div>
-    <div class="area area-visual" data-area="sync-floor" data-accent="amber">
-      <div class="area-scene">🤝</div>
+    <div class="phase-connector" aria-hidden="true"></div>
+    <div class="area area-visual area-phase" data-area="sync-floor" data-accent="amber">
+      <div class="area-scene"><span class="phase-disc"><span class="phase-glyph">&#x26AD;&#xFE0E;</span></span></div>
       <div class="area-label">Sync<span class="lbl-sub">conditional</span></div>
       <div class="badge-row" id="badges-sync-floor"></div>
     </div>
-    <div class="arrow">→</div>
-    <div class="area area-visual" data-area="push-bay" data-accent="amber">
-      <div class="area-scene">🏭</div>
+    <div class="phase-connector" aria-hidden="true"></div>
+    <div class="area area-visual area-phase" data-area="push-bay" data-accent="amber">
+      <div class="area-scene"><span class="phase-disc"><span class="phase-glyph">&#x2692;&#xFE0E;</span></span></div>
       <div class="area-label">Produce<span class="lbl-sub">conditional</span></div>
       <div class="badge-row" id="badges-push-bay"></div>
     </div>
-    <div class="arrow">→</div>
-    <div class="area area-visual" data-area="debrief-booth" data-accent="blue" data-cockpit-mode="true">
-      <div class="area-scene">📋</div>
+    <div class="phase-connector" aria-hidden="true"></div>
+    <div class="area area-visual area-phase" data-area="debrief-booth" data-accent="blue" data-cockpit-mode="true">
+      <div class="area-scene"><span class="phase-disc"><span class="phase-glyph">&#x263D;&#xFE0E;</span></span></div>
       <div class="area-label">Debrief<span class="lbl-sub">required</span></div>
       <div class="badge-row" id="badges-debrief-booth"></div>
     </div>

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -3216,16 +3216,13 @@
   }
 
   /* ── Phase rail (bottom gutter subnav) ──
-     Persistent across all lab views (floor + alt-views). Sits fixed at the
-     bottom of the viewport. Discs are the passive "where in the turn am I"
-     indicator; the lit disc tells you which phase's drawer is open.
-     Eventually the active phase will drive what the main screen shows. */
+     Persistent across all lab views (floor + alt-views). Sits in normal
+     document flow right after the active content section so there's no
+     empty stone-bed gap between content and the rail. Discs are the
+     passive "where in the turn am I" indicator; the lit disc tells you
+     which phase's drawer is open. Eventually the active phase will drive
+     what the main screen shows. */
   .phase-rail {
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    z-index: 150;
     /* Same dark-stone material as the toolbar lintel — the rail is the
        bottom counterpart to the top chrome. */
     background: hsla(var(--bed-hue), calc(var(--bed-sat) * 1%), calc((var(--bed-light) - 12) * 1%), 0.94);
@@ -3233,6 +3230,7 @@
     border-top: 1px solid rgba(255, 230, 200, 0.12);
     box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.45);
     padding: 12px 16px 12px;
+    margin-top: 8px;
   }
   .phase-rail-inner {
     display: flex;
@@ -3242,8 +3240,6 @@
     max-width: 1400px;
     margin: 0 auto;
   }
-  /* Push lab content up so the fixed rail doesn't cover the bottom of any view. */
-  body { padding-bottom: 96px; }
 
   /* Phase tile — disc + caption stack. No rectangular tile chrome; the disc
      is the visible element. (Phase tiles no longer carry .area-visual since

--- a/cognitive-lab/cognitive-lab-v0.1.html
+++ b/cognitive-lab/cognitive-lab-v0.1.html
@@ -2955,12 +2955,15 @@
     opacity: 0.85;
   }
 
-  /* Day-band: Pilot Check (morning) left, Today's Frame middle, Recovery (evening) right. */
+  /* Day-band: Pilot Check (morning) left, Today's Frame middle, Recovery (evening) right.
+     Center-aligned so the flanking stone tiles don't stretch to Today's Frame's
+     content height — they sit at their natural artwork aspect (forced via
+     aspect-ratio below), with the (typically taller) plate driving the row. */
   .band-day {
-    align-items: stretch;
+    align-items: center;
     gap: 8px;
   }
-  .band-day > .area { flex: 1.5; min-width: 0; }
+  .band-day > .area { flex: 1.5; min-width: 0; aspect-ratio: 1.833; }
   .band-day > #today-frame-strip { flex: 3; min-width: 0; }
   /* Legacy band-rule (kept for older layouts that may reference it) */
   .band-rule {
@@ -3212,52 +3215,71 @@
     .band-day > .area, .band-day > #today-frame-strip { flex: none; }
   }
 
-  /* ── Phase rail (Band 3) ──
-     Discs on an engraved bar. Position conveys order; the lit disc tells
-     you what phase you're in. Replaces the rectangular emoji-tile pattern
-     with a passive MTG-style track. Each .area-phase keeps the .area /
-     .area-visual class (so click-to-open-drawer, badges, cockpit-mode all
-     still work) but its visual treatment is heavily overridden below. */
-  .band-phase {
-    align-items: center;
-    gap: 0;
+  /* ── Phase rail (bottom gutter subnav) ──
+     Persistent across all lab views (floor + alt-views). Sits fixed at the
+     bottom of the viewport. Discs are the passive "where in the turn am I"
+     indicator; the lit disc tells you which phase's drawer is open.
+     Eventually the active phase will drive what the main screen shows. */
+  .phase-rail {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 150;
+    /* Same dark-stone material as the toolbar lintel — the rail is the
+       bottom counterpart to the top chrome. */
+    background: hsla(var(--bed-hue), calc(var(--bed-sat) * 1%), calc((var(--bed-light) - 12) * 1%), 0.94);
+    backdrop-filter: blur(2px);
+    border-top: 1px solid rgba(255, 230, 200, 0.12);
+    box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.45);
+    padding: 12px 16px 12px;
   }
-  /* Strip the rectangular tile chrome — no border, no panel bg, no min-height.
-     The disc is the visible element; the area-label sits below it as a caption. */
-  .band-phase .area-phase {
+  .phase-rail-inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0;
+    max-width: 1400px;
+    margin: 0 auto;
+  }
+  /* Push lab content up so the fixed rail doesn't cover the bottom of any view. */
+  body { padding-bottom: 96px; }
+
+  /* Phase tile — disc + caption stack. No rectangular tile chrome; the disc
+     is the visible element. (Phase tiles no longer carry .area-visual since
+     they're outside the band grid — styled directly here.) */
+  .area-phase {
+    flex: 0 1 auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    padding: 0;
     background: transparent;
     border: none;
-    box-shadow: none;
-    padding: 0;
-    min-height: 0;
-    flex: 0 1 auto;
-    align-items: center;
-    justify-content: flex-start;
-    gap: 6px;
-    overflow: visible;
+    border-radius: 0;
+    cursor: pointer;
+    position: relative;
+    min-width: 0;
+    transition: transform 0.18s;
   }
-  .band-phase .area-phase:hover {
-    border: none;
-    box-shadow: none;
-  }
-  /* .area-scene becomes the disc container; emoji-fallback font-size is reset. */
-  .band-phase .area-phase .area-scene {
+  .area-phase:hover { border: none; box-shadow: none; }
+  .area-phase .area-scene {
     flex: 0 0 auto;
     font-size: 0;
-    filter: none;
-    transition: transform 0.25s;
+    line-height: 1;
+    user-select: none;
   }
-  .band-phase .area-phase:hover .area-scene { transform: none; }
 
-  /* The disc — engraved chip seated on the rail. Same warm-bronze gradient
-     and gold-bordered material as the Today's Frame plate, so the day's
-     interactive elements share a visual lineage. */
-  .band-phase .phase-disc {
+  /* The disc — engraved chip on the bottom rail. Same warm-bronze material
+     as the Today's Frame plate so the day's interactive elements share a
+     visual lineage. */
+  .phase-disc {
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 54px;
-    height: 54px;
+    width: 44px;
+    height: 44px;
     border-radius: 50%;
     background: radial-gradient(
       circle at 30% 30%,
@@ -3278,15 +3300,15 @@
   }
   /* The glyph — single-codepoint primary symbol, forced text-style rendering
      so platforms with color emoji fonts don't substitute their picto. */
-  .band-phase .phase-glyph {
+  .phase-glyph {
     font-family: var(--font-display), 'Apple Symbols', 'Segoe UI Symbol', serif;
     font-variant-emoji: text;
-    font-size: 24px;
+    font-size: 20px;
     line-height: 1;
     text-shadow: 0 1px 1px rgba(0, 0, 0, 0.55);
   }
-  /* Hover — disc lifts slightly and brightens. Pre-active affordance. */
-  .band-phase .area-phase:hover .phase-disc {
+  /* Hover — disc lifts slightly and brightens. */
+  .area-phase:hover .phase-disc {
     transform: translateY(-1px);
     border-color: rgba(232, 184, 109, 0.55);
     color: var(--accent-glow);
@@ -3296,10 +3318,9 @@
       0 3px 6px rgba(0, 0, 0, 0.45),
       0 0 8px rgba(232, 184, 109, 0.25);
   }
-  /* Active (drawer-open) — gold glow on the disc. This is the "you are
-     in phase X" indicator. Lights up when the drawer for that phase is
-     open and reads at a glance even on a busy screen. */
-  .band-phase .area-phase.active .phase-disc {
+  /* Active (drawer-open) — gold glow on the disc. The "you are in phase X"
+     indicator. Reads at a glance even on a busy screen. */
+  .area-phase.active .phase-disc {
     border-color: var(--accent-glow);
     color: var(--accent-glow);
     background: radial-gradient(
@@ -3313,16 +3334,15 @@
       0 0 10px rgba(232, 184, 109, 0.45),
       0 0 22px rgba(232, 184, 109, 0.22);
   }
-  /* Suppress the base .area.active rectangular glow on phase tiles —
-     the disc carries the signal now, not the (invisible) tile border. */
-  .band-phase .area-phase.active {
+  .area-phase.active {
     border-color: transparent !important;
     box-shadow: none !important;
   }
 
-  /* Caption — phase name + sub-label sit below the disc as a static caption,
-     not the hover-overlay treatment used elsewhere. */
-  .band-phase .area-phase .area-label {
+  /* Caption — phase name only in the gutter form (no sub-label, to keep the
+     rail slim). lbl-sub kept in DOM for screen readers + future use, hidden
+     visually. */
+  .area-phase .area-label {
     position: static;
     inset: auto;
     background: none;
@@ -3330,36 +3350,48 @@
     opacity: 1;
     pointer-events: none;
     padding: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0;
     font-family: var(--font-display);
-    font-size: 13px;
+    font-size: 12px;
     font-weight: 500;
     letter-spacing: 0.06em;
     text-transform: none;
     color: var(--fg);
     text-shadow: 0 1px 1px rgba(0, 0, 0, 0.45);
-    gap: 1px;
+    line-height: 1.1;
   }
-  .band-phase .area-phase.active .area-label { color: var(--accent-glow); }
-  .band-phase .area-phase .area-label .lbl-sub {
-    font-family: var(--font-display);
-    font-size: 11px;
-    font-style: italic;
-    letter-spacing: 0.04em;
-    color: var(--fg-dim);
-    text-transform: none;
-    margin-top: 0;
+  .area-phase.active .area-label { color: var(--accent-glow); }
+  .area-phase .area-label .lbl-sub {
+    /* Slim rail — hide the sub-label visually. */
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
   }
-  /* Badges live on top-right of the disc, not the (collapsed) tile rect. */
-  .band-phase .area-phase .badge-row {
-    top: -4px;
-    right: calc(50% - 36px);
+  /* Badges sit above the disc — small status dots for the phase. */
+  .area-phase .badge-row {
+    position: absolute;
+    top: -2px;
+    right: calc(50% - 28px);
+    margin: 0;
+    z-index: 2;
+  }
+  .area-phase .badge-row .dot {
+    font-size: 7px;
+    padding: 1px 4px;
   }
 
   /* Connector between discs — thin engraved line, gold-tinted at the ends. */
-  .band-phase .phase-connector {
+  .phase-rail .phase-connector {
     flex: 1 1 auto;
-    align-self: flex-start;
-    margin-top: 27px;
+    align-self: center;
+    margin-top: -10px;
+    margin-left: 8px;
+    margin-right: 8px;
     height: 1px;
     min-width: 12px;
     background: linear-gradient(
@@ -5901,9 +5933,6 @@
 <!-- ── Lab Floor ── -->
 <div id="lab-floor" class="floor-bg">
 
-  <!-- Top wall -->
-  <div class="wall-strip"></div>
-
   <!-- Band 1: Reference / aux (gestalt visuals) -->
   <div class="band">
     <!-- Library: stone tile for visual weight, not cockpit (band-1 bench; full list auto-expands). -->
@@ -5998,67 +6027,6 @@
     </div>
   </div>
 
-  <!-- Band 3: Turn cycle — phase rail with primary-glyph discs.
-       Each phase is a single-codepoint glyph from a Hellenistic/alchemical
-       day-arc: sun rises (Comprehend) → square (Frame) → linked rings (Sync)
-       → hammer + pick (Produce) → crescent moon (Debrief). Position on the
-       rail conveys order; the lit disc tells you what phase you're in.
-       Replaces the emoji-on-tile pattern with a passive MTG-style indicator. -->
-  <div class="band band-phase">
-    <div class="area area-visual area-phase" data-area="comprehend-station" data-accent="amber" data-cockpit-mode="true">
-      <div class="area-scene"><span class="phase-disc"><span class="phase-glyph">&#x2609;&#xFE0E;</span></span></div>
-      <div class="area-label">Comprehend<span class="lbl-sub">orient first</span></div>
-      <div class="badge-row" id="badges-comprehend-station"></div>
-    </div>
-    <div class="phase-connector" aria-hidden="true"></div>
-    <div class="area area-visual area-phase" data-area="frame-workshop" data-accent="blue" data-cockpit-mode="true">
-      <div class="area-scene"><span class="phase-disc"><span class="phase-glyph">&#x25A1;&#xFE0E;</span></span></div>
-      <div class="area-label">Frame<span class="lbl-sub">required</span></div>
-      <div class="badge-row" id="badges-frame-workshop"></div>
-    </div>
-    <div class="phase-connector" aria-hidden="true"></div>
-    <div class="area area-visual area-phase" data-area="sync-floor" data-accent="amber">
-      <div class="area-scene"><span class="phase-disc"><span class="phase-glyph">&#x26AD;&#xFE0E;</span></span></div>
-      <div class="area-label">Sync<span class="lbl-sub">conditional</span></div>
-      <div class="badge-row" id="badges-sync-floor"></div>
-    </div>
-    <div class="phase-connector" aria-hidden="true"></div>
-    <div class="area area-visual area-phase" data-area="push-bay" data-accent="amber">
-      <div class="area-scene"><span class="phase-disc"><span class="phase-glyph">&#x2692;&#xFE0E;</span></span></div>
-      <div class="area-label">Produce<span class="lbl-sub">conditional</span></div>
-      <div class="badge-row" id="badges-push-bay"></div>
-    </div>
-    <div class="phase-connector" aria-hidden="true"></div>
-    <div class="area area-visual area-phase" data-area="debrief-booth" data-accent="blue" data-cockpit-mode="true">
-      <div class="area-scene"><span class="phase-disc"><span class="phase-glyph">&#x263D;&#xFE0E;</span></span></div>
-      <div class="area-label">Debrief<span class="lbl-sub">required</span></div>
-      <div class="badge-row" id="badges-debrief-booth"></div>
-    </div>
-  </div>
-
-  <!-- Band 4: Meta — Transition · Trim · Director's Desk -->
-  <div class="band">
-    <!-- Transition Hallway: stone tile (Alexandria bridge fresco — see cognitive-lab/assets/CREDITS.md). Not yet cockpit-mode; workshop bootstrap is deferred. -->
-    <div class="area area-visual" data-area="transition-hallway" data-accent="tan" data-tile-art="bridge-stone" data-tile-art-frame="raw" data-tile-active-variant="half" data-tile-pulse="off">
-      <div class="area-scene">🚪<img class="tile-art tile-art-dormant" src="assets/bridge-stone.png" alt="" aria-hidden="true" draggable="false"/><img class="tile-art tile-art-active" src="assets/bridge-stone-active.png" alt="" aria-hidden="true" draggable="false"/></div>
-      <div class="area-label">Transition<span class="lbl-sub">meta</span></div>
-      <div class="badge-row" id="badges-transition-hallway"></div>
-    </div>
-    <div class="area area-visual" data-area="trim-bench" data-accent="tan">
-      <div class="area-scene">✂️</div>
-      <div class="area-label">Trim<span class="lbl-sub">meta</span></div>
-      <div class="badge-row" id="badges-trim-bench"></div>
-    </div>
-    <div class="area area-visual" data-area="director-desk" data-accent="dark">
-      <div class="area-scene">🧑‍💻</div>
-      <div class="area-label">Director's Desk<span class="lbl-sub">you</span></div>
-      <div class="badge-row" id="badges-director-desk"></div>
-    </div>
-  </div>
-
-  <!-- Bottom wall -->
-  <div class="wall-strip"></div>
-
 </div><!-- /#lab-floor -->
 
 <!-- ── Alternate views (PoC: same items, different lenses) ── -->
@@ -6106,6 +6074,47 @@
   <div id="course-finalize"></div>
   <div id="course-comprehend" class="course-comprehend"></div>
 </div>
+
+<!-- ── Phase rail (bottom gutter) ──
+     Turn cycle as a sticky bottom subnav: Comprehend → Frame → Sync → Produce
+     → Debrief. Lives outside #lab-floor so it persists across all alt-views
+     (Course, Priority, Timeline, By-status, Leg). The lit disc is the passive
+     "where in the turn am I" indicator. Eventually the active phase will
+     drive what the main screen shows; for now click-to-open-drawer behavior
+     is preserved (same .area click handlers as before). -->
+<nav id="phase-rail" class="phase-rail" aria-label="Turn phase rail">
+  <div class="phase-rail-inner">
+    <div class="area area-phase" data-area="comprehend-station" data-accent="amber" data-cockpit-mode="true">
+      <div class="area-scene"><span class="phase-disc"><span class="phase-glyph">&#x2609;&#xFE0E;</span></span></div>
+      <div class="area-label">Comprehend<span class="lbl-sub">orient first</span></div>
+      <div class="badge-row" id="badges-comprehend-station"></div>
+    </div>
+    <div class="phase-connector" aria-hidden="true"></div>
+    <div class="area area-phase" data-area="frame-workshop" data-accent="blue" data-cockpit-mode="true">
+      <div class="area-scene"><span class="phase-disc"><span class="phase-glyph">&#x25A1;&#xFE0E;</span></span></div>
+      <div class="area-label">Frame<span class="lbl-sub">required</span></div>
+      <div class="badge-row" id="badges-frame-workshop"></div>
+    </div>
+    <div class="phase-connector" aria-hidden="true"></div>
+    <div class="area area-phase" data-area="sync-floor" data-accent="amber">
+      <div class="area-scene"><span class="phase-disc"><span class="phase-glyph">&#x26AD;&#xFE0E;</span></span></div>
+      <div class="area-label">Sync<span class="lbl-sub">conditional</span></div>
+      <div class="badge-row" id="badges-sync-floor"></div>
+    </div>
+    <div class="phase-connector" aria-hidden="true"></div>
+    <div class="area area-phase" data-area="push-bay" data-accent="amber">
+      <div class="area-scene"><span class="phase-disc"><span class="phase-glyph">&#x2692;&#xFE0E;</span></span></div>
+      <div class="area-label">Produce<span class="lbl-sub">conditional</span></div>
+      <div class="badge-row" id="badges-push-bay"></div>
+    </div>
+    <div class="phase-connector" aria-hidden="true"></div>
+    <div class="area area-phase" data-area="debrief-booth" data-accent="blue" data-cockpit-mode="true">
+      <div class="area-scene"><span class="phase-disc"><span class="phase-glyph">&#x263D;&#xFE0E;</span></span></div>
+      <div class="area-label">Debrief<span class="lbl-sub">required</span></div>
+      <div class="badge-row" id="badges-debrief-booth"></div>
+    </div>
+  </div>
+</nav>
 
 <!-- ── Cmd-K palette ── -->
 <div id="cmdk-overlay" role="dialog" aria-modal="true" aria-labelledby="cmdk-input">
@@ -11566,7 +11575,7 @@
   let AREA_VISUALS = {};
   function buildAreaVisuals() {
     const map = {};
-    document.querySelectorAll('#lab-floor .area[data-area]').forEach(el => {
+    document.querySelectorAll('#lab-floor .area[data-area], #phase-rail .area[data-area]').forEach(el => {
       const id = el.dataset.area;
       const accent = el.dataset.accent || 'dark';
       const sceneEl = el.querySelector('.area-scene');

--- a/cognitive-lab/phase-rail-prototype.html
+++ b/cognitive-lab/phase-rail-prototype.html
@@ -1,0 +1,315 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Phase rail · prototype comparison</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Inter:wght@400;500&display=swap" rel="stylesheet" />
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  :root {
+    --fg:          #e8e0d4;
+    --fg-dim:      #8a7e6e;
+    --accent:      #d4a052;
+    --accent-dim:  #b8863a;
+    --accent-glow: #e8b86d;
+    --font-px:      'Inter', system-ui, sans-serif;
+    --font-display: 'Cormorant Garamond', Georgia, serif;
+    --bed-hue:        28;
+    --bed-sat:        14;
+    --bed-light:      32;
+  }
+
+  body {
+    font-family: var(--font-px);
+    color: var(--fg);
+    background:
+      radial-gradient(ellipse at 50% 50%, rgba(0,0,0,0) 40%, rgba(0,0,0,0.6) 100%),
+      hsl(28, 14%, 26%);
+    min-height: 100vh;
+    padding: 40px 32px;
+  }
+
+  h1 {
+    font-family: var(--font-display);
+    font-weight: 500;
+    font-size: 26px;
+    letter-spacing: 0.04em;
+    color: var(--accent);
+    margin-bottom: 6px;
+  }
+  .subtitle {
+    color: var(--fg-dim);
+    font-size: 13px;
+    font-style: italic;
+    margin-bottom: 36px;
+  }
+
+  /* ── Rail container ── */
+  .rail-block {
+    margin-bottom: 48px;
+  }
+  .rail-heading {
+    font-family: var(--font-display);
+    font-size: 18px;
+    font-weight: 500;
+    letter-spacing: 0.08em;
+    color: var(--accent);
+    margin-bottom: 4px;
+  }
+  .rail-note {
+    font-family: var(--font-display);
+    font-size: 13px;
+    font-style: italic;
+    color: var(--fg-dim);
+    margin-bottom: 16px;
+  }
+
+  /* The rail itself — chiseled brass-engraved bar inside a stone recess. */
+  .rail {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0;
+    padding: 22px 32px;
+    background:
+      linear-gradient(180deg,
+        rgba(58, 44, 28, 0.70) 0%,
+        rgba(44, 32, 20, 0.60) 100%);
+    border: 1px solid rgba(212, 160, 82, 0.22);
+    border-top-color: rgba(212, 160, 82, 0.32);
+    border-bottom-color: rgba(0, 0, 0, 0.45);
+    border-radius: 4px;
+    box-shadow:
+      inset 0 2px 6px rgba(0, 0, 0, 0.45),
+      0 2px 6px rgba(0, 0, 0, 0.35);
+  }
+
+  /* Phase cell */
+  .phase {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    flex: 1;
+    min-width: 0;
+    opacity: 0.45;
+    transition: opacity 0.25s, transform 0.25s;
+    cursor: pointer;
+  }
+  .phase:hover { opacity: 0.75; }
+  .phase.active { opacity: 1; }
+  .phase.active .disc { transform: translateY(-1px); }
+
+  /* The disc — engraved chip seated on the rail. */
+  .disc {
+    width: 54px;
+    height: 54px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background:
+      radial-gradient(circle at 30% 30%,
+        rgba(232, 184, 109, 0.18) 0%,
+        rgba(40, 28, 16, 0.55) 70%);
+    border: 1px solid rgba(212, 160, 82, 0.35);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 230, 200, 0.18),
+      inset 0 -1px 1px rgba(0, 0, 0, 0.40),
+      0 2px 4px rgba(0, 0, 0, 0.45);
+    color: var(--accent);
+    transition: box-shadow 0.25s, border-color 0.25s, color 0.25s, background 0.25s, transform 0.25s;
+  }
+  .phase.active .disc {
+    border-color: var(--accent-glow);
+    color: var(--accent-glow);
+    background:
+      radial-gradient(circle at 30% 30%,
+        rgba(232, 184, 109, 0.40) 0%,
+        rgba(80, 56, 28, 0.65) 70%);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 230, 200, 0.30),
+      inset 0 -1px 1px rgba(0, 0, 0, 0.45),
+      0 2px 4px rgba(0, 0, 0, 0.45),
+      0 0 10px rgba(232, 184, 109, 0.45),
+      0 0 22px rgba(232, 184, 109, 0.22);
+  }
+
+  /* Numeral inside disc — Cormorant Garamond, serif weight. */
+  .disc .numeral {
+    font-family: var(--font-display);
+    font-size: 22px;
+    font-weight: 500;
+    letter-spacing: 0.06em;
+    line-height: 1;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.55);
+  }
+  /* Glyph inside disc — single-codepoint primary symbol, text variant forced. */
+  .disc .glyph {
+    font-family: var(--font-display), 'Apple Symbols', 'Segoe UI Symbol', serif;
+    font-variant-emoji: text;
+    font-size: 24px;
+    line-height: 1;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.55);
+  }
+
+  /* Phase name */
+  .phase-name {
+    font-family: var(--font-display);
+    font-size: 14px;
+    font-weight: 500;
+    letter-spacing: 0.06em;
+    color: var(--fg);
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.45);
+  }
+  .phase.active .phase-name { color: var(--accent-glow); }
+
+  /* Phase sub-label */
+  .phase-sub {
+    font-family: var(--font-display);
+    font-size: 11px;
+    font-style: italic;
+    letter-spacing: 0.04em;
+    color: var(--fg-dim);
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.45);
+  }
+
+  /* Connector between phases — a thin engraved line, not an arrow. */
+  .connector {
+    flex: 0 0 auto;
+    align-self: flex-start;
+    margin-top: 26px;
+    width: 30px;
+    height: 1px;
+    background: linear-gradient(
+      to right,
+      rgba(212, 160, 82, 0.05) 0%,
+      rgba(212, 160, 82, 0.40) 50%,
+      rgba(212, 160, 82, 0.05) 100%);
+  }
+
+  /* ── Footer note ── */
+  .compare-note {
+    font-family: var(--font-display);
+    font-size: 14px;
+    font-style: italic;
+    color: var(--fg-dim);
+    text-align: center;
+    margin-top: 24px;
+    padding: 16px;
+    border-top: 1px solid rgba(212, 160, 82, 0.15);
+  }
+  .compare-note kbd {
+    font-family: var(--font-px);
+    font-style: normal;
+    background: rgba(212, 160, 82, 0.18);
+    border: 1px solid rgba(212, 160, 82, 0.35);
+    border-radius: 3px;
+    padding: 1px 6px;
+    font-size: 11px;
+    color: var(--accent);
+  }
+</style>
+</head>
+<body>
+
+<h1>Phase rail · prototype comparison</h1>
+<p class="subtitle">Two takes on the Comprehend → Frame → Sync → Produce → Debrief turn. Click any phase to make it the active one and see how the rail reads as the day moves.</p>
+
+<!-- ── Variant A: Roman numerals ── -->
+<section class="rail-block">
+  <h2 class="rail-heading">Variant A · Roman numerals</h2>
+  <p class="rail-note">Position is meaning. The numeral is empty signal — the label carries the semantic load. Closest to MTG's phase track.</p>
+  <div class="rail" id="rail-numerals">
+    <div class="phase active" data-phase="comprehend">
+      <div class="disc"><span class="numeral">I</span></div>
+      <div class="phase-name">Comprehend</div>
+      <div class="phase-sub">orient first</div>
+    </div>
+    <div class="connector"></div>
+    <div class="phase" data-phase="frame">
+      <div class="disc"><span class="numeral">II</span></div>
+      <div class="phase-name">Frame</div>
+      <div class="phase-sub">required</div>
+    </div>
+    <div class="connector"></div>
+    <div class="phase" data-phase="sync">
+      <div class="disc"><span class="numeral">III</span></div>
+      <div class="phase-name">Sync</div>
+      <div class="phase-sub">conditional</div>
+    </div>
+    <div class="connector"></div>
+    <div class="phase" data-phase="produce">
+      <div class="disc"><span class="numeral">IV</span></div>
+      <div class="phase-name">Produce</div>
+      <div class="phase-sub">conditional</div>
+    </div>
+    <div class="connector"></div>
+    <div class="phase" data-phase="debrief">
+      <div class="disc"><span class="numeral">V</span></div>
+      <div class="phase-name">Debrief</div>
+      <div class="phase-sub">required</div>
+    </div>
+  </div>
+</section>
+
+<!-- ── Variant B: Hellenistic/alchemical glyphs ── -->
+<section class="rail-block">
+  <h2 class="rail-heading">Variant B · Primary glyphs</h2>
+  <p class="rail-note">A day-arc told in symbols: sun rises (orient) → square (declare) → linked rings (exchange) → hammer (forge) → crescent moon (reflect). Each glyph is single-codepoint, text-rendered, ancient.</p>
+  <div class="rail" id="rail-glyphs">
+    <div class="phase active" data-phase="comprehend">
+      <div class="disc"><span class="glyph">☉&#xFE0E;</span></div>
+      <div class="phase-name">Comprehend</div>
+      <div class="phase-sub">orient first</div>
+    </div>
+    <div class="connector"></div>
+    <div class="phase" data-phase="frame">
+      <div class="disc"><span class="glyph">□&#xFE0E;</span></div>
+      <div class="phase-name">Frame</div>
+      <div class="phase-sub">required</div>
+    </div>
+    <div class="connector"></div>
+    <div class="phase" data-phase="sync">
+      <div class="disc"><span class="glyph">⚭&#xFE0E;</span></div>
+      <div class="phase-name">Sync</div>
+      <div class="phase-sub">conditional</div>
+    </div>
+    <div class="connector"></div>
+    <div class="phase" data-phase="produce">
+      <div class="disc"><span class="glyph">⚒&#xFE0E;</span></div>
+      <div class="phase-name">Produce</div>
+      <div class="phase-sub">conditional</div>
+    </div>
+    <div class="connector"></div>
+    <div class="phase" data-phase="debrief">
+      <div class="disc"><span class="glyph">☽&#xFE0E;</span></div>
+      <div class="phase-name">Debrief</div>
+      <div class="phase-sub">required</div>
+    </div>
+  </div>
+</section>
+
+<p class="compare-note">
+  Click any phase to advance the active marker. Try the rotation: <kbd>I</kbd> → <kbd>II</kbd> → <kbd>III</kbd> → <kbd>IV</kbd> → <kbd>V</kbd>.
+  Watch which rail tells you faster, at a glance, which phase you're in.
+</p>
+
+<script>
+  // Click any phase to make it active. Lets you see how the rail reads with
+  // each phase lit — the "where in the turn am I?" cue.
+  document.querySelectorAll('.rail').forEach(rail => {
+    rail.addEventListener('click', e => {
+      const phase = e.target.closest('.phase');
+      if (!phase) return;
+      rail.querySelectorAll('.phase').forEach(p => p.classList.remove('active'));
+      phase.classList.add('active');
+    });
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Re-architects the lab floor based on author feedback after PR #148 merged:

1. **Phase rail → bottom gutter (sticky subnav).** Comprehend → Frame → Sync → Produce → Debrief now lives as a fixed bottom strip outside `#lab-floor`, persistent across all alt-views. Slimmer 44px discs with named captions; the lit disc remains the passive "you are in phase X" indicator. Eventually the active phase will drive what the main screen renders.
2. **Day-band realigned.** `.band-day` was `align-items: stretch`, so Pilot Check and Recover grew to match Today's Frame's content height and looked oversized. Now `align-items: center`, with `aspect-ratio: 1.833` forced on the flanking stone tiles so they size to their artwork's natural aspect. Today's Frame drives the row; flankers center inside it at proper proportions.
3. **Band 4 (Transition / Trim / Director's Desk) removed.** Tiles dropped from the floor — author plans to surface that work as projects in the main flow rather than as cognitive scaffolding. Data registry entries (logs, chunks, To-Dos) left intact; drawers for these areas still reachable via Cmd-K.
4. **Wall strips removed** (top and bottom of `#lab-floor`). The toolbar's bottom border and the phase rail's top border now carry the crisp horizontal edges; the 10px stone-strip placeholders were redundant.

Includes one selector update: `buildAreaVisuals()` expanded from `#lab-floor` to `#lab-floor .area[data-area], #phase-rail .area[data-area]` so the icon/accent lookup still finds the phase areas after they moved outside the floor.

Also includes the **glyph phase rail** itself (☉ □ ⚭ ⚒ ☽) — cherry-picked from the activate-cognitive-lab branch; that commit didn't make it into the PR #148 squash.

## Test plan

- [ ] Open the lab — confirm: top toolbar, Band 1 (4 stone artifacts), Band 2 (Pilot · Today's Frame · Recover with the flankers proportionally smaller than before), no Band 4, fixed phase rail at the bottom of the viewport
- [ ] Scroll within the lab — confirm the phase rail stays pinned at the bottom and nothing scrolls under it
- [ ] Click a phase disc — confirm the drawer opens for that area and the disc lights with the gold active glow
- [ ] Switch to an alt-view (Course / Priority / Timeline / By-status / Leg) — confirm the phase rail is still visible at the bottom
- [ ] Open Cmd-K and search for "transition" / "trim" / "director" — drawers for these areas should still open even though the floor tiles are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)